### PR TITLE
feat: establish canonical felicia contract and offline workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,9 +104,13 @@ test-workflow: ## Run full journey workflow against disposable SQLite
 	$(UV_RUN) run python scripts/test_journey_workflow.py --start-server
 
 test-workflow-postgres: ## Run full journey workflow against disposable PostgreSQL
-	@test -n "$(FELICIA_TEST_DATABASE_DSN)" || (echo "FELICIA_TEST_DATABASE_DSN is required" >&2; exit 1)
-	DATABASE_DSN="$(FELICIA_TEST_DATABASE_DSN)" $(MAKE) migrate
-	FELICIA_TEST_DATABASE_DSN="$(FELICIA_TEST_DATABASE_DSN)" $(UV_RUN) run python scripts/test_journey_workflow.py --start-server --database-driver postgres
+	@test -n "$(FELICIA_TEST_DATABASE_DSN)$(FELICIA_TEST_POSTGRES_ADMIN_DSN)" || (echo "FELICIA_TEST_DATABASE_DSN or FELICIA_TEST_POSTGRES_ADMIN_DSN is required" >&2; exit 1)
+	@if test -n "$(FELICIA_TEST_POSTGRES_ADMIN_DSN)"; then \
+		FELICIA_TEST_POSTGRES_ADMIN_DSN="$(FELICIA_TEST_POSTGRES_ADMIN_DSN)" $(UV_RUN) run python scripts/test_journey_workflow.py --start-server --database-driver postgres; \
+	else \
+		DATABASE_DSN="$(FELICIA_TEST_DATABASE_DSN)" $(MAKE) migrate; \
+		FELICIA_TEST_DATABASE_DSN="$(FELICIA_TEST_DATABASE_DSN)" $(UV_RUN) run python scripts/test_journey_workflow.py --start-server --database-driver postgres; \
+	fi
 
 test-sqlite: ## Run all tests with SQLite as the only enabled provider
 	DATABASE_DSN= FELICIA_TEST_DATABASE_DSN= $(MAKE) test

--- a/apps/web-admin/src/App.svelte
+++ b/apps/web-admin/src/App.svelte
@@ -1,6 +1,22 @@
 <script lang="ts">
+  import { onMount } from "svelte"
+  import { loadAdminOverview, type AdminOverview } from "./api"
+
   const navItems = ["Overview", "Inbox", "Journeys", "Mementos", "Settings"]
   let active = $state("Overview")
+  let overview = $state<AdminOverview>({ journeys: [], mementos: [] })
+  let loading = $state(true)
+  let error = $state("")
+
+  onMount(async () => {
+    try {
+      overview = await loadAdminOverview()
+    } catch (cause) {
+      error = cause instanceof Error ? cause.message : "Unable to load the local workspace"
+    } finally {
+      loading = false
+    }
+  })
 </script>
 
 <svelte:head>
@@ -48,9 +64,16 @@
 
       <section class="cards" aria-label="Workspace summary">
         <article><span class="card-label">Inbox</span><strong>0</strong><span class="card-note">packages to review</span></article>
-        <article><span class="card-label">Journeys</span><strong>1</strong><span class="card-note">local preview journey</span></article>
-        <article><span class="card-label">Draft mementos</span><strong>0</strong><span class="card-note">ready for curation</span></article>
+        <article><span class="card-label">Journeys</span><strong>{loading ? "—" : overview.journeys.length}</strong><span class="card-note">from the admin API</span></article>
+        <article>
+          <span class="card-label">Draft mementos</span><strong>{loading ? "—" : overview.mementos.filter((memento) => ["candidate", "draft"].includes(memento.state)).length}</strong><span
+            class="card-note">ready for curation</span
+          >
+        </article>
       </section>
+      {#if error}
+        <p class="api-error" role="alert">{error}. Start the local API to load authoring data.</p>
+      {/if}
     {:else}
       <section class="empty-state">
         <span class="empty-icon">{active.slice(0, 1)}</span>

--- a/apps/web-admin/src/api.ts
+++ b/apps/web-admin/src/api.ts
@@ -1,0 +1,48 @@
+export interface AdminJourney {
+  id: string
+  journal_id: string
+  slug: string
+  title: string
+  place: string
+  country?: string
+  region?: string
+  date_start: string
+  date_end: string
+  authored_fields: string[]
+}
+
+export interface AdminMemento {
+  id: string
+  journey_id: string
+  kind: string
+  seq: number
+  title: string
+  place: string
+  essay?: string
+  vendor?: string
+  price_amount?: number
+  price_currency?: string
+  state: "candidate" | "draft" | "authored" | "published" | "archived" | string
+}
+
+export interface AdminOverview {
+  journeys: AdminJourney[]
+  mementos: AdminMemento[]
+}
+
+function apiURL(path: string): string {
+  const base = (import.meta.env.VITE_API_BASE as string | undefined) ?? ""
+  return `${base}${path}`
+}
+
+async function getJSON<T>(path: string): Promise<T> {
+  const response = await fetch(apiURL(path), { headers: { Accept: "application/json" } })
+  if (!response.ok) throw new Error(`Felicia API returned ${response.status}`)
+  return (await response.json()) as T
+}
+
+export async function loadAdminOverview(): Promise<AdminOverview> {
+  const journeys = await getJSON<AdminJourney[]>("/api/admin/journeys")
+  const mementos = (await Promise.all(journeys.map((journey) => getJSON<AdminMemento[]>(`/api/admin/journeys/${journey.id}/mementos`)))).flat()
+  return { journeys, mementos }
+}

--- a/apps/web-admin/src/app.css
+++ b/apps/web-admin/src/app.css
@@ -157,6 +157,12 @@ h2 {
   gap: 16px;
   margin-top: 18px;
 }
+
+.api-error {
+  margin-top: 1rem;
+  color: #a84a34;
+  font-size: 0.9rem;
+}
 .cards article {
   display: grid;
   gap: 10px;

--- a/cli/cmd/felicia/main.go
+++ b/cli/cmd/felicia/main.go
@@ -226,7 +226,11 @@ func packageCommand(args []string, output io.Writer) error {
 	if err != nil {
 		return err
 	}
-	return writeJSON(output, map[string]any{"package_id": pkg.Manifest.PackageID, "schema_version": pkg.Manifest.SchemaVersion, "files": len(pkg.Files)})
+	document, err := importer.DecodePackage(pkg)
+	if err != nil {
+		return fmt.Errorf("validate package contents: %w", err)
+	}
+	return writeJSON(output, map[string]any{"package_id": pkg.Manifest.PackageID, "schema_version": pkg.Manifest.SchemaVersion, "files": len(pkg.Files), "journeys": 1, "mementos": len(document.Mementos), "photos": len(document.Photos)})
 }
 
 func importCommand(args []string, output io.Writer) error {

--- a/contracts/canonical/v1/examples/memento.json
+++ b/contracts/canonical/v1/examples/memento.json
@@ -1,0 +1,54 @@
+{
+  "schema": "felicia.canonical.v1",
+  "version": "1",
+  "kind": "memento",
+  "data": {
+    "id": "0190cbde-f300-7000-8000-333333333333",
+    "journey_id": "0190cbde-f300-7000-8000-111111111111",
+    "kind": "goods",
+    "state": "authored",
+    "revision": 2,
+    "occurred_at": "2026-04-01T09:30:00Z",
+    "occurred_tz": "Asia/Tokyo",
+    "geom": {
+      "type": "Point",
+      "coordinates": [135.5016, 34.6687]
+    },
+    "title": "Dotonbori souvenir",
+    "place": "Osaka",
+    "vendor": "Example shop",
+    "price": {
+      "amount": 1200,
+      "currency": "JPY"
+    },
+    "kind_data": {
+      "category": "souvenir"
+    },
+    "media": [
+      {
+        "id": "immich:asset:photo-1",
+        "kind": "image",
+        "mime": "image/jpeg",
+        "visibility": "public",
+        "source": {
+          "system": "immich",
+          "external_id": "asset:photo-1"
+        },
+        "object_key": "media/dotonbori.jpg",
+        "content_hash": "sha256:example",
+        "caption": "The shop front"
+      }
+    ],
+    "provenance": [
+      {
+        "source": {
+          "system": "manual",
+          "external_id": "author-1"
+        },
+        "observed_at": "2026-04-02T10:00:00Z",
+        "confidence": 1
+      }
+    ],
+    "authored_fields": ["title", "vendor", "price"]
+  }
+}

--- a/contracts/canonical/v1/schema.json
+++ b/contracts/canonical/v1/schema.json
@@ -1,0 +1,219 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://felicia.local/contracts/canonical/v1/schema.json",
+  "title": "Felicia canonical contract v1",
+  "description": "Stable Felicia-owned data shapes. Transport adapters may project these records, but provider-specific fields do not belong here.",
+  "$defs": {
+    "source_identity": {
+      "type": "object",
+      "required": ["system", "external_id"],
+      "properties": {
+        "system": { "type": "string", "minLength": 1 },
+        "external_id": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    },
+    "provenance": {
+      "type": "object",
+      "required": ["source", "observed_at", "confidence"],
+      "properties": {
+        "source": { "$ref": "#/$defs/source_identity" },
+        "observed_at": { "type": "string", "format": "date-time" },
+        "confidence": { "type": "number", "minimum": 0, "maximum": 1 }
+      },
+      "additionalProperties": false
+    },
+    "geometry": {
+      "type": "object",
+      "required": ["type", "coordinates"],
+      "properties": {
+        "type": { "enum": ["Point", "LineString", "MultiLineString"] },
+        "coordinates": { "type": "array" }
+      },
+      "additionalProperties": false
+    },
+    "media": {
+      "type": "object",
+      "required": ["id", "kind", "visibility", "source"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "kind": { "enum": ["image", "video", "audio", "document", "link", "embed"] },
+        "mime": { "type": "string", "minLength": 1 },
+        "visibility": { "enum": ["private", "public"] },
+        "source": { "$ref": "#/$defs/source_identity" },
+        "object_key": { "type": "string", "minLength": 1 },
+        "content_hash": { "type": "string", "minLength": 1 },
+        "caption": { "type": "string" },
+        "title": { "type": "string" },
+        "width": { "type": "integer", "minimum": 1 },
+        "height": { "type": "integer", "minimum": 1 },
+        "duration_ms": { "type": "integer", "minimum": 1 },
+        "poster_key": { "type": "string", "minLength": 1 },
+        "url": { "type": "string", "format": "uri" }
+      },
+      "additionalProperties": false
+    },
+    "route": {
+      "type": "object",
+      "required": ["id", "geometry", "source", "provenance"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "geometry": { "$ref": "#/$defs/geometry" },
+        "points": { "type": "array", "items": { "$ref": "#/$defs/route_point" } },
+        "mode": { "type": "string" },
+        "distance_m": { "type": "number", "minimum": 0 },
+        "source": { "$ref": "#/$defs/source_identity" },
+        "provenance": { "$ref": "#/$defs/provenance" }
+      },
+      "additionalProperties": false
+    },
+    "route_point": {
+      "type": "object",
+      "required": ["coord", "at"],
+      "properties": {
+        "coord": { "type": "array", "prefixItems": [{ "type": "number" }, { "type": "number" }], "items": false, "minItems": 2, "maxItems": 2 },
+        "at": { "type": "string", "format": "date-time" }
+      },
+      "additionalProperties": false
+    },
+    "visit": {
+      "type": "object",
+      "required": ["id", "coord", "arrive", "depart", "source", "provenance"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "label": { "type": "string" },
+        "coord": { "type": "array", "prefixItems": [{ "type": "number" }, { "type": "number" }], "items": false, "minItems": 2, "maxItems": 2 },
+        "arrive": { "type": "string", "format": "date-time" },
+        "depart": { "type": "string", "format": "date-time" },
+        "source": { "$ref": "#/$defs/source_identity" },
+        "provenance": { "$ref": "#/$defs/provenance" }
+      },
+      "additionalProperties": false
+    },
+    "stop_candidate": {
+      "type": "object",
+      "required": ["id", "journey_id", "candidate_key", "state", "evidence"],
+      "properties": {
+        "id": { "type": "string", "format": "uuid" },
+        "journey_id": { "type": "string", "format": "uuid" },
+        "candidate_key": { "type": "string", "minLength": 1 },
+        "derivation_version": { "type": "string", "minLength": 1 },
+        "label": { "type": "string" },
+        "state": { "enum": ["proposed", "kept", "ignored", "merged"] },
+        "evidence": { "type": "array", "items": { "$ref": "#/$defs/evidence" } },
+        "confidence": { "type": "number", "minimum": 0, "maximum": 1 },
+        "revision": { "type": "integer", "minimum": 0 }
+      },
+      "additionalProperties": false
+    },
+    "evidence": {
+      "type": "object",
+      "required": ["kind", "source", "locator"],
+      "properties": {
+        "kind": { "enum": ["route", "visit", "media"] },
+        "source": { "$ref": "#/$defs/source_identity" },
+        "locator": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    },
+    "memento": {
+      "type": "object",
+      "required": ["id", "journey_id", "kind", "state", "revision", "occurred_at", "kind_data", "media"],
+      "properties": {
+        "id": { "type": "string", "format": "uuid" },
+        "journey_id": { "type": "string", "format": "uuid" },
+        "kind": { "type": "string", "minLength": 1 },
+        "state": { "enum": ["candidate", "draft", "authored", "published", "archived"] },
+        "revision": { "type": "integer", "minimum": 1 },
+        "occurred_at": { "type": "string", "format": "date-time" },
+        "occurred_tz": { "type": "string", "minLength": 1 },
+        "geom": { "anyOf": [{ "$ref": "#/$defs/geometry" }, { "type": "null" }] },
+        "title": { "type": "string" },
+        "place": { "type": "string" },
+        "vendor": { "type": "string" },
+        "essay": { "type": "string" },
+        "price": { "$ref": "#/$defs/price" },
+        "kind_data": { "type": "object" },
+        "media": { "type": "array", "items": { "$ref": "#/$defs/media" } },
+        "provenance": { "type": "array", "items": { "$ref": "#/$defs/provenance" } },
+        "authored_fields": { "type": "array", "uniqueItems": true, "items": { "type": "string" } }
+      },
+      "additionalProperties": false
+    },
+    "price": {
+      "type": "object",
+      "required": ["amount", "currency"],
+      "properties": {
+        "amount": { "type": "integer" },
+        "currency": { "type": "string", "pattern": "^[A-Z]{3}$" }
+      },
+      "additionalProperties": false
+    },
+    "journey": {
+      "type": "object",
+      "required": ["id", "journal_id", "slug", "title", "date_start", "date_end", "routes"],
+      "properties": {
+        "id": { "type": "string", "format": "uuid" },
+        "journal_id": { "type": "string", "format": "uuid" },
+        "slug": { "type": "string", "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$" },
+        "title": { "type": "string", "minLength": 1 },
+        "place": { "type": "string" },
+        "country": { "type": "string" },
+        "region": { "type": "string" },
+        "date_start": { "type": "string", "format": "date" },
+        "date_end": { "type": "string", "format": "date" },
+        "routes": { "type": "array", "items": { "$ref": "#/$defs/route" } },
+        "visits": { "type": "array", "items": { "$ref": "#/$defs/visit" } },
+        "source_ref": { "type": "string" },
+        "authored_fields": { "type": "array", "uniqueItems": true, "items": { "type": "string" } }
+      },
+      "additionalProperties": false
+    },
+    "journal": {
+      "type": "object",
+      "required": ["id"],
+      "properties": {
+        "id": { "type": "string", "format": "uuid" },
+        "title": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "suggestion": {
+      "type": "object",
+      "required": ["id", "target", "operation", "proposal", "evidence", "status", "provider"],
+      "properties": {
+        "id": { "type": "string", "format": "uuid" },
+        "target": { "type": "string", "minLength": 1 },
+        "operation": { "enum": ["set", "clear", "append", "remove"] },
+        "proposal": {},
+        "evidence": { "type": "array", "items": { "$ref": "#/$defs/evidence" } },
+        "status": { "enum": ["proposed", "accepted", "rejected", "superseded"] },
+        "provider": { "type": "string", "minLength": 1 },
+        "model": { "type": "string" },
+        "confidence": { "type": "number", "minimum": 0, "maximum": 1 },
+        "created_at": { "type": "string", "format": "date-time" }
+      },
+      "additionalProperties": false
+    },
+    "document": {
+      "type": "object",
+      "required": ["schema", "version", "kind", "data"],
+      "properties": {
+        "schema": { "const": "felicia.canonical.v1" },
+        "version": { "const": "1" },
+        "kind": { "enum": ["journal", "journey", "memento", "stop_candidate", "suggestion"] },
+        "data": {
+          "oneOf": [
+            { "$ref": "#/$defs/journal" },
+            { "$ref": "#/$defs/journey" },
+            { "$ref": "#/$defs/memento" },
+            { "$ref": "#/$defs/stop_candidate" },
+            { "$ref": "#/$defs/suggestion" }
+          ]
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "$ref": "#/$defs/document"
+}

--- a/core/contracts/contracts.go
+++ b/core/contracts/contracts.go
@@ -13,17 +13,26 @@ import (
 	"github.com/azusachino/felicia/core/domain"
 )
 
+// CanonicalVersion identifies the stable Felicia-owned semantic contract.
 const CanonicalVersion = "felicia.canonical.v1"
 
+// Capability identifies an optional behavior an adapter can provide.
 type Capability string
 
 const (
-	CapabilityRoutes      Capability = "routes.read"
-	CapabilityVisits      Capability = "visits.read"
-	CapabilityMedia       Capability = "media.read"
-	CapabilityAuthoring   Capability = "mementos.write"
-	CapabilityReview      Capability = "stops.review"
+	// CapabilityRoutes reads normalized route evidence.
+	CapabilityRoutes Capability = "routes.read"
+	// CapabilityVisits reads normalized visit evidence.
+	CapabilityVisits Capability = "visits.read"
+	// CapabilityMedia reads normalized media evidence.
+	CapabilityMedia Capability = "media.read"
+	// CapabilityAuthoring writes authored mementos.
+	CapabilityAuthoring Capability = "mementos.write"
+	// CapabilityReview applies explicit stop review decisions.
+	CapabilityReview Capability = "stops.review"
+	// CapabilitySuggestions proposes non-mutating authoring changes.
 	CapabilitySuggestions Capability = "suggestions.propose"
+	// CapabilityPublication writes a public projection.
 	CapabilityPublication Capability = "publication.write"
 )
 
@@ -46,27 +55,32 @@ type Trait interface {
 	Capabilities() []Capability
 }
 
+// RouteSource reads normalized route evidence for a time range.
 type RouteSource interface {
 	Trait
 	FetchRoutes(context.Context, time.Time, time.Time) ([]domain.Route, error)
 }
 
+// VisitSource reads normalized visit evidence for a time range.
 type VisitSource interface {
 	Trait
 	FetchVisits(context.Context, time.Time, time.Time) ([]domain.Visit, error)
 }
 
+// MediaSource reads normalized media evidence for a time range.
 type MediaSource interface {
 	Trait
 	FetchMedia(context.Context, time.Time, time.Time) ([]domain.MediaAsset, error)
 }
 
+// AuthoringStore applies revision-protected authored memento changes.
 type AuthoringStore interface {
 	Trait
 	GetMemento(context.Context, uuid.UUID) (*domain.Memento, error)
 	ApplyManualMementoPatch(context.Context, *domain.ManualMementoPatch) error
 }
 
+// CandidateReviewStore exposes private stop candidates and explicit reviews.
 type CandidateReviewStore interface {
 	Trait
 	ListStopCandidatesByJourney(context.Context, uuid.UUID) ([]*domain.StopCandidate, error)

--- a/core/contracts/contracts.go
+++ b/core/contracts/contracts.go
@@ -1,0 +1,82 @@
+// Package contracts declares versioned Felicia capability traits.
+//
+// The interfaces describe behavior at adapter boundaries. Canonical data
+// shapes and transport schemas remain versioned artifacts under contracts/.
+package contracts
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/azusachino/felicia/core/domain"
+)
+
+const CanonicalVersion = "felicia.canonical.v1"
+
+type Capability string
+
+const (
+	CapabilityRoutes      Capability = "routes.read"
+	CapabilityVisits      Capability = "visits.read"
+	CapabilityMedia       Capability = "media.read"
+	CapabilityAuthoring   Capability = "mementos.write"
+	CapabilityReview      Capability = "stops.review"
+	CapabilitySuggestions Capability = "suggestions.propose"
+	CapabilityPublication Capability = "publication.write"
+)
+
+// Suggestion is proposal data, not an authored domain mutation.
+type Suggestion struct {
+	ID         uuid.UUID
+	Target     string
+	Operation  string
+	Proposal   any
+	Provider   string
+	Model      string
+	Confidence float64
+	CreatedAt  time.Time
+}
+
+// Trait lets an adapter advertise the contract version and optional behavior
+// it supports. Unsupported capabilities must be reported, not guessed.
+type Trait interface {
+	ContractVersion() string
+	Capabilities() []Capability
+}
+
+type RouteSource interface {
+	Trait
+	FetchRoutes(context.Context, time.Time, time.Time) ([]domain.Route, error)
+}
+
+type VisitSource interface {
+	Trait
+	FetchVisits(context.Context, time.Time, time.Time) ([]domain.Visit, error)
+}
+
+type MediaSource interface {
+	Trait
+	FetchMedia(context.Context, time.Time, time.Time) ([]domain.MediaAsset, error)
+}
+
+type AuthoringStore interface {
+	Trait
+	GetMemento(context.Context, uuid.UUID) (*domain.Memento, error)
+	ApplyManualMementoPatch(context.Context, *domain.ManualMementoPatch) error
+}
+
+type CandidateReviewStore interface {
+	Trait
+	ListStopCandidatesByJourney(context.Context, uuid.UUID) ([]*domain.StopCandidate, error)
+	ApplyStopReview(context.Context, *domain.StopReviewPatch) error
+}
+
+// SuggestionStore is intentionally proposal-only. Accepting a suggestion must
+// go through an explicit authoring operation with revision protection.
+type SuggestionStore interface {
+	Trait
+	ListSuggestions(context.Context, string) ([]Suggestion, error)
+	CreateSuggestion(context.Context, Suggestion) error
+}

--- a/core/contracts/contracts_test.go
+++ b/core/contracts/contracts_test.go
@@ -1,0 +1,12 @@
+package contracts
+
+import "testing"
+
+func TestCanonicalVersionAndCapabilityNames(t *testing.T) {
+	if CanonicalVersion != "felicia.canonical.v1" {
+		t.Fatalf("canonical version = %q", CanonicalVersion)
+	}
+	if CapabilityMedia != "media.read" || CapabilitySuggestions != "suggestions.propose" {
+		t.Fatalf("capability names changed unexpectedly")
+	}
+}

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -1,6 +1,9 @@
 services:
   db:
     image: postgis/postgis:18-3.6-alpine
+    # The pinned PostGIS image currently publishes amd64 only; Podman on
+    # Apple Silicon runs this service through its supported emulation path.
+    platform: linux/amd64
     container_name: felicia-db
     ports:
       - "5432:5432"

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -6,13 +6,13 @@ or local file format is an adapter of that contract.
 
 ## Contract layers
 
-| Layer | Authority | Purpose |
-| --- | --- | --- |
-| Canonical | [`contracts/canonical/v1/schema.json`](../../contracts/canonical/v1/schema.json) | Felicia-owned records and media semantics |
-| Workspace | `schemas/local-authoring-v1.schema.json` | Human/agent-editable local files |
-| CLI | `felicia-cli` commands and JSON/JSONL output | Offline planning, import, review, and publication |
-| Admin API | `server/api` transport projection | Server-side authoring and source synchronization |
-| Public API | `publication` projection | Published reader data and static JSON |
+| Layer      | Authority                                                                        | Purpose                                           |
+| ---------- | -------------------------------------------------------------------------------- | ------------------------------------------------- |
+| Canonical  | [`contracts/canonical/v1/schema.json`](../../contracts/canonical/v1/schema.json) | Felicia-owned records and media semantics         |
+| Workspace  | `schemas/local-authoring-v1.schema.json`                                         | Human/agent-editable local files                  |
+| CLI        | `felicia-cli` commands and JSON/JSONL output                                     | Offline planning, import, review, and publication |
+| Admin API  | `server/api` transport projection                                                | Server-side authoring and source synchronization  |
+| Public API | `publication` projection                                                         | Published reader data and static JSON             |
 
 The workspace schema is not the canonical model. It is intentionally convenient
 for editing and may contain review controls that never enter the public API.

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -1,0 +1,44 @@
+# Felicia contracts
+
+Felicia's contracts are owned here before implementation details. A contract
+must define the stable meaning of data or behavior; a provider, frontend, CLI,
+or local file format is an adapter of that contract.
+
+## Contract layers
+
+| Layer | Authority | Purpose |
+| --- | --- | --- |
+| Canonical | [`contracts/canonical/v1/schema.json`](../../contracts/canonical/v1/schema.json) | Felicia-owned records and media semantics |
+| Workspace | `schemas/local-authoring-v1.schema.json` | Human/agent-editable local files |
+| CLI | `felicia-cli` commands and JSON/JSONL output | Offline planning, import, review, and publication |
+| Admin API | `server/api` transport projection | Server-side authoring and source synchronization |
+| Public API | `publication` projection | Published reader data and static JSON |
+
+The workspace schema is not the canonical model. It is intentionally convenient
+for editing and may contain review controls that never enter the public API.
+
+## Versioning rules
+
+- Canonical identifiers use `felicia.canonical.vN`.
+- A breaking field, meaning, lifecycle, identity, or media change requires a new
+  version.
+- Additive optional fields may remain within a version only when old readers can
+  safely ignore them.
+- Projections must document their mapping to canonical fields.
+- Provider-specific fields stay in provenance or adapter payloads; they do not
+  become canonical by accident.
+- Every write path must define idempotency, revision conflict, and error behavior.
+
+## Contract-first gate
+
+Before implementing a new entity or endpoint, add or update:
+
+1. canonical schema and examples;
+2. capability/trait semantics;
+3. projection mapping;
+4. compatibility and migration rules;
+5. contract tests for CLI, HTTP, providers, and static output.
+
+The Go interfaces in `core/ports` remain implementation seams. The versioned
+behavioral traits are declared in `core/contracts`; neither replaces the JSON
+contract or its projection tests.

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -42,3 +42,8 @@ Before implementing a new entity or endpoint, add or update:
 The Go interfaces in `core/ports` remain implementation seams. The versioned
 behavioral traits are declared in `core/contracts`; neither replaces the JSON
 contract or its projection tests.
+
+For agent-operated offline workflows, use the repository skill:
+[`skills/felicia-cli/SKILL.md`](../../skills/felicia-cli/SKILL.md). It is the
+operational companion to these contracts and must not invent commands or fields
+that are not implemented.

--- a/docs/contracts/canonical-v1.md
+++ b/docs/contracts/canonical-v1.md
@@ -1,0 +1,51 @@
+# Canonical contract v1
+
+The canonical contract is Felicia's stable semantic model. It is independent of
+SQLite, PostgreSQL, the local workspace, HTTP, and GitHub Pages. The machine-
+readable record envelope is [`contracts/canonical/v1/schema.json`](../../contracts/canonical/v1/schema.json).
+
+## Record ownership
+
+- `journal` and `journey` are authored aggregate identity and metadata.
+- `route` and `visit` are source-derived evidence. They may be absent or
+  incomplete when a source cannot provide them.
+- `stop_candidate` is private review state, never public place data.
+- `memento` is the authored/public story object. Its lifecycle and revision are
+  canonical; source evidence cannot silently overwrite authored fields.
+- `media` is an attachment reference with source identity, visibility, and
+  publication metadata. A media kind is not automatically renderable.
+- `suggestion` is a non-mutating proposal. Acceptance is a separate authoring
+  operation.
+
+## Stable semantics
+
+All coordinates are `[longitude, latitude]`. Timestamps are RFC 3339 strings and
+must preserve the source timezone where it is meaningful; `occurred_tz` records
+the display timezone separately from the instant. Source identity is the
+idempotency key across re-imports. Local UUIDs identify Felicia records.
+
+Memento writes use optimistic revisions. A stale write is a conflict, not an
+implicit merge. Ingest and authoring writes use different ownership rules:
+ingest may update source-owned fields, while authoring explicitly claims fields.
+
+## Media capability boundary
+
+Canonical media kinds are `image`, `video`, `audio`, `document`, `link`, and
+`embed`. Each adapter declares what it can ingest, store, preview, and publish.
+The presence of a canonical media record does not authorize publication. A
+public projection must apply visibility, provider trust, derivative, and MIME
+rules before emitting an attachment.
+
+## Projection map
+
+```text
+canonical/v1
+  ├── workspace/v1       editable files and review controls
+  ├── cli/v1             plan JSON/JSONL and command reports
+  ├── admin-api/v1       write/read transport DTOs
+  ├── storage             normalized relational persistence
+  └── public-api/v1      published, redacted static/server projection
+```
+
+No projection may add provider-specific semantics to the canonical record or
+publish private source evidence by default.

--- a/docs/development/database.md
+++ b/docs/development/database.md
@@ -65,12 +65,19 @@ FELICIA_TEST_DATABASE_DSN='postgres://postgres:password@localhost:5432/felicia?s
 
 FELICIA_TEST_DATABASE_DSN='postgres://postgres:password@localhost:5432/felicia?sslmode=disable' \
   make test-workflow-postgres
+
+# Preferred: create, migrate, and drop a unique database per run.
+FELICIA_TEST_POSTGRES_ADMIN_DSN='postgres://postgres:password@localhost:5432/postgres?sslmode=disable' \
+  make test-workflow-postgres
 ```
 
-PostgreSQL tests require `FELICIA_TEST_DATABASE_DSN`, not ordinary
-`DATABASE_DSN`. The test database must be disposable: integration tests clean
-tables before exercising provider behavior. Tests also verify that Goose
-migrations have reached version 8 or later.
+PostgreSQL tests require a test DSN rather than ordinary `DATABASE_DSN`. The
+preferred workflow uses `FELICIA_TEST_POSTGRES_ADMIN_DSN` to create, migrate,
+and drop a unique database per run. The direct `FELICIA_TEST_DATABASE_DSN`
+form remains available when CI or another runner owns database lifecycle; that
+database must be disposable because integration tests clean tables before
+exercising provider behavior. Tests also verify that Goose migrations have
+reached version 8 or later.
 
 The repository contract suite runs against both providers. Provider-specific
 features, such as PostGIS route acceleration, remain in PostgreSQL-specific

--- a/docs/experiments/2026-07-18-local-journey-workflow.md
+++ b/docs/experiments/2026-07-18-local-journey-workflow.md
@@ -38,6 +38,7 @@ uv run python scripts/local_journey.py preprocess \
 The command runs the real `felicia-cli journey plan` and writes:
 
 - `plan.json`: immutable-ish source-derived output and diagnostics;
+- `workspace.json`: optional root index for multiple journey workspaces;
 - `journey.json`: journey metadata to complete;
 - `stops.json`: the stop decisions to curate (`selected` and `label`);
 - `mementos.json`: editable memento drafts seeded from matched media.

--- a/docs/experiments/2026-07-18-local-journey-workflow.md
+++ b/docs/experiments/2026-07-18-local-journey-workflow.md
@@ -68,8 +68,7 @@ SQLite database and generated site are local build artifacts.
 
 ## Current boundary
 
-The package importer currently accepts title/place/kind data and photos, but not
-essay/vendor/price authored fields. This workflow therefore tests the real
-stop-selection, memento metadata, media, import, and static-preview path. Essay
-authoring needs a follow-up package/import contract before it should be added to
-this script.
+The package importer carries essay/vendor/price and an explicit `authored_fields`
+mask into the existing no-clobber write path. Translations are intentionally not
+part of this v1 workflow: authored content has no translation sidecar and is
+rendered exactly as entered. Media remains the separate image-support contract.

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,7 @@ The exploration trail, roughly in order:
 - [Architecture experiments](experiments/README.md)
 - [GitHub Pages design demo](experiments/2026-07-17-pages-design-demo.md)
 - [Local workflow boundaries](research/local-workflow-boundaries.md) · [Media support matrix](research/media-support-matrix.md)
+- [Local authoring schema v1](research/local-authoring-schema-v1.md)
 - [Public read contract](experiments/2026-07-17-public-read-contract.md)
 - [GitHub Pages v0.1 release](release/github-pages-v0.1.md)
 - [SQLite-backed Pages epic](roadmap/pages-v1-epic.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,7 @@ The exploration trail, roughly in order:
 - [Architecture experiments](experiments/README.md)
 - [GitHub Pages design demo](experiments/2026-07-17-pages-design-demo.md)
 - [Local workflow boundaries](research/local-workflow-boundaries.md) · [Media support matrix](research/media-support-matrix.md)
+- [Contract-first overview](contracts/README.md) · [Canonical contract v1](contracts/canonical-v1.md)
 - [Local authoring schema v1](research/local-authoring-schema-v1.md)
 - [Local authoring schema v1 review](research/local-authoring-schema-v1-review.md)
 - [Public read contract](experiments/2026-07-17-public-read-contract.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,7 @@ The exploration trail, roughly in order:
 - [GitHub Pages design demo](experiments/2026-07-17-pages-design-demo.md)
 - [Local workflow boundaries](research/local-workflow-boundaries.md) · [Media support matrix](research/media-support-matrix.md)
 - [Local authoring schema v1](research/local-authoring-schema-v1.md)
+- [Local authoring schema v1 review](research/local-authoring-schema-v1-review.md)
 - [Public read contract](experiments/2026-07-17-public-read-contract.md)
 - [GitHub Pages v0.1 release](release/github-pages-v0.1.md)
 - [SQLite-backed Pages epic](roadmap/pages-v1-epic.md)

--- a/docs/research/local-authoring-schema-v1-review.md
+++ b/docs/research/local-authoring-schema-v1-review.md
@@ -58,12 +58,10 @@ The contract is usable for the local-first workflow, with explicit boundaries:
 
 ## Remaining gaps before calling v1 product-ready
 
-1. Type the `plan.json` route/visit/stop/memento evidence arrays instead of
-   validating them only as arrays.
-2. Implement agent suggestion storage and an explicit review transition.
-3. Add the future media attachment model for video, audio, documents, and
+1. Implement agent suggestion storage and an explicit review transition.
+2. Add the future media attachment model for video, audio, documents, and
    trusted embeds.
 
 Conclusion: schema v1 is suitable for the current offline authoring and static
-preview experiment, but the five gaps above must remain visible in the next
+preview experiment, but the two gaps above must remain visible in the next
 implementation stage.

--- a/docs/research/local-authoring-schema-v1-review.md
+++ b/docs/research/local-authoring-schema-v1-review.md
@@ -1,0 +1,71 @@
+# Local authoring schema v1 review
+
+Review date: 2026-07-18
+
+This report closes the schema-v1 task sequence with the executable intake matrix,
+the two-journey static preview, and provider checks. The raw intake report is
+generated at `.felicia/experiments/intake/report.json` by:
+
+```sh
+make cli-build
+uv run python scripts/run_intake_experiments.py \
+  --out .felicia/experiments/intake/report.json
+BASE_PATH=/ nix develop --command uv run python scripts/felicia.py preview
+```
+
+## Story results
+
+| Story                    | Result  | Evidence and remaining boundary                                                                                                                                       |
+| ------------------------ | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| US-01 plan               | Pass    | Real CLI plan is deterministic across repeated runs; six route points, two derived stops, and three media inputs.                                                     |
+| US-02 review stops       | Partial | Stop candidate output is executable; the matrix does not yet drive an authored review action. The SQLite HTTP workflow covers the separate review/write API path.     |
+| US-03 missing metadata   | Partial | JSONL sidecar promotes one asset; EXIF extraction and confidence classes remain incomplete.                                                                           |
+| US-04 mementos from stop | Partial | Planner emits at most one generic candidate per matched stop. The local authoring file can contain multiple authored mementos, but the planner does not propose them. |
+| US-05 agent suggestions  | Not run | No suggestion schema or persistence contract exists; the safe behavior is still non-mutating absence.                                                                 |
+| US-06 safe publish       | Pass    | Both prepared packages pass CLI validation; raw GPX is not copied into the public artifact.                                                                           |
+| Evil: malformed GPX      | Pass    | Invalid latitude is rejected.                                                                                                                                         |
+| Evil: 20,000-point GPX   | Pass    | Current XML materialization completed in about 292 ms with about 15.6 MiB child RSS in this run; limits and streaming remain future hardening.                        |
+
+## End-to-end evidence
+
+- Both preview workspaces validate against the v1 JSON Schema.
+- Two independent packages import successfully: two journeys, eight mementos,
+  and eight media files compile into the static preview.
+- `make test-workflow` passes against SQLite.
+- `FELICIA_TEST_DATABASE_DSN=... make test-postgres` passes against the live
+  Podman PostgreSQL/PostGIS service.
+- The PostgreSQL admin API starts and direct journey/memento writes succeed.
+  The existing `test_journey_workflow.py` PostgreSQL mode is not accepted as a
+  full pass because its fixed IDs and fixed port allow stale or competing state;
+  repeated runs fail the expected revision-1 assertion. The harness needs an
+  isolated database and dynamically reserved port before this story can be
+  called provider-parity green.
+
+## Schema-v1 decision
+
+The contract is usable for the local-first workflow, with explicit boundaries:
+
+- `journey.json`, `stops.json`, `mementos.json`, and optional `plan.json` are
+  executable-validated documents.
+- Authored memento fields use an explicit `authored_fields` mask and survive
+  SQLite/PostgreSQL no-clobber imports.
+- Public packaging accepts only public local JPEG/PNG/WebP images. Broader
+  intake media kinds remain descriptive until a `memento_media` model exists.
+- Authored translations are intentionally absent; the canonical model has no
+  translation sidecar.
+
+## Remaining gaps before calling v1 product-ready
+
+1. Make the PostgreSQL HTTP workflow genuinely disposable: create/drop a test
+   database per run, reserve a free port, and include response diagnostics.
+2. Type the `plan.json` route/visit/stop/memento evidence arrays instead of
+   validating them only as arrays.
+3. Add a root multi-journey workspace manifest; v1 currently uses one workspace
+   and package per journey.
+4. Implement agent suggestion storage and an explicit review transition.
+5. Add the future media attachment model for video, audio, documents, and
+   trusted embeds.
+
+Conclusion: schema v1 is suitable for the current offline authoring and static
+preview experiment, but the five gaps above must remain visible in the next
+implementation stage.

--- a/docs/research/local-authoring-schema-v1-review.md
+++ b/docs/research/local-authoring-schema-v1-review.md
@@ -60,10 +60,8 @@ The contract is usable for the local-first workflow, with explicit boundaries:
 
 1. Type the `plan.json` route/visit/stop/memento evidence arrays instead of
    validating them only as arrays.
-2. Add a root multi-journey workspace manifest; v1 currently uses one workspace
-   and package per journey.
-3. Implement agent suggestion storage and an explicit review transition.
-4. Add the future media attachment model for video, audio, documents, and
+2. Implement agent suggestion storage and an explicit review transition.
+3. Add the future media attachment model for video, audio, documents, and
    trusted embeds.
 
 Conclusion: schema v1 is suitable for the current offline authoring and static

--- a/docs/research/local-authoring-schema-v1-review.md
+++ b/docs/research/local-authoring-schema-v1-review.md
@@ -35,11 +35,13 @@ BASE_PATH=/ nix develop --command uv run python scripts/felicia.py preview
 - `FELICIA_TEST_DATABASE_DSN=... make test-postgres` passes against the live
   Podman PostgreSQL/PostGIS service.
 - The PostgreSQL admin API starts and direct journey/memento writes succeed.
-  The existing `test_journey_workflow.py` PostgreSQL mode is not accepted as a
-  full pass because its fixed IDs and fixed port allow stale or competing state;
-  repeated runs fail the expected revision-1 assertion. The harness needs an
-  isolated database and dynamically reserved port before this story can be
-  called provider-parity green.
+- The original PostgreSQL HTTP workflow exposed two isolation/parity defects:
+  fixed IDs and ports allowed stale state, and the PostgreSQL no-clobber upsert
+  path also preserved draft values during a manual publish. The harness now
+  creates per-run IDs, probes `/readyz` on a reserved port, and can create,
+  migrate, and drop a unique PostgreSQL database. Manual authoring uses a
+  separate PostgreSQL upsert path. The isolated SQLite and PostgreSQL workflows
+  now pass.
 
 ## Schema-v1 decision
 
@@ -56,14 +58,12 @@ The contract is usable for the local-first workflow, with explicit boundaries:
 
 ## Remaining gaps before calling v1 product-ready
 
-1. Make the PostgreSQL HTTP workflow genuinely disposable: create/drop a test
-   database per run, reserve a free port, and include response diagnostics.
-2. Type the `plan.json` route/visit/stop/memento evidence arrays instead of
+1. Type the `plan.json` route/visit/stop/memento evidence arrays instead of
    validating them only as arrays.
-3. Add a root multi-journey workspace manifest; v1 currently uses one workspace
+2. Add a root multi-journey workspace manifest; v1 currently uses one workspace
    and package per journey.
-4. Implement agent suggestion storage and an explicit review transition.
-5. Add the future media attachment model for video, audio, documents, and
+3. Implement agent suggestion storage and an explicit review transition.
+4. Add the future media attachment model for video, audio, documents, and
    trusted embeds.
 
 Conclusion: schema v1 is suitable for the current offline authoring and static

--- a/docs/research/local-authoring-schema-v1.md
+++ b/docs/research/local-authoring-schema-v1.md
@@ -43,14 +43,12 @@ The machine-readable definitions are in
 ## Deliberate boundaries and gaps
 
 This task freezes file shape, not every downstream capability. The following
-remain explicit next-task work:
+boundaries remain explicit:
 
-- essay/vendor/price and the explicit `authored_fields` mask must be mapped
-  through the importer without being dropped;
 - translations are intentionally not part of v1: the canonical model has no
   translation sidecar, and authored content is rendered exactly as entered;
 - `media` is still image-shaped in the current package/publication path;
 - multiple journeys remain multiple packages at publication time; the root
   manifest indexes them for local authoring and preview discovery only;
-- JSON Schema validation is defined here but executable validation belongs in
-  the implementation task.
+- `plan.json` is source evidence and is validated structurally, but it is not
+  an author-editable document.

--- a/docs/research/local-authoring-schema-v1.md
+++ b/docs/research/local-authoring-schema-v1.md
@@ -27,6 +27,9 @@ The machine-readable definitions are in
   top-level so importers and readers can handle them consistently.
 - `media.path` is a local source reference in the workspace. The package
   builder resolves, hashes, and rewrites it to a safe package object key.
+- `media.kind` and `media.visibility` describe intake intent. The public v1
+  package accepts only `public` JPEG/PNG/WebP images; unsupported or private
+  attachments fail package creation and remain outside publication.
 - Unknown top-level fields are invalid in v1. The schema must be versioned before
   adding a new field; reserved authored fields are already represented even when
   the current importer has not mapped every one yet.

--- a/docs/research/local-authoring-schema-v1.md
+++ b/docs/research/local-authoring-schema-v1.md
@@ -1,0 +1,45 @@
+# Local authoring schema v1
+
+The local workflow has four distinct JSON documents. `plan.json` is generated
+evidence; the other three are editable authoring state.
+
+| File            | Schema identifier                      | Ownership | Purpose                                          |
+| --------------- | -------------------------------------- | --------- | ------------------------------------------------ |
+| `plan.json`     | `felicia.intake.plan` + `version: "1"` | Felicia   | Reproducible source-derived plan and diagnostics |
+| `journey.json`  | `felicia.local.journey.v1`             | Author    | Journey metadata and date range                  |
+| `stops.json`    | `felicia.local.stops.v1`               | Author    | Keep/ignore decisions and stop labels            |
+| `mementos.json` | `felicia.local.mementos.v1`            | Author    | Memento order, kind, content, and selected media |
+
+The machine-readable definitions are in
+[`schemas/local-authoring-v1.schema.json`](../../schemas/local-authoring-v1.schema.json).
+
+## v1 rules
+
+- The `schema` identifier is exact; a future incompatible shape gets a new
+  identifier rather than silently changing v1.
+- `plan.json` is regenerated from GPX/provider inputs and is never hand-edited.
+- `candidate_key` is the stable join from a curated memento to a stop. A
+  missing stop key is an authoring error, not an orphan to publish.
+- `selected: false` excludes a stop and all mementos linked to it from the
+  generated package. It does not delete source evidence.
+- Memento IDs and `seq` are explicit. Reordering changes `seq`, not identity.
+- `kind_data` is open for kind-specific fields; common authored fields remain
+  top-level so importers and readers can handle them consistently.
+- `media.path` is a local source reference in the workspace. The package
+  builder resolves, hashes, and rewrites it to a safe package object key.
+- Unknown top-level fields are invalid in v1. The schema must be versioned before
+  adding a new field; reserved authored fields are already represented even when
+  the current importer has not mapped every one yet.
+
+## Deliberate boundaries and gaps
+
+This task freezes file shape, not every downstream capability. The following
+remain explicit next-task work:
+
+- essay/vendor/price/translations must be mapped through the importer without
+  being dropped;
+- `media` is still image-shaped in the current package/publication path;
+- multiple journeys are currently multiple workspaces/packages, not one root
+  workspace document;
+- JSON Schema validation is defined here but executable validation belongs in
+  the implementation task.

--- a/docs/research/local-authoring-schema-v1.md
+++ b/docs/research/local-authoring-schema-v1.md
@@ -36,8 +36,10 @@ The machine-readable definitions are in
 This task freezes file shape, not every downstream capability. The following
 remain explicit next-task work:
 
-- essay/vendor/price/translations must be mapped through the importer without
-  being dropped;
+- essay/vendor/price and the explicit `authored_fields` mask must be mapped
+  through the importer without being dropped;
+- translations are intentionally not part of v1: the canonical model has no
+  translation sidecar, and authored content is rendered exactly as entered;
 - `media` is still image-shaped in the current package/publication path;
 - multiple journeys are currently multiple workspaces/packages, not one root
   workspace document;

--- a/docs/research/local-authoring-schema-v1.md
+++ b/docs/research/local-authoring-schema-v1.md
@@ -1,14 +1,16 @@
 # Local authoring schema v1
 
-The local workflow has four distinct JSON documents. `plan.json` is generated
-evidence; the other three are editable authoring state.
+The local workflow has a root `workspace.json` index plus four journey JSON
+documents. `plan.json` is generated evidence; the other three are editable
+authoring state.
 
-| File            | Schema identifier                      | Ownership | Purpose                                          |
-| --------------- | -------------------------------------- | --------- | ------------------------------------------------ |
-| `plan.json`     | `felicia.intake.plan` + `version: "1"` | Felicia   | Reproducible source-derived plan and diagnostics |
-| `journey.json`  | `felicia.local.journey.v1`             | Author    | Journey metadata and date range                  |
-| `stops.json`    | `felicia.local.stops.v1`               | Author    | Keep/ignore decisions and stop labels            |
-| `mementos.json` | `felicia.local.mementos.v1`            | Author    | Memento order, kind, content, and selected media |
+| File             | Schema identifier                      | Ownership | Purpose                                          |
+| ---------------- | -------------------------------------- | --------- | ------------------------------------------------ |
+| `workspace.json` | `felicia.local.workspace.v1`           | Author    | Index multiple journey workspaces                |
+| `plan.json`      | `felicia.intake.plan` + `version: "1"` | Felicia   | Reproducible source-derived plan and diagnostics |
+| `journey.json`   | `felicia.local.journey.v1`             | Author    | Journey metadata and date range                  |
+| `stops.json`     | `felicia.local.stops.v1`               | Author    | Keep/ignore decisions and stop labels            |
+| `mementos.json`  | `felicia.local.mementos.v1`            | Author    | Memento order, kind, content, and selected media |
 
 The machine-readable definitions are in
 [`schemas/local-authoring-v1.schema.json`](../../schemas/local-authoring-v1.schema.json).
@@ -17,6 +19,10 @@ The machine-readable definitions are in
 
 - The `schema` identifier is exact; a future incompatible shape gets a new
   identifier rather than silently changing v1.
+- `workspace.json` is the root index for a multi-journey authoring directory.
+  Each entry names a relative journey directory and must match that directory's
+  `journey.json` ID and journal ID. A path of `.` means the root directory is
+  itself a journey workspace.
 - `plan.json` is regenerated from GPX/provider inputs and is never hand-edited.
 - `candidate_key` is the stable join from a curated memento to a stop. A
   missing stop key is an authoring error, not an orphan to publish.
@@ -44,7 +50,7 @@ remain explicit next-task work:
 - translations are intentionally not part of v1: the canonical model has no
   translation sidecar, and authored content is rendered exactly as entered;
 - `media` is still image-shaped in the current package/publication path;
-- multiple journeys are currently multiple workspaces/packages, not one root
-  workspace document;
+- multiple journeys remain multiple packages at publication time; the root
+  manifest indexes them for local authoring and preview discovery only;
 - JSON Schema validation is defined here but executable validation belongs in
   the implementation task.

--- a/docs/research/local-workflow-boundaries.md
+++ b/docs/research/local-workflow-boundaries.md
@@ -11,7 +11,7 @@ felicia-cli journey plan       runtime/intake + providers/local
         │ plan.json
         ▼
 local_journey_author.py        human/agent stop and memento decisions
-        │ journey.json, stops.json, mementos.json
+        │ workspace.json + journey.json, stops.json, mementos.json
         ▼
 local_journey_package.py       portable package serialization + media hashing
         │ journey.zip

--- a/docs/research/media-support-matrix.md
+++ b/docs/research/media-support-matrix.md
@@ -18,8 +18,12 @@ The current demo deliberately exercises multiple image files and repeated use
 of one image. Repeated assets must remain valid: attachment keys are identified
 by memento plus sequence, not only by the URL/object key.
 
-The next media seam should be a versioned `memento_media` model with
-`kind=image|video|audio|document|embed`, `object_key`, `content_hash`, optional
-`mime`, `width`, `height`, `duration_ms`, `poster_key`, `caption`, and `seq`.
-Until that exists, only reviewed image derivatives should enter a public static
-artifact; raw originals, unsupported files, and external URLs stay in intake.
+The v1 local authoring attachment shape now permits
+`kind=image|video|audio|document|embed`, `mime`, `visibility=public|private`,
+`caption`, and `path`. This is descriptive intake metadata, not a promise that
+the current publisher can render every kind. The public package boundary accepts
+only public local JPEG/PNG/WebP images; private attachments, unsupported kinds,
+raw unsupported files, and external URLs are rejected rather than silently
+published. A future `memento_media` model still needs `object_key`,
+`content_hash`, `width`, `height`, `duration_ms`, `poster_key`, and `seq` for
+non-image publication.

--- a/examples/preview/local-journey/workspace.json
+++ b/examples/preview/local-journey/workspace.json
@@ -1,0 +1,19 @@
+{
+  "schema": "felicia.local.workspace.v1",
+  "version": "1",
+  "journal_id": "0190cbde-f300-7000-8000-000000000000",
+  "journeys": [
+    {
+      "path": ".",
+      "id": "0190cbde-f300-7000-8000-111111111111",
+      "slug": "golden-route",
+      "title": "Narita Express Day Trip"
+    },
+    {
+      "path": "kansai-ramble",
+      "id": "0190cbde-f300-7000-8000-222222222222",
+      "slug": "kansai-ramble",
+      "title": "Kansai Ramble"
+    }
+  ]
+}

--- a/providers/postgres/db/query.sql.go
+++ b/providers/postgres/db/query.sql.go
@@ -806,6 +806,72 @@ func (q *Queries) UpsertMemento(ctx context.Context, arg UpsertMementoParams) er
 	return nil
 }
 
+const upsertManualMemento = `-- name: UpsertManualMemento :exec
+INSERT INTO tb_mementos (
+    id, journey_id, kind, seq, occurred_at, occurred_tz, geom, title, place, vendor, essay, price_amount, price_currency, kind_data, source_system, source_external_id, source_ref, authored_fields, orphaned_at, state, revision, created_at, updated_at
+) VALUES (
+    $1, $2, $3, $4, $5, $6, ST_GeomFromWKB($7, 4326), $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, COALESCE($21, 1), NOW(), NOW()
+) ON CONFLICT (id) DO UPDATE SET
+    journey_id = EXCLUDED.journey_id,
+    kind = EXCLUDED.kind,
+    seq = EXCLUDED.seq,
+    occurred_at = EXCLUDED.occurred_at,
+    occurred_tz = EXCLUDED.occurred_tz,
+    geom = EXCLUDED.geom,
+    title = EXCLUDED.title,
+    place = EXCLUDED.place,
+    vendor = EXCLUDED.vendor,
+    essay = EXCLUDED.essay,
+    price_amount = EXCLUDED.price_amount,
+    price_currency = EXCLUDED.price_currency,
+    kind_data = EXCLUDED.kind_data,
+    source_system = EXCLUDED.source_system,
+    source_external_id = EXCLUDED.source_external_id,
+    source_ref = EXCLUDED.source_ref,
+    authored_fields = EXCLUDED.authored_fields,
+    orphaned_at = EXCLUDED.orphaned_at,
+    state = EXCLUDED.state,
+    revision = tb_mementos.revision + 1,
+    updated_at = NOW()
+WHERE $22::bigint IS NULL OR tb_mementos.revision = $22
+`
+
+type UpsertManualMementoParams = UpsertMementoParams
+
+func (q *Queries) UpsertManualMemento(ctx context.Context, arg UpsertManualMementoParams) error {
+	tag, err := q.db.Exec(ctx, upsertManualMemento,
+		arg.ID,
+		arg.JourneyID,
+		arg.Kind,
+		arg.Seq,
+		arg.OccurredAt,
+		arg.OccurredTz,
+		arg.StGeomfromwkb,
+		arg.Title,
+		arg.Place,
+		arg.Vendor,
+		arg.Essay,
+		arg.PriceAmount,
+		arg.PriceCurrency,
+		arg.KindData,
+		arg.SourceSystem,
+		arg.SourceExternalID,
+		arg.SourceRef,
+		arg.AuthoredFields,
+		arg.OrphanedAt,
+		arg.State,
+		arg.Revision,
+		arg.ExpectedRevision,
+	)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return pgx.ErrNoRows
+	}
+	return nil
+}
+
 const upsertPhoto = `-- name: UpsertPhoto :exec
 INSERT INTO tb_memento_photos (
     id, memento_id, object_key, content_hash, caption, seq, taken_at, source_ref, created_at

--- a/providers/postgres/queries/query.sql
+++ b/providers/postgres/queries/query.sql
@@ -123,6 +123,35 @@ INSERT INTO tb_mementos (
     updated_at = NOW()
 WHERE $22::bigint IS NULL OR tb_mementos.revision = $22;
 
+-- name: UpsertManualMemento :exec
+INSERT INTO tb_mementos (
+    id, journey_id, kind, seq, occurred_at, occurred_tz, geom, title, place, vendor, essay, price_amount, price_currency, kind_data, source_system, source_external_id, source_ref, authored_fields, orphaned_at, state, revision, created_at, updated_at
+) VALUES (
+    $1, $2, $3, $4, $5, $6, ST_GeomFromWKB($7, 4326), $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, COALESCE($21, 1), NOW(), NOW()
+) ON CONFLICT (id) DO UPDATE SET
+    journey_id = EXCLUDED.journey_id,
+    kind = EXCLUDED.kind,
+    seq = EXCLUDED.seq,
+    occurred_at = EXCLUDED.occurred_at,
+    occurred_tz = EXCLUDED.occurred_tz,
+    geom = EXCLUDED.geom,
+    title = EXCLUDED.title,
+    place = EXCLUDED.place,
+    vendor = EXCLUDED.vendor,
+    essay = EXCLUDED.essay,
+    price_amount = EXCLUDED.price_amount,
+    price_currency = EXCLUDED.price_currency,
+    kind_data = EXCLUDED.kind_data,
+    source_system = EXCLUDED.source_system,
+    source_external_id = EXCLUDED.source_external_id,
+    source_ref = EXCLUDED.source_ref,
+    authored_fields = EXCLUDED.authored_fields,
+    orphaned_at = EXCLUDED.orphaned_at,
+    state = EXCLUDED.state,
+    revision = tb_mementos.revision + 1,
+    updated_at = NOW()
+WHERE $22::bigint IS NULL OR tb_mementos.revision = $22;
+
 -- name: GetPhoto :one
 SELECT id, memento_id, object_key, content_hash, caption, seq, taken_at, source_ref, created_at
 FROM tb_memento_photos

--- a/providers/postgres/repository.go
+++ b/providers/postgres/repository.go
@@ -254,6 +254,14 @@ func (r *pgRepository) UpsertMemento(ctx context.Context, memento *domain.Mement
 }
 
 func (r *pgRepository) upsertMemento(ctx context.Context, memento *domain.Memento, expectedRevision *int64) error {
+	return r.upsertMementoWith(ctx, memento, expectedRevision, false)
+}
+
+func (r *pgRepository) upsertManualMemento(ctx context.Context, memento *domain.Memento, expectedRevision *int64) error {
+	return r.upsertMementoWith(ctx, memento, expectedRevision, true)
+}
+
+func (r *pgRepository) upsertMementoWith(ctx context.Context, memento *domain.Memento, expectedRevision *int64, manual bool) error {
 	var geomBytes []byte
 	var err error
 	if memento.Geom != nil {
@@ -270,7 +278,7 @@ func (r *pgRepository) upsertMemento(ctx context.Context, memento *domain.Mement
 		revision = &memento.Revision
 	}
 
-	if err := r.q.UpsertMemento(ctx, db.UpsertMementoParams{
+	params := db.UpsertMementoParams{
 		ID:               memento.ID,
 		JourneyID:        memento.JourneyID,
 		Kind:             memento.Kind,
@@ -293,7 +301,13 @@ func (r *pgRepository) upsertMemento(ctx context.Context, memento *domain.Mement
 		State:            string(state),
 		Revision:         toInt8(revision),
 		ExpectedRevision: toInt8(expectedRevision),
-	}); err != nil {
+	}
+	if manual {
+		err = r.q.UpsertManualMemento(ctx, params)
+	} else {
+		err = r.q.UpsertMemento(ctx, params)
+	}
+	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return domain.ErrWriteConflict
 		}
@@ -335,7 +349,7 @@ func (r *pgRepository) ApplyManualMementoPatch(ctx context.Context, patch *domai
 	if patch.State != "" {
 		current.State = patch.State
 	}
-	return r.upsertMemento(ctx, current, patch.ExpectedRevision)
+	return r.upsertManualMemento(ctx, current, patch.ExpectedRevision)
 }
 
 // ApplyMementoAggregate persists the authored memento and child content in a

--- a/providers/sqlite/runtime_test.go
+++ b/providers/sqlite/runtime_test.go
@@ -76,7 +76,7 @@ func TestApplyPackageIsIdempotent(t *testing.T) {
 	source := domain.SourceIdentity{System: "package:sample", ExternalID: mementoID.String()}
 	document := &importer.PackageDocument{
 		Journey:  &domain.Journey{ID: journeyID, JournalID: journalID, Slug: "sample", Title: "Sample", Place: "Kyoto", DateStart: time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC), DateEnd: time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC), GPSRoute: orb.MultiLineString{{{135.7, 35.0}, {135.8, 35.1}}}},
-		Mementos: []*domain.Memento{{ID: mementoID, JourneyID: journeyID, Kind: "transit", Seq: 1, Title: "Train", Place: "Kyoto", KindData: []byte(`{"operator":"JR"}`), SourceIdentity: &source, State: domain.MementoCandidateState}},
+		Mementos: []*domain.Memento{{ID: mementoID, JourneyID: journeyID, Kind: "transit", Seq: 1, Title: "Train", Place: "Kyoto", Vendor: runtimeStringPtr("JR East"), Essay: runtimeStringPtr("A quiet departure."), PriceAmount: runtimeInt64Ptr(1800), PriceCurrency: runtimeStringPtr("JPY"), AuthoredFields: []string{"title", "vendor", "essay", "price_amount", "price_currency"}, KindData: []byte(`{"operator":"JR"}`), SourceIdentity: &source, State: domain.MementoPublished}},
 		Photos:   []*domain.MementoPhoto{{ID: photoID, MementoID: mementoID, ObjectKey: "media/train.jpg", ContentHash: "sha256:train", Seq: 1}},
 	}
 	for attempt := 0; attempt < 2; attempt++ {
@@ -92,11 +92,18 @@ func TestApplyPackageIsIdempotent(t *testing.T) {
 	if err != nil || len(mementos) != 1 {
 		t.Fatalf("mementos after repeat import: %d, %v", len(mementos), err)
 	}
+	if mementos[0].Vendor == nil || *mementos[0].Vendor != "JR East" || mementos[0].Essay == nil || *mementos[0].Essay != "A quiet departure." || mementos[0].PriceAmount == nil || *mementos[0].PriceAmount != 1800 || mementos[0].State != domain.MementoPublished {
+		t.Fatalf("authored memento fields after import: %#v", mementos[0])
+	}
 	photos, err := repo.ListPhotosByMemento(context.Background(), mementoID)
 	if err != nil || len(photos) != 1 {
 		t.Fatalf("photos after repeat import: %d, %v", len(photos), err)
 	}
 }
+
+func runtimeStringPtr(value string) *string { return &value }
+
+func runtimeInt64Ptr(value int64) *int64 { return &value }
 
 func pragmaString(t *testing.T, db *sql.DB, name string) string {
 	t.Helper()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ docs = [
 ]
 dev = [
   "psycopg[binary]>=3.2.0",
+  "jsonschema>=4.23.0,<5",
   "ruff>=0.12,<0.13",
 ]
 

--- a/runtime/importer/package.go
+++ b/runtime/importer/package.go
@@ -59,6 +59,11 @@ func ApplyPackage(ctx context.Context, document *PackageDocument, store PackageS
 		if err := store.ApplyIngestMementoPatch(ctx, &domain.IngestMementoPatch{Memento: memento, Fields: fields}); err != nil {
 			return ImportReport{}, fmt.Errorf("import memento %s: %w", memento.ID, err)
 		}
+		if len(memento.AuthoredFields) > 0 || (memento.State != "" && memento.State != domain.MementoCandidateState) {
+			if err := store.ApplyManualMementoPatch(ctx, &domain.ManualMementoPatch{Memento: memento, Fields: memento.AuthoredFields, State: memento.State}); err != nil {
+				return ImportReport{}, fmt.Errorf("apply authored memento %s: %w", memento.ID, err)
+			}
+		}
 	}
 	for _, photo := range document.Photos {
 		if err := store.UpsertPhoto(ctx, photo); err != nil {
@@ -82,17 +87,22 @@ type journeyFile struct {
 }
 
 type mementoFile struct {
-	ID         string         `yaml:"id"`
-	Seq        int            `yaml:"seq"`
-	Kind       string         `yaml:"kind"`
-	OccurredAt string         `yaml:"occurred_at"`
-	OccurredTZ string         `yaml:"occurred_tz"`
-	Title      string         `yaml:"title"`
-	Place      string         `yaml:"place"`
-	Geom       []float64      `yaml:"geom"`
-	KindData   map[string]any `yaml:"kind_data"`
-	State      string         `yaml:"state"`
-	Photos     []photoFile    `yaml:"photos"`
+	ID             string         `yaml:"id"`
+	Seq            int            `yaml:"seq"`
+	Kind           string         `yaml:"kind"`
+	OccurredAt     string         `yaml:"occurred_at"`
+	OccurredTZ     string         `yaml:"occurred_tz"`
+	Title          string         `yaml:"title"`
+	Place          string         `yaml:"place"`
+	Geom           []float64      `yaml:"geom"`
+	Vendor         string         `yaml:"vendor"`
+	Essay          string         `yaml:"essay"`
+	PriceAmount    *int64         `yaml:"price_amount"`
+	PriceCurrency  string         `yaml:"price_currency"`
+	AuthoredFields []string       `yaml:"authored_fields"`
+	KindData       map[string]any `yaml:"kind_data"`
+	State          string         `yaml:"state"`
+	Photos         []photoFile    `yaml:"photos"`
 }
 
 type photoFile struct {
@@ -207,7 +217,7 @@ func normalizeMemento(pkg *journeypackage.Package, journeyID uuid.UUID, raw meme
 	if state == "" {
 		state = domain.MementoCandidateState
 	}
-	memento := &domain.Memento{ID: id, JourneyID: journeyID, Kind: raw.Kind, Seq: raw.Seq, OccurredAt: occurredAt, OccurredTZ: raw.OccurredTZ, Geom: geom, Title: raw.Title, Place: raw.Place, KindData: kindData, SourceIdentity: &source, State: state}
+	memento := &domain.Memento{ID: id, JourneyID: journeyID, Kind: raw.Kind, Seq: raw.Seq, OccurredAt: occurredAt, OccurredTZ: raw.OccurredTZ, Geom: geom, Title: raw.Title, Place: raw.Place, Vendor: optional(raw.Vendor), Essay: optional(raw.Essay), PriceAmount: raw.PriceAmount, PriceCurrency: optional(raw.PriceCurrency), AuthoredFields: raw.AuthoredFields, KindData: kindData, SourceIdentity: &source, State: state}
 	photos := make([]*domain.MementoPhoto, 0, len(raw.Photos))
 	for index, rawPhoto := range raw.Photos {
 		photoID, err := uuid.Parse(rawPhoto.ID)

--- a/runtime/importer/package_test.go
+++ b/runtime/importer/package_test.go
@@ -11,7 +11,7 @@ func TestDecodePackageNormalizesRouteMementoAndMedia(t *testing.T) {
 		Manifest: journeypackage.Manifest{PackageID: "timeline-1"},
 		Files: map[string][]byte{
 			"journey.yaml":     []byte("id: 00000000-0000-0000-0000-000000000001\njournal_id: 00000000-0000-0000-0000-000000000002\nslug: kyoto\ntitle: Kyoto\nplace: Kyoto\ndate_start: 2026-04-01\ndate_end: 2026-04-01\n"),
-			"mementos.yaml":    []byte("- id: 00000000-0000-0000-0000-000000000003\n  seq: 1\n  kind: transit\n  occurred_at: 2026-04-01T09:00:00+09:00\n  title: Train\n  place: Kyoto\n  geom: [135.7681, 35.0116]\n  kind_data:\n    operator: JR West\n  photos:\n    - id: 00000000-0000-0000-0000-000000000004\n      path: media/ticket.jpg\n      content_hash: sha256:ticket\n      seq: 1\n"),
+			"mementos.yaml":    []byte("- id: 00000000-0000-0000-0000-000000000003\n  seq: 1\n  kind: transit\n  occurred_at: 2026-04-01T09:00:00+09:00\n  title: Train\n  place: Kyoto\n  vendor: JR East\n  essay: A quiet departure.\n  price_amount: 1800\n  price_currency: JPY\n  authored_fields: [title, vendor, essay, price_amount, price_currency]\n  geom: [135.7681, 35.0116]\n  kind_data:\n    operator: JR West\n  photos:\n    - id: 00000000-0000-0000-0000-000000000004\n      path: media/ticket.jpg\n      content_hash: sha256:ticket\n      seq: 1\n"),
 			"route.gpx":        []byte(`<?xml version="1.0"?><gpx><trk><trkseg><trkpt lat="35.0116" lon="135.7681"/><trkpt lat="35.6812" lon="139.7671"/></trkseg></trk></gpx>`),
 			"media/ticket.jpg": []byte("image"),
 		},
@@ -29,5 +29,8 @@ func TestDecodePackageNormalizesRouteMementoAndMedia(t *testing.T) {
 	}
 	if got.Mementos[0].SourceIdentity == nil || got.Mementos[0].SourceIdentity.Ref() != "package:timeline-1:00000000-0000-0000-0000-000000000003" {
 		t.Fatalf("missing source identity: %#v", got.Mementos[0].SourceIdentity)
+	}
+	if got.Mementos[0].Vendor == nil || *got.Mementos[0].Vendor != "JR East" || got.Mementos[0].Essay == nil || got.Mementos[0].PriceAmount == nil || *got.Mementos[0].PriceAmount != 1800 || len(got.Mementos[0].AuthoredFields) != 5 {
+		t.Fatalf("authored fields were not normalized: %#v", got.Mementos[0])
 	}
 }

--- a/schemas/local-authoring-v1.schema.json
+++ b/schemas/local-authoring-v1.schema.json
@@ -19,6 +19,9 @@
       "required": ["path"],
       "properties": {
         "path": { "type": "string", "minLength": 1 },
+        "kind": { "enum": ["image", "video", "audio", "document", "embed"] },
+        "mime": { "type": "string", "minLength": 1 },
+        "visibility": { "enum": ["public", "private"] },
         "caption": { "type": "string" }
       },
       "additionalProperties": false

--- a/schemas/local-authoring-v1.schema.json
+++ b/schemas/local-authoring-v1.schema.json
@@ -44,6 +44,36 @@
       },
       "additionalProperties": false
     },
+    "workspace_journey": {
+      "type": "object",
+      "required": ["path", "id"],
+      "properties": {
+        "path": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^(?:\\.|[A-Za-z0-9][A-Za-z0-9._-]*)(?:/[A-Za-z0-9][A-Za-z0-9._-]*)*$"
+        },
+        "id": { "type": "string", "format": "uuid" },
+        "slug": { "type": "string", "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$" },
+        "title": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "workspace": {
+      "type": "object",
+      "required": ["schema", "version", "journal_id", "journeys"],
+      "properties": {
+        "schema": { "const": "felicia.local.workspace.v1" },
+        "version": { "const": "1" },
+        "journal_id": { "type": "string", "format": "uuid" },
+        "journeys": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/workspace_journey" }
+        }
+      },
+      "additionalProperties": false
+    },
     "stop": {
       "type": "object",
       "required": ["candidate_key", "selected", "label"],

--- a/schemas/local-authoring-v1.schema.json
+++ b/schemas/local-authoring-v1.schema.json
@@ -109,6 +109,163 @@
       },
       "additionalProperties": false
     },
+    "source_identity": {
+      "type": "object",
+      "required": ["system", "external_id"],
+      "properties": {
+        "system": { "type": "string", "minLength": 1 },
+        "external_id": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    },
+    "provenance": {
+      "type": "object",
+      "required": ["source", "observed_at", "confidence"],
+      "properties": {
+        "source": { "$ref": "#/$defs/source_identity" },
+        "observed_at": { "type": "string", "format": "date-time" },
+        "confidence": { "type": "number", "minimum": 0, "maximum": 1 }
+      },
+      "additionalProperties": false
+    },
+    "track_point": {
+      "type": "object",
+      "required": ["Coord", "At"],
+      "properties": {
+        "Coord": { "$ref": "#/$defs/coordinate" },
+        "At": { "type": "string", "format": "date-time" }
+      },
+      "additionalProperties": false
+    },
+    "route": {
+      "type": "object",
+      "required": ["Line", "Points", "From", "To", "DistanceM", "Mode", "SourceRef", "Provenance"],
+      "properties": {
+        "Line": { "anyOf": [{ "type": "array", "items": { "$ref": "#/$defs/coordinate" } }, { "type": "null" }] },
+        "Points": { "type": "array", "items": { "$ref": "#/$defs/track_point" } },
+        "From": { "type": "string", "format": "date-time" },
+        "To": { "type": "string", "format": "date-time" },
+        "DistanceM": { "type": "integer", "minimum": 0 },
+        "Mode": { "type": "string" },
+        "SourceRef": { "type": "string" },
+        "Provenance": { "$ref": "#/$defs/provenance" }
+      },
+      "additionalProperties": false
+    },
+    "visit": {
+      "type": "object",
+      "required": ["Coord", "Label", "Arrive", "Depart", "Confidence", "SourceRef", "Provenance"],
+      "properties": {
+        "Coord": { "$ref": "#/$defs/coordinate" },
+        "Label": { "type": "string" },
+        "Arrive": { "type": "string", "format": "date-time" },
+        "Depart": { "type": "string", "format": "date-time" },
+        "Confidence": { "type": "number", "minimum": 0, "maximum": 1 },
+        "SourceRef": { "type": "string" },
+        "Provenance": { "$ref": "#/$defs/provenance" }
+      },
+      "additionalProperties": false
+    },
+    "evidence": {
+      "type": "object",
+      "required": ["kind", "source", "locator"],
+      "properties": {
+        "kind": { "enum": ["route", "visit", "media"] },
+        "source": { "$ref": "#/$defs/source_identity" },
+        "locator": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    },
+    "candidate_identity": {
+      "type": "object",
+      "required": ["derivation_version", "key"],
+      "properties": {
+        "derivation_version": { "type": "string", "minLength": 1 },
+        "key": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    },
+    "stop_candidate": {
+      "type": "object",
+      "required": ["ID", "JourneyID", "Identity", "Label", "Coord", "Arrive", "Depart", "Confidence", "Evidence", "State", "Revision", "CreatedAt", "UpdatedAt"],
+      "properties": {
+        "ID": { "type": "string", "format": "uuid" },
+        "JourneyID": { "type": "string", "format": "uuid" },
+        "Identity": { "$ref": "#/$defs/candidate_identity" },
+        "Label": { "type": "string" },
+        "AuthoredFields": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+        "Coord": { "$ref": "#/$defs/coordinate" },
+        "Arrive": { "type": "string", "format": "date-time" },
+        "Depart": { "type": "string", "format": "date-time" },
+        "Confidence": { "type": "number", "minimum": 0, "maximum": 1 },
+        "Evidence": { "type": "array", "items": { "$ref": "#/$defs/evidence" } },
+        "State": { "enum": ["proposed", "kept", "ignored", "merged"] },
+        "MergedInto": { "anyOf": [{ "type": "string", "format": "uuid" }, { "type": "null" }] },
+        "Provenance": { "type": "array", "items": { "$ref": "#/$defs/provenance" } },
+        "Revision": { "type": "integer", "minimum": 0 },
+        "CreatedAt": { "type": "string", "format": "date-time" },
+        "UpdatedAt": { "type": "string", "format": "date-time" }
+      },
+      "additionalProperties": false
+    },
+    "memory_link": {
+      "type": "object",
+      "required": ["entity_type", "entity_id", "relation"],
+      "properties": {
+        "entity_type": { "type": "string", "minLength": 1 },
+        "entity_id": { "type": "string", "format": "uuid" },
+        "relation": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    },
+    "media_asset": {
+      "type": "object",
+      "properties": {
+        "ID": { "type": "string" },
+        "Kind": { "enum": ["image", "video", "audio", "document", "link", "embed"] },
+        "At": { "type": "string", "format": "date-time" },
+        "Coord": { "anyOf": [{ "$ref": "#/$defs/coordinate" }, { "type": "null" }] },
+        "Checksum": { "type": "string" },
+        "SourceRef": { "type": "string" },
+        "Provenance": { "$ref": "#/$defs/provenance" },
+        "URI": { "type": "string" },
+        "MIME": { "type": "string" },
+        "Title": { "type": "string" },
+        "Provider": { "type": "string" },
+        "EmbedURL": { "type": "string" },
+        "MemoryLinks": { "type": "array", "items": { "$ref": "#/$defs/memory_link" } }
+      },
+      "additionalProperties": false
+    },
+    "memento_candidate": {
+      "type": "object",
+      "required": ["source", "stop_key", "kind", "occurred_at", "occurred_tz", "geom", "title", "place", "kind_data", "media", "memory_links", "provenance"],
+      "properties": {
+        "source": { "$ref": "#/$defs/source_identity" },
+        "stop_key": { "type": "string", "minLength": 1 },
+        "kind": { "type": "string", "minLength": 1 },
+        "occurred_at": { "type": "string", "format": "date-time" },
+        "occurred_tz": { "type": "string" },
+        "geom": { "anyOf": [{ "$ref": "#/$defs/coordinate" }, { "type": "null" }] },
+        "title": { "type": "string" },
+        "place": { "type": "string" },
+        "kind_data": { "type": "object" },
+        "media": { "type": "array", "items": { "$ref": "#/$defs/media_asset" } },
+        "memory_links": { "type": "array", "items": { "$ref": "#/$defs/memory_link" } },
+        "provenance": { "$ref": "#/$defs/provenance" }
+      },
+      "additionalProperties": false
+    },
+    "plan_issue": {
+      "type": "object",
+      "required": ["severity", "code", "message"],
+      "properties": {
+        "severity": { "enum": ["info", "warning", "error"] },
+        "code": { "type": "string", "minLength": 1 },
+        "message": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    },
     "plan": {
       "type": "object",
       "required": ["journey_id", "schema", "version", "routes", "visits", "stops", "mementos", "issues"],
@@ -117,11 +274,11 @@
         "schema": { "const": "felicia.intake.plan" },
         "version": { "const": "1" },
         "source_fingerprint": { "type": "string" },
-        "routes": { "type": "array" },
-        "visits": { "type": "array" },
-        "stops": { "type": "array" },
-        "mementos": { "type": "array" },
-        "issues": { "type": "array" }
+        "routes": { "type": "array", "items": { "$ref": "#/$defs/route" } },
+        "visits": { "type": "array", "items": { "$ref": "#/$defs/visit" } },
+        "stops": { "type": "array", "items": { "$ref": "#/$defs/stop_candidate" } },
+        "mementos": { "type": "array", "items": { "$ref": "#/$defs/memento_candidate" } },
+        "issues": { "type": "array", "items": { "$ref": "#/$defs/plan_issue" } }
       },
       "additionalProperties": false
     }

--- a/schemas/local-authoring-v1.schema.json
+++ b/schemas/local-authoring-v1.schema.json
@@ -1,0 +1,120 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://felicia.local/schemas/local-authoring-v1.schema.json",
+  "title": "Felicia local authoring v1",
+  "description": "Definitions for the editable local journey workspace. Each file selects one definition below.",
+  "$defs": {
+    "coordinate": {
+      "type": "array",
+      "prefixItems": [
+        { "type": "number", "minimum": -180, "maximum": 180 },
+        { "type": "number", "minimum": -90, "maximum": 90 }
+      ],
+      "items": false,
+      "minItems": 2,
+      "maxItems": 2
+    },
+    "media": {
+      "type": "object",
+      "required": ["path"],
+      "properties": {
+        "path": { "type": "string", "minLength": 1 },
+        "caption": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "journey": {
+      "type": "object",
+      "required": ["schema", "id", "journal_id", "slug", "title", "date_start", "date_end"],
+      "properties": {
+        "schema": { "const": "felicia.local.journey.v1" },
+        "id": { "type": "string", "format": "uuid" },
+        "journal_id": { "type": "string", "format": "uuid" },
+        "slug": { "type": "string", "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$" },
+        "title": { "type": "string", "minLength": 1 },
+        "place": { "type": "string" },
+        "country": { "type": "string" },
+        "region": { "type": "string" },
+        "date_start": { "type": "string", "format": "date" },
+        "date_end": { "type": "string", "format": "date" },
+        "source_ref": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "stop": {
+      "type": "object",
+      "required": ["candidate_key", "selected", "label"],
+      "properties": {
+        "candidate_key": { "type": "string", "minLength": 1 },
+        "selected": { "type": "boolean" },
+        "label": { "type": "string" },
+        "coord": { "anyOf": [{ "$ref": "#/$defs/coordinate" }, { "type": "null" }] },
+        "arrive": { "type": "string", "format": "date-time" },
+        "depart": { "type": "string", "format": "date-time" },
+        "confidence": { "type": "number", "minimum": 0, "maximum": 1 },
+        "source_index": { "type": "integer", "minimum": 1 },
+        "review_note": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "stops_file": {
+      "type": "object",
+      "required": ["schema", "stops"],
+      "properties": {
+        "schema": { "const": "felicia.local.stops.v1" },
+        "stops": { "type": "array", "items": { "$ref": "#/$defs/stop" } }
+      },
+      "additionalProperties": false
+    },
+    "memento": {
+      "type": "object",
+      "required": ["id", "stop_key", "seq", "kind", "occurred_at", "state", "title", "kind_data", "media"],
+      "properties": {
+        "id": { "type": "string", "format": "uuid" },
+        "stop_key": { "type": "string", "minLength": 1 },
+        "seq": { "type": "integer", "minimum": 1 },
+        "kind": { "enum": ["goods", "live", "transit", "stamp", "receipt"] },
+        "occurred_at": { "type": "string", "format": "date-time" },
+        "occurred_tz": { "type": "string", "minLength": 1 },
+        "state": { "enum": ["candidate", "draft", "authored", "published", "archived"] },
+        "title": { "type": "string" },
+        "place": { "type": "string" },
+        "geom": { "anyOf": [{ "$ref": "#/$defs/coordinate" }, { "type": "null" }] },
+        "kind_data": { "type": "object" },
+        "essay": { "type": "string" },
+        "vendor": { "type": "string" },
+        "price_amount": { "type": "integer" },
+        "price_currency": { "type": "string" },
+        "translations": { "type": "object" },
+        "media": { "type": "array", "items": { "$ref": "#/$defs/media" } },
+        "author_note": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "mementos_file": {
+      "type": "object",
+      "required": ["schema", "mementos"],
+      "properties": {
+        "schema": { "const": "felicia.local.mementos.v1" },
+        "mementos": { "type": "array", "items": { "$ref": "#/$defs/memento" } }
+      },
+      "additionalProperties": false
+    },
+    "plan": {
+      "type": "object",
+      "required": ["journey_id", "schema", "version", "routes", "visits", "stops", "mementos", "issues"],
+      "properties": {
+        "journey_id": { "type": "string", "format": "uuid" },
+        "schema": { "const": "felicia.intake.plan" },
+        "version": { "const": "1" },
+        "source_fingerprint": { "type": "string" },
+        "routes": { "type": "array" },
+        "visits": { "type": "array" },
+        "stops": { "type": "array" },
+        "mementos": { "type": "array" },
+        "issues": { "type": "array" }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/schemas/local-authoring-v1.schema.json
+++ b/schemas/local-authoring-v1.schema.json
@@ -83,9 +83,15 @@
         "kind_data": { "type": "object" },
         "essay": { "type": "string" },
         "vendor": { "type": "string" },
-        "price_amount": { "type": "integer" },
-        "price_currency": { "type": "string" },
-        "translations": { "type": "object" },
+        "price_amount": { "anyOf": [{ "type": "integer" }, { "type": "null" }] },
+        "price_currency": { "type": "string", "pattern": "^[A-Z]{3}$" },
+        "authored_fields": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "enum": ["title", "place", "kind", "seq", "occurred_at", "occurred_tz", "geom", "vendor", "essay", "price_amount", "price_currency", "kind_data"]
+          }
+        },
         "media": { "type": "array", "items": { "$ref": "#/$defs/media" } },
         "author_note": { "type": "string" }
       },

--- a/scripts/build_preview_package.py
+++ b/scripts/build_preview_package.py
@@ -9,6 +9,7 @@ from argparse import Namespace
 from pathlib import Path
 
 from local_journey import build_package
+from validate_local_authoring import validate_workspace_root
 
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -47,7 +48,13 @@ def build_from_local_workspace(source: Path, workspace: Path) -> Path:
 def main() -> None:
     OUTPUT.parent.mkdir(parents=True, exist_ok=True)
     source_root = ROOT / "examples" / "preview" / "local-journey"
-    sources = [source_root, *sorted(path for path in source_root.iterdir() if path.is_dir())]
+    manifest = source_root / "workspace.json"
+    if manifest.is_file():
+        validate_workspace_root(source_root)
+        entries = json.loads(manifest.read_text(encoding="utf-8"))["journeys"]
+        sources = [(source_root / entry["path"]).resolve() for entry in entries]
+    else:
+        sources = [source_root, *sorted(path for path in source_root.iterdir() if path.is_dir())]
     shutil.rmtree(PACKAGE_DIR, ignore_errors=True)
     PACKAGE_DIR.mkdir(parents=True, exist_ok=True)
     generated = []

--- a/scripts/local_journey.py
+++ b/scripts/local_journey.py
@@ -68,7 +68,7 @@ def preprocess(args: argparse.Namespace) -> None:
                 "id": str(uuid.uuid5(NAMESPACE, f"{args.journey}:memento:{index}")),
                 "stop_key": source.get("stop_key", ""),
                 "seq": index,
-                "kind": source.get("kind") or "note",
+                "kind": source.get("kind") or "goods",
                 "occurred_at": source.get("occurred_at", ""),
                 "occurred_tz": source.get("occurred_tz", "UTC"),
                 "title": source.get("title", ""),

--- a/scripts/local_journey_author.py
+++ b/scripts/local_journey_author.py
@@ -29,6 +29,15 @@ def parse_coord(value: str) -> list[float] | None:
     return [longitude, latitude]
 
 
+def parse_price(value: str) -> int | None:
+    if not value:
+        return None
+    try:
+        return int(value)
+    except ValueError as error:
+        raise SystemExit("price amount must be an integer") from error
+
+
 def interactive_author(args: Namespace) -> None:
     """Let a person curate generated evidence before it becomes authored data."""
     workspace = args.workspace.resolve()
@@ -74,6 +83,11 @@ def interactive_author(args: Namespace) -> None:
         print(f"\nEdit memento {memento.get('id')}")
         memento["title"] = ask("  title", memento.get("title", ""))
         memento["kind"] = ask("  kind", memento.get("kind", "goods"))
+        memento["vendor"] = ask("  vendor", memento.get("vendor", ""))
+        memento["essay"] = ask("  essay", memento.get("essay", ""))
+        memento["price_amount"] = parse_price(ask("  price amount", str(memento.get("price_amount", "") or "")))
+        memento["price_currency"] = ask("  price currency", memento.get("price_currency", "JPY"))
+        memento["authored_fields"] = ["title", "kind", "vendor", "essay", "price_amount", "price_currency"]
         memento["state"] = ask("  state (draft/published)", "published")
         media_default = ",".join(item.get("path", "") for item in memento.get("media", []))
         media_paths = ask("  media paths (comma-separated)", media_default)
@@ -95,6 +109,11 @@ def interactive_author(args: Namespace) -> None:
                     "geom": stop.get("coord"),
                     "state": ask("  state (draft/published)", "published"),
                     "kind_data": {},
+                    "vendor": ask("  vendor"),
+                    "essay": ask("  essay"),
+                    "price_amount": parse_price(ask("  price amount")),
+                    "price_currency": ask("  price currency", "JPY"),
+                    "authored_fields": ["title", "kind", "vendor", "essay", "price_amount", "price_currency"],
                     "media": [
                         {"path": path.strip(), "caption": ""}
                         for path in ask("  media paths (comma-separated)").split(",")

--- a/scripts/local_journey_author.py
+++ b/scripts/local_journey_author.py
@@ -73,7 +73,7 @@ def interactive_author(args: Namespace) -> None:
     for memento in mementos:
         print(f"\nEdit memento {memento.get('id')}")
         memento["title"] = ask("  title", memento.get("title", ""))
-        memento["kind"] = ask("  kind", memento.get("kind", "note"))
+        memento["kind"] = ask("  kind", memento.get("kind", "goods"))
         memento["state"] = ask("  state (draft/published)", "published")
         media_default = ",".join(item.get("path", "") for item in memento.get("media", []))
         media_paths = ask("  media paths (comma-separated)", media_default)
@@ -87,7 +87,7 @@ def interactive_author(args: Namespace) -> None:
                     "id": str(uuid.uuid5(NAMESPACE, f"{args.journey}:memento:{index}")),
                     "stop_key": stop["candidate_key"],
                     "seq": index,
-                    "kind": ask("  kind", "note"),
+                    "kind": ask("  kind", "goods"),
                     "occurred_at": ask("  occurred_at RFC3339", stop.get("arrive", "")),
                     "occurred_tz": ask("  timezone", "UTC"),
                     "title": ask("  title"),

--- a/scripts/local_journey_package.py
+++ b/scripts/local_journey_package.py
@@ -58,7 +58,10 @@ def build_package(args: Namespace) -> Path:
         package_mementos.append(
             {
                 key: memento[key]
-                for key in ("id", "seq", "kind", "occurred_at", "occurred_tz", "title", "place", "geom", "kind_data", "state")
+                for key in (
+                    "id", "seq", "kind", "occurred_at", "occurred_tz", "title", "place", "geom",
+                    "vendor", "essay", "price_amount", "price_currency", "authored_fields", "kind_data", "state"
+                )
                 if key in memento
             }
             | {"photos": photos}

--- a/scripts/local_journey_package.py
+++ b/scripts/local_journey_package.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import mimetypes
 import uuid
 import zipfile
 from argparse import Namespace
@@ -43,8 +44,11 @@ def build_package(args: Namespace) -> Path:
         photos = []
         for photo_index, photo in enumerate(memento.get("media", []), start=1):
             source = safe_media_path(workspace, str(photo.get("path", "")))
+            validate_public_image(photo, source)
             name = f"media/{source.name}"
             data = source.read_bytes()
+            if name in copied_media and copied_media[name] != data:
+                raise SystemExit(f"media basename collision with different files: {source.name}")
             copied_media[name] = data
             photos.append(
                 {
@@ -80,3 +84,23 @@ def build_package(args: Namespace) -> Path:
             archive.writestr(name, data)
     print(f"package ready: {output} (stops={len(selected)}, mementos={len(package_mementos)}, media={len(copied_media)})")
     return output
+
+
+def validate_public_image(attachment: dict, source: Path) -> None:
+    """Enforce the v1 public-package media boundary."""
+    visibility = attachment.get("visibility", "public")
+    if visibility != "public":
+        raise SystemExit(f"private media cannot enter a public package: {attachment.get('path', '')}")
+    kind = attachment.get("kind", "image")
+    if kind != "image":
+        raise SystemExit(f"unsupported public media kind {kind!r}: {attachment.get('path', '')}")
+    extension = source.suffix.lower()
+    if extension not in {".jpg", ".jpeg", ".png", ".webp"}:
+        raise SystemExit(f"only JPEG, PNG, and WebP images are supported in public packages: {source.name}")
+    declared_mime = attachment.get("mime")
+    detected_mime, _ = mimetypes.guess_type(source.name)
+    allowed_mime = {"image/jpeg", "image/png", "image/webp"}
+    if declared_mime and declared_mime not in allowed_mime:
+        raise SystemExit(f"unsupported public image MIME {declared_mime!r}: {source.name}")
+    if detected_mime and detected_mime not in allowed_mime:
+        raise SystemExit(f"unsupported public image MIME {detected_mime!r}: {source.name}")

--- a/scripts/local_journey_package.py
+++ b/scripts/local_journey_package.py
@@ -12,12 +12,18 @@ from pathlib import Path
 
 try:
     from .local_journey_common import NAMESPACE, read_json, safe_media_path
+    from .validate_local_authoring import validate_workspace
 except ImportError:
     from local_journey_common import NAMESPACE, read_json, safe_media_path
+    from validate_local_authoring import validate_workspace
 
 
 def build_package(args: Namespace) -> Path:
     workspace = args.workspace.resolve()
+    try:
+        validate_workspace(workspace)
+    except ValueError as error:
+        raise SystemExit(str(error)) from error
     journey = read_json(workspace / "journey.json")
     stop_data = read_json(workspace / "stops.json")
     memento_data = read_json(workspace / "mementos.json")

--- a/scripts/test_journey_workflow.py
+++ b/scripts/test_journey_workflow.py
@@ -4,20 +4,40 @@
 import argparse
 import json
 import os
+import socket
 import subprocess
 import sys
 import tempfile
 import time
 import urllib.error
 import urllib.request
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
+from dataclasses import dataclass
+from uuid import NAMESPACE_URL, uuid4, uuid5
 
 
 BASE_URL = os.getenv("API_BASE", "http://localhost:8080")
-JOURNAL_ID = "0190cbde-f300-7000-8000-d11111111111"
-JOURNEY_ID = "0190cbde-f300-7000-8000-d22222222222"
-MEMENTO_ID = "0190cbde-f300-7000-8000-d33333333333"
-PHOTO_ID = "0190cbde-f300-7000-8000-d44444444444"
+
+
+@dataclass(frozen=True)
+class WorkflowIDs:
+    journal: str
+    journey: str
+    memento: str
+    photo: str
+    slug: str
+
+
+def workflow_ids() -> WorkflowIDs:
+    run_id = uuid4()
+    prefix = f"felicia-workflow:{run_id}"
+    return WorkflowIDs(
+        journal=str(uuid5(NAMESPACE_URL, f"{prefix}:journal")),
+        journey=str(uuid5(NAMESPACE_URL, f"{prefix}:journey")),
+        memento=str(uuid5(NAMESPACE_URL, f"{prefix}:memento")),
+        photo=str(uuid5(NAMESPACE_URL, f"{prefix}:photo")),
+        slug=f"workflow-{run_id.hex[:12]}",
+    )
 
 
 def parse_args() -> argparse.Namespace:
@@ -27,10 +47,15 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="build and run the API against the selected database",
     )
-    parser.add_argument("--port", type=int, default=18080)
+    parser.add_argument("--port", type=int, default=0, help="server port; 0 reserves a free port")
     parser.add_argument("--database-driver", choices=("sqlite", "postgres"), default="sqlite")
     parser.add_argument("--database-path", default="", help="SQLite database path")
     parser.add_argument("--database-dsn", default="", help="PostgreSQL test database DSN")
+    parser.add_argument(
+        "--postgres-admin-dsn",
+        default="",
+        help="create and drop a disposable PostgreSQL database using this admin DSN",
+    )
     return parser.parse_args()
 
 
@@ -57,18 +82,24 @@ def request(path: str, method: str = "GET", payload: dict | None = None):
 
 def post(path: str, payload: dict):
     status, body = request(path, "POST", payload)
-    assert status == 200, f"expected 200 from {path}, got {status}: {body}"
+    if status != 200:
+        raise AssertionError(f"expected 200 from {path}, got {status}: {body!r}")
     return body
 
 
-def run_workflow() -> None:
-    post("/api/admin/journals", {"id": JOURNAL_ID})
+def expect(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def run_workflow(ids: WorkflowIDs) -> None:
+    post("/api/admin/journals", {"id": ids.journal})
     post(
         "/api/admin/journeys",
         {
-            "id": JOURNEY_ID,
-            "journal_id": JOURNAL_ID,
-            "slug": "workflow-journey",
+            "id": ids.journey,
+            "journal_id": ids.journal,
+            "slug": ids.slug,
             "title": "Workflow journey",
             "place": "Tokyo",
             "country": "JPN",
@@ -80,16 +111,19 @@ def run_workflow() -> None:
     )
 
     draft = {
-        "id": MEMENTO_ID,
-        "journey_id": JOURNEY_ID,
+        "id": ids.memento,
+        "journey_id": ids.journey,
         "kind": "live",
         "seq": 1,
         "state": "draft",
         "kind_data": {"artist": "羊文学"},
     }
     post("/api/admin/mementos", draft)
-    status, saved = request(f"/api/admin/mementos/{MEMENTO_ID}")
-    assert status == 200 and saved["state"] == "draft" and saved["revision"] == 1
+    status, saved = request(f"/api/admin/mementos/{ids.memento}")
+    expect(
+        status == 200 and saved.get("state") == "draft" and saved.get("revision") == 1,
+        f"draft memento mismatch: status={status} body={saved!r}",
+    )
 
     published = {
         **draft,
@@ -111,71 +145,131 @@ def run_workflow() -> None:
     post(
         "/api/admin/photos",
         {
-            "id": PHOTO_ID,
-            "memento_id": MEMENTO_ID,
+            "id": ids.photo,
+            "memento_id": ids.memento,
             "object_key": "workflow/live.jpg",
             "content_hash": "workflow-photo-hash",
             "seq": 1,
         },
     )
-    status, mementos = request(f"/api/admin/journeys/{JOURNEY_ID}/mementos")
-    assert status == 200 and len(mementos) == 1 and mementos[0]["state"] == "published"
-    status, public = request(f"/api/v1/journeys/{JOURNEY_ID}/mementos")
-    assert status == 200 and len(public) == 1 and len(public[0]["photos"]) == 1
-    assert public[0]["title"] == "Live show"
+    status, mementos = request(f"/api/admin/journeys/{ids.journey}/mementos")
+    expect(
+        status == 200 and len(mementos) == 1 and mementos[0].get("state") == "published",
+        f"admin memento mismatch: status={status} body={mementos!r}",
+    )
+    status, public = request(f"/api/v1/journeys/{ids.journey}/mementos")
+    expect(
+        status == 200 and len(public) == 1 and len(public[0].get("photos", [])) == 1,
+        f"public memento mismatch: status={status} body={public!r}",
+    )
+    expect(public[0].get("title") == "Live show", f"public title mismatch: {public!r}")
     print("full journey workflow passed")
 
 
+def find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def create_postgres_database(admin_dsn: str, database_name: str) -> str:
+    import psycopg
+    from psycopg import sql
+    from psycopg.conninfo import make_conninfo
+
+    with psycopg.connect(admin_dsn, autocommit=True) as connection:
+        connection.execute(sql.SQL("CREATE DATABASE {} ").format(sql.Identifier(database_name)))
+    return make_conninfo(admin_dsn, dbname=database_name)
+
+
+def drop_postgres_database(admin_dsn: str, database_name: str) -> None:
+    import psycopg
+    from psycopg import sql
+
+    with psycopg.connect(admin_dsn, autocommit=True) as connection:
+        connection.execute(
+            sql.SQL("DROP DATABASE IF EXISTS {} WITH (FORCE)").format(sql.Identifier(database_name))
+        )
+
+
 @contextmanager
-def disposable_server(port: int, driver: str, database_path: str, database_dsn: str):
+def disposable_postgres_database(admin_dsn: str):
+    database_name = f"felicia_workflow_{uuid4().hex[:16]}"
+    database_dsn = create_postgres_database(admin_dsn, database_name)
+    try:
+        yield database_dsn
+    finally:
+        drop_postgres_database(admin_dsn, database_name)
+
+
+@contextmanager
+def disposable_server(port: int, driver: str, database_path: str, database_dsn: str, postgres_admin_dsn: str):
     global BASE_URL
+    ids = workflow_ids()
     with tempfile.TemporaryDirectory(prefix="felicia-workflow-") as temp_dir:
         api_bin = os.path.join(temp_dir, "felicia-api")
         if driver == "sqlite":
             database_path = database_path or os.path.join(temp_dir, "felicia.db")
-        elif not database_dsn:
-            raise RuntimeError("--database-dsn or FELICIA_TEST_DATABASE_DSN is required for postgres")
-        subprocess.run(["go", "build", "-o", api_bin, "./server/cmd/api"], check=True)
-        environment = {
-            **os.environ,
-            "DATABASE_DRIVER": driver,
-            "CACHE_ADDR": "",
-            "PORT": str(port),
-        }
-        if driver == "sqlite":
-            environment["DATABASE_PATH"] = database_path
-        else:
-            environment["DATABASE_DSN"] = database_dsn
-        server = subprocess.Popen(
-            [api_bin],
-            env=environment,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.PIPE,
-            text=True,
+        elif not database_dsn and not postgres_admin_dsn:
+            raise RuntimeError(
+                "--database-dsn, FELICIA_TEST_DATABASE_DSN, or "
+                "--postgres-admin-dsn is required for postgres"
+            )
+        database_context = (
+            disposable_postgres_database(postgres_admin_dsn)
+            if driver == "postgres" and postgres_admin_dsn
+            else nullcontext(database_dsn)
         )
-        try:
-            BASE_URL = f"http://localhost:{port}"
-            for _ in range(30):
-                try:
-                    request(
-                        "/api/admin/journals",
-                        "POST",
-                        {"id": JOURNAL_ID},
-                    )
-                    break
-                except (OSError, urllib.error.URLError):
-                    time.sleep(1)
+        with database_context as selected_database_dsn:
+            subprocess.run(["go", "build", "-o", api_bin, "./server/cmd/api"], check=True)
+            if driver == "postgres" and postgres_admin_dsn:
+                subprocess.run(
+                    ["make", "migrate"],
+                    check=True,
+                    env={**os.environ, "DATABASE_DSN": selected_database_dsn},
+                )
+            selected_port = port or find_free_port()
+            environment = {
+                **os.environ,
+                "DATABASE_DRIVER": driver,
+                "CACHE_ADDR": "",
+                "PORT": str(selected_port),
+            }
+            if driver == "sqlite":
+                environment["DATABASE_PATH"] = database_path
             else:
-                stderr = server.stderr.read() if server.stderr else ""
-                raise RuntimeError(f"API did not become ready:\n{stderr}")
-            yield
-        finally:
-            server.terminate()
+                environment["DATABASE_DSN"] = selected_database_dsn
+            server = subprocess.Popen(
+                [api_bin],
+                env=environment,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
             try:
-                server.wait(timeout=5)
-            except subprocess.TimeoutExpired:
-                server.kill()
-                server.wait()
+                BASE_URL = f"http://127.0.0.1:{selected_port}"
+                for _ in range(30):
+                    if server.poll() is not None:
+                        stderr = server.stderr.read() if server.stderr else ""
+                        raise RuntimeError(f"API exited before readiness ({server.returncode}):\n{stderr}")
+                    try:
+                        status, body = request("/readyz")
+                        if status != 200:
+                            raise RuntimeError(f"API readiness failed ({status}): {body!r}")
+                        break
+                    except (OSError, urllib.error.URLError, ConnectionError):
+                        time.sleep(0.2)
+                else:
+                    stderr = server.stderr.read() if server.stderr else ""
+                    raise RuntimeError(f"API did not become ready:\n{stderr}")
+                yield ids
+            finally:
+                server.terminate()
+                try:
+                    server.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    server.kill()
+                    server.wait()
 
 
 if __name__ == "__main__":
@@ -183,10 +277,16 @@ if __name__ == "__main__":
         arguments = parse_args()
         if arguments.start_server:
             database_dsn = arguments.database_dsn or os.getenv("FELICIA_TEST_DATABASE_DSN", "")
-            with disposable_server(arguments.port, arguments.database_driver, arguments.database_path, database_dsn):
-                run_workflow()
+            with disposable_server(
+                arguments.port,
+                arguments.database_driver,
+                arguments.database_path,
+                database_dsn,
+                arguments.postgres_admin_dsn or os.getenv("FELICIA_TEST_POSTGRES_ADMIN_DSN", ""),
+            ) as ids:
+                run_workflow(ids)
         else:
-            run_workflow()
+            run_workflow(workflow_ids())
     except (AssertionError, OSError, RuntimeError, urllib.error.URLError) as exc:
-        print(f"workflow failed: {exc}", file=sys.stderr)
+        print(f"workflow failed: {exc!r}", file=sys.stderr)
         raise SystemExit(1) from exc

--- a/scripts/validate_local_authoring.py
+++ b/scripts/validate_local_authoring.py
@@ -1,0 +1,54 @@
+"""Validate local authoring JSON documents against the committed v1 schema."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from jsonschema import Draft202012Validator, FormatChecker
+
+
+ROOT = Path(__file__).resolve().parent.parent
+SCHEMA_PATH = ROOT / "schemas" / "local-authoring-v1.schema.json"
+DEFINITION_FOR_FILE = {
+    "journey.json": "journey",
+    "stops.json": "stops_file",
+    "mementos.json": "mementos_file",
+    "plan.json": "plan",
+}
+
+
+def validate_document(path: Path) -> None:
+    try:
+        definition = DEFINITION_FOR_FILE[path.name]
+    except KeyError as error:
+        raise ValueError(f"unsupported local authoring file: {path.name}") from error
+    document = json.loads(path.read_text(encoding="utf-8"))
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    selected = {"$schema": schema["$schema"], "$defs": schema["$defs"], "$ref": f"#/$defs/{definition}"}
+    validator = Draft202012Validator(selected, format_checker=FormatChecker())
+    errors = sorted(validator.iter_errors(document), key=lambda error: list(error.path))
+    if errors:
+        location = ".".join(str(part) for part in errors[0].path) or "document"
+        raise ValueError(f"{path.name}:{location}: {errors[0].message}")
+
+
+def validate_workspace(workspace: Path) -> None:
+    for filename in ("journey.json", "stops.json", "mementos.json"):
+        path = workspace / filename
+        if not path.is_file():
+            raise ValueError(f"{filename} is required in {workspace}")
+        validate_document(path)
+    plan = workspace / "plan.json"
+    if plan.is_file():
+        validate_document(plan)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("workspace", type=Path)
+    args = parser.parse_args()
+    validate_workspace(args.workspace.resolve())
+    print(f"local authoring valid: {args.workspace}")

--- a/scripts/validate_local_authoring.py
+++ b/scripts/validate_local_authoring.py
@@ -11,11 +11,45 @@ from jsonschema import Draft202012Validator, FormatChecker
 ROOT = Path(__file__).resolve().parent.parent
 SCHEMA_PATH = ROOT / "schemas" / "local-authoring-v1.schema.json"
 DEFINITION_FOR_FILE = {
+    "workspace.json": "workspace",
     "journey.json": "journey",
     "stops.json": "stops_file",
     "mementos.json": "mementos_file",
     "plan.json": "plan",
 }
+
+
+def validate_workspace_root(root: Path) -> None:
+    manifest_path = root / "workspace.json"
+    validate_document(manifest_path)
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    root_resolved = root.resolve()
+    seen_paths: set[Path] = set()
+    seen_ids: set[str] = set()
+    for entry in manifest["journeys"]:
+        journey_path = (root / entry["path"]).resolve()
+        try:
+            journey_path.relative_to(root_resolved)
+        except ValueError as error:
+            raise ValueError(f"workspace journey escapes root: {entry['path']}") from error
+        if journey_path in seen_paths:
+            raise ValueError(f"workspace journey path is duplicated: {entry['path']}")
+        if entry["id"] in seen_ids:
+            raise ValueError(f"workspace journey ID is duplicated: {entry['id']}")
+        seen_paths.add(journey_path)
+        seen_ids.add(entry["id"])
+    for entry in manifest["journeys"]:
+        journey_path = (root / entry["path"]).resolve()
+        if not journey_path.is_dir():
+            raise ValueError(f"workspace journey directory is missing: {entry['path']}")
+        validate_workspace(journey_path)
+        journey = json.loads((journey_path / "journey.json").read_text(encoding="utf-8"))
+        if journey["id"] != entry["id"]:
+            raise ValueError(f"workspace journey ID mismatch: {entry['path']}")
+        if journey["journal_id"] != manifest["journal_id"]:
+            raise ValueError(f"workspace journal ID mismatch: {entry['path']}")
+        if entry.get("slug") and journey.get("slug") != entry["slug"]:
+            raise ValueError(f"workspace journey slug mismatch: {entry['path']}")
 
 
 def validate_document(path: Path) -> None:

--- a/skills/felicia-cli/SKILL.md
+++ b/skills/felicia-cli/SKILL.md
@@ -1,0 +1,266 @@
+# Felicia CLI agent skill
+
+Use this skill when an agent must turn a user's offline travel exports into a
+reviewable Felicia journey and preview it locally.
+
+Felicia is contract-first. The canonical semantic contract is
+[`contracts/canonical/v1/schema.json`](../../contracts/canonical/v1/schema.json).
+The editable workspace files are an adapter of that contract, not the database
+model or the public API. Read the relevant contract before inventing fields.
+
+## Safety and authority
+
+The default workflow is offline and local. Do not upload GPX, photos, sidecars,
+or package contents. Do not call Immich, Dawarich, an HTTP server, or a remote
+agent tool unless the user explicitly provides that authority.
+
+Never:
+
+- publish, deploy, push, or send a message without explicit user approval;
+- overwrite authored fields during re-import;
+- mark a stop as kept or publish a memento merely because a model suggests it;
+- copy raw originals, private media, or unsanitized route data into a public
+  artifact;
+- invent attraction names, dates, coordinates, vendors, prices, or evidence;
+- treat a missing timestamp or coordinate as proof that an asset is unrelated.
+
+When evidence is insufficient, preserve the candidate as unresolved and explain
+what the user must decide.
+
+## Current command boundary
+
+Build the real CLI through the repository task runner:
+
+```sh
+make cli-build
+```
+
+The binary is `bin/felicia-cli`. The CLI currently operates locally and does
+not contact the Felicia server. The server's admin API is a separate transport
+used only when the user explicitly asks for server authoring.
+
+Available CLI commands:
+
+```text
+felicia-cli journey plan
+felicia-cli journey apply
+felicia-cli journey review
+felicia-cli package validate
+felicia-cli import
+felicia-cli static compile
+```
+
+Do not claim that commands such as `journey diff`, `publish`, agent suggestion
+acceptance, or multi-journey package import exist until the CLI help/source and
+contract are updated.
+
+## Required input
+
+Minimum planning input:
+
+- a valid GPX file;
+- a stable journey UUID;
+- a photo directory is optional but required to match local photos;
+- a JSONL sidecar is optional and should be used when photo metadata is missing.
+
+The sidecar is one JSON object per line. Use stable local paths and only factual
+metadata, for example:
+
+```json
+{"path":"photos/IMG_0001.jpg","at":"2026-04-01T09:10:00Z","coord":[135.5016,34.6687],"source_ref":"local:photo:IMG_0001"}
+```
+
+Do not put prose guesses in the sidecar. Keep the original files unchanged.
+
+## Happy path: plan and inspect
+
+1. Build the CLI.
+2. Run a plan without mutation.
+3. Save the plan as evidence.
+4. Inspect stops, mementos, issues, and source fingerprints.
+
+```sh
+make cli-build
+./bin/felicia-cli journey plan \
+  --journey 00000000-0000-0000-0000-000000000001 \
+  --gpx /path/to/route.gpx \
+  --photos /path/to/photos \
+  --sidecar /path/to/photos.jsonl \
+  --format json > plan.json
+```
+
+The JSON plan is source-derived evidence. It is not an authoring decision.
+Repeated planning with unchanged inputs should be deterministic. Record:
+
+- command and input paths;
+- plan schema/version;
+- source fingerprint;
+- route/visit/stop/memento counts;
+- warnings and errors;
+- unmatched media count.
+
+For streaming inspection, use JSONL:
+
+```sh
+./bin/felicia-cli journey plan \
+  --journey 00000000-0000-0000-0000-000000000001 \
+  --gpx /path/to/route.gpx \
+  --format jsonl > plan.jsonl
+```
+
+JSONL records are currently `{"type":"stop", ...}` followed by one summary
+record. Treat the summary as authoritative for counts and the stop records as
+review candidates.
+
+## Authoring workspace
+
+The UV orchestration creates an editable workspace from a plan:
+
+```sh
+uv run python scripts/local_journey.py preprocess \
+  --journey 00000000-0000-0000-0000-000000000001 \
+  --gpx /path/to/route.gpx \
+  --photos /path/to/photos \
+  --sidecar /path/to/photos.jsonl \
+  --workspace .felicia/local-journey
+```
+
+The workspace contains:
+
+- `plan.json`: immutable-ish source evidence; regenerate rather than hand-edit;
+- `journey.json`: authored journey metadata;
+- `stops.json`: explicit stop selection and labels;
+- `mementos.json`: authored memento order, kind, content, and media selection;
+- `route.gpx`: private source route;
+- optional `workspace.json`: root index when one directory contains multiple
+  journey workspaces.
+
+Authoring rules:
+
+- select a stop only when its evidence supports a meaningful stay or place;
+- rename labels only when the user or reliable source evidence supports it;
+- one stop may contain multiple mementos;
+- add a memento manually when the attraction is not inferable from GPS;
+- preserve `candidate_key` joins;
+- keep memento IDs stable when reordering; update `seq` only;
+- leave uncertain fields empty or in a review note rather than hallucinating.
+
+Validate before packaging:
+
+```sh
+uv run python scripts/validate_local_authoring.py .felicia/local-journey
+```
+
+## Package and preview
+
+Package one reviewed journey:
+
+```sh
+uv run python scripts/local_journey.py package \
+  --workspace .felicia/local-journey
+```
+
+Validate the actual transport archive:
+
+```sh
+./bin/felicia-cli package validate .felicia/local-journey/journey.zip
+```
+
+The current public package accepts only public local JPEG, PNG, and WebP image
+attachments. Video, audio, documents, links, embeds, private media, external
+URLs, and unsupported files must remain outside publication and should produce
+an explicit error or unresolved report.
+
+Run the complete local preview:
+
+```sh
+uv run python scripts/local_journey.py preview \
+  --workspace .felicia/local-journey
+```
+
+This imports into workspace-local SQLite and compiles a static site. It does not
+contact a server or publish anywhere. Inspect `site/` and verify that:
+
+- only published mementos appear;
+- route geometry is present;
+- media paths resolve;
+- private/unselected material is absent;
+- repeated runs do not duplicate records.
+
+The repository demo builds multiple journey packages with:
+
+```sh
+BASE_PATH=/ nix develop --command uv run python scripts/build_preview_package.py
+```
+
+## Applying a plan and reviewing stops
+
+The CLI can apply a plan to SQLite:
+
+```sh
+./bin/felicia-cli journey apply \
+  --db .felicia/felicia.sqlite plan.json
+```
+
+Review a persisted stop explicitly:
+
+```sh
+./bin/felicia-cli journey review \
+  --db .felicia/felicia.sqlite \
+  --candidate <candidate-uuid> \
+  --state kept \
+  --label "Dotonbori" \
+  --expected-revision 1
+```
+
+Valid states are `proposed`, `kept`, `ignored`, and `merged`. A stale expected
+revision must be treated as a conflict; reload before retrying.
+
+## Server/API boundary
+
+When the user explicitly requests server authoring, use the documented admin
+routes in `server/api/server.go`. Current important routes include:
+
+- `GET /api/admin/journeys` and `POST /api/admin/journeys`;
+- `GET /api/admin/journeys/{id}/mementos`;
+- `GET/POST /api/admin/mementos/{id}` and `/api/admin/mementos`;
+- `GET /api/admin/journeys/{id}/stop-candidates`;
+- `POST /api/admin/stop-candidates/{id}/review`;
+- `POST /api/admin/photos`;
+- `GET /api/v1/journeys.json` and journey memento projections.
+
+The admin API is authoring state; the `/api/v1` API is public state. Do not
+expose admin endpoints through a public static deployment. Respect revision
+conflicts and preserve the same canonical ownership rules as the CLI.
+
+## Failure and evil paths
+
+Stop and report clearly for:
+
+- malformed XML, invalid latitude/longitude, missing track points, or huge GPX;
+- photos without timestamps or coordinates;
+- sidecar paths outside the photo directory;
+- duplicate IDs, missing stop keys, invalid kinds, or invalid timestamps;
+- private/unsupported media in a public package;
+- path traversal, checksum mismatch, or duplicate package members;
+- stale memento/stop revisions;
+- a plan that has warnings but no trustworthy stops.
+
+Do not “repair” an input silently. Keep the source and emit a deterministic
+diagnostic that lets the user correct or explicitly accept the result.
+
+## Agent handoff report
+
+Every agent run should finish with:
+
+1. inputs and command lines;
+2. files created or edited;
+3. selected/ignored stop decisions and their evidence;
+4. mementos created, changed, or left unresolved;
+5. media included and excluded with reasons;
+6. validation/package/preview results;
+7. remaining user decisions;
+8. whether any publish or server mutation was performed.
+
+If a contract field or command is missing, stop and identify the contract gap.
+Do not invent a new shape inside a user workspace as a substitute.

--- a/skills/felicia-cli/SKILL.md
+++ b/skills/felicia-cli/SKILL.md
@@ -67,7 +67,7 @@ The sidecar is one JSON object per line. Use stable local paths and only factual
 metadata, for example:
 
 ```json
-{"path":"photos/IMG_0001.jpg","at":"2026-04-01T09:10:00Z","coord":[135.5016,34.6687],"source_ref":"local:photo:IMG_0001"}
+{ "path": "photos/IMG_0001.jpg", "at": "2026-04-01T09:10:00Z", "coord": [135.5016, 34.6687], "source_ref": "local:photo:IMG_0001" }
 ```
 
 Do not put prose guesses in the sidecar. Keep the original files unchanged.

--- a/tests/test_contract_schema.py
+++ b/tests/test_contract_schema.py
@@ -1,0 +1,30 @@
+import json
+import unittest
+from pathlib import Path
+
+from jsonschema import Draft202012Validator, FormatChecker
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "contracts" / "canonical" / "v1" / "schema.json"
+EXAMPLE = ROOT / "contracts" / "canonical" / "v1" / "examples" / "memento.json"
+
+
+class CanonicalContractTest(unittest.TestCase):
+    def test_canonical_example_is_valid(self):
+        schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+        document = json.loads(EXAMPLE.read_text(encoding="utf-8"))
+        errors = list(Draft202012Validator(schema, format_checker=FormatChecker()).iter_errors(document))
+        self.assertEqual([], errors)
+
+    def test_canonical_media_requires_visibility_and_source(self):
+        schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+        document = json.loads(EXAMPLE.read_text(encoding="utf-8"))
+        del document["data"]["media"][0]["visibility"]
+        media_schema = {"$schema": schema["$schema"], "$defs": schema["$defs"], "$ref": "#/$defs/media"}
+        errors = list(Draft202012Validator(media_schema, format_checker=FormatChecker()).iter_errors(document["data"]["media"][0]))
+        self.assertTrue(any(error.validator == "required" for error in errors))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_local_journey.py
+++ b/tests/test_local_journey.py
@@ -6,12 +6,13 @@ from argparse import Namespace
 from pathlib import Path
 
 from scripts.local_journey import build_package
-from scripts.validate_local_authoring import validate_document, validate_workspace
+from scripts.validate_local_authoring import validate_document, validate_workspace, validate_workspace_root
 
 
 class LocalJourneyWorkflowTest(unittest.TestCase):
     def test_preview_workspaces_validate_as_independent_journeys(self):
         root = Path(__file__).resolve().parents[1] / "examples" / "preview" / "local-journey"
+        validate_workspace_root(root)
         workspaces = [root, root / "kansai-ramble"]
         for workspace in workspaces:
             validate_workspace(workspace)
@@ -114,6 +115,26 @@ class LocalJourneyWorkflowTest(unittest.TestCase):
             plan_path.write_text(json.dumps(document), encoding="utf-8")
             with self.assertRaisesRegex(ValueError, "routes.0.DistanceM"):
                 validate_document(plan_path)
+
+    def test_workspace_manifest_rejects_duplicate_journey_paths(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "workspace.json").write_text(
+                json.dumps(
+                    {
+                        "schema": "felicia.local.workspace.v1",
+                        "version": "1",
+                        "journal_id": "0190cbde-f300-7000-8000-000000000000",
+                        "journeys": [
+                            {"path": ".", "id": "0190cbde-f300-7000-8000-111111111111"},
+                            {"path": ".", "id": "0190cbde-f300-7000-8000-222222222222"},
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(ValueError, "path is duplicated"):
+                validate_workspace_root(root)
 
     def test_package_keeps_only_selected_stops_and_copies_media(self):
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/test_local_journey.py
+++ b/tests/test_local_journey.py
@@ -86,6 +86,18 @@ class LocalJourneyWorkflowTest(unittest.TestCase):
                 self.assertEqual(b"ticket", archive.read("media/ticket.jpg"))
                 self.assertIn(b"sha256:", archive.read("manifest.yaml"))
 
+    def test_package_rejects_private_and_unsupported_media(self):
+        with tempfile.TemporaryDirectory() as directory:
+            workspace = Path(directory)
+            (workspace / "journey.json").write_text(json.dumps({"id": "0190cbde-f300-7000-8000-111111111111", "journal_id": "0190cbde-f300-7000-8000-000000000000", "slug": "test", "title": "Test", "date_start": "2026-04-01", "date_end": "2026-04-01"}))
+            (workspace / "stops.json").write_text(json.dumps({"stops": [{"candidate_key": "stop", "selected": True}]}))
+            (workspace / "mementos.json").write_text(json.dumps({"mementos": [{"id": "0190cbde-f300-7000-8000-a00000000001", "stop_key": "stop", "seq": 1, "kind": "goods", "occurred_at": "2026-04-01T09:00:00Z", "media": [{"path": "secret.mp4", "kind": "video"}]}]}))
+            (workspace / "route.gpx").write_text("<gpx />")
+            (workspace / "secret.mp4").write_bytes(b"video")
+
+            with self.assertRaisesRegex(SystemExit, "unsupported public media kind"):
+                build_package(Namespace(workspace=workspace))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_local_journey.py
+++ b/tests/test_local_journey.py
@@ -6,7 +6,7 @@ from argparse import Namespace
 from pathlib import Path
 
 from scripts.local_journey import build_package
-from scripts.validate_local_authoring import validate_workspace
+from scripts.validate_local_authoring import validate_document, validate_workspace
 
 
 class LocalJourneyWorkflowTest(unittest.TestCase):
@@ -18,6 +18,102 @@ class LocalJourneyWorkflowTest(unittest.TestCase):
             self.assertTrue((workspace / "journey.json").is_file())
             self.assertTrue((workspace / "stops.json").is_file())
             self.assertTrue((workspace / "mementos.json").is_file())
+
+    def test_plan_schema_types_all_evidence_arrays(self):
+        with tempfile.TemporaryDirectory() as directory:
+            plan_path = Path(directory) / "plan.json"
+            plan_path.write_text(
+                json.dumps(
+                    {
+                        "journey_id": "0190cbde-f300-7000-8000-111111111111",
+                        "schema": "felicia.intake.plan",
+                        "version": "1",
+                        "routes": [
+                            {
+                                "Line": [[135.5, 34.7], [135.6, 34.8]],
+                                "Points": [{"Coord": [135.5, 34.7], "At": "2026-04-01T09:00:00Z"}],
+                                "From": "2026-04-01T09:00:00Z",
+                                "To": "2026-04-01T10:00:00Z",
+                                "DistanceM": 100,
+                                "Mode": "walking",
+                                "SourceRef": "gpx:segment-1",
+                                "Provenance": {
+                                    "source": {"system": "gpx", "external_id": "segment-1"},
+                                    "observed_at": "2026-04-01T09:00:00Z",
+                                    "confidence": 1,
+                                },
+                            }
+                        ],
+                        "visits": [
+                            {
+                                "Coord": [135.5, 34.7],
+                                "Label": "Osaka",
+                                "Arrive": "2026-04-01T09:00:00Z",
+                                "Depart": "2026-04-01T10:00:00Z",
+                                "Confidence": 0.9,
+                                "SourceRef": "dawarich:visit-1",
+                                "Provenance": {
+                                    "source": {"system": "dawarich", "external_id": "visit-1"},
+                                    "observed_at": "2026-04-01T09:00:00Z",
+                                    "confidence": 0.9,
+                                },
+                            }
+                        ],
+                        "stops": [
+                            {
+                                "ID": "0190cbde-f300-7000-8000-222222222222",
+                                "JourneyID": "0190cbde-f300-7000-8000-111111111111",
+                                "Identity": {"derivation_version": "gpx-stops-v1", "key": "visit-1"},
+                                "Label": "Osaka",
+                                "Coord": [135.5, 34.7],
+                                "Arrive": "2026-04-01T09:00:00Z",
+                                "Depart": "2026-04-01T10:00:00Z",
+                                "Confidence": 0.9,
+                                "Evidence": [
+                                    {
+                                        "kind": "visit",
+                                        "source": {"system": "dawarich", "external_id": "visit-1"},
+                                        "locator": "visit-1",
+                                    }
+                                ],
+                                "State": "proposed",
+                                "Revision": 0,
+                                "CreatedAt": "2026-04-01T09:00:00Z",
+                                "UpdatedAt": "2026-04-01T09:00:00Z",
+                            }
+                        ],
+                        "mementos": [
+                            {
+                                "source": {"system": "immich", "external_id": "asset-1"},
+                                "stop_key": "visit-1",
+                                "kind": "goods",
+                                "occurred_at": "2026-04-01T09:30:00Z",
+                                "occurred_tz": "Asia/Tokyo",
+                                "geom": [135.5, 34.7],
+                                "title": "Souvenir",
+                                "place": "Osaka",
+                                "kind_data": {},
+                                "media": [],
+                                "memory_links": [],
+                                "provenance": {
+                                    "source": {"system": "immich", "external_id": "asset-1"},
+                                    "observed_at": "2026-04-01T09:30:00Z",
+                                    "confidence": 0.8,
+                                },
+                            }
+                        ],
+                        "issues": [{"severity": "warning", "code": "review", "message": "check stop"}],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            validate_document(plan_path)
+            document = json.loads(plan_path.read_text(encoding="utf-8"))
+            document["routes"][0]["DistanceM"] = "100"
+            plan_path.write_text(json.dumps(document), encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "routes.0.DistanceM"):
+                validate_document(plan_path)
 
     def test_package_keeps_only_selected_stops_and_copies_media(self):
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/test_local_journey.py
+++ b/tests/test_local_journey.py
@@ -6,15 +6,26 @@ from argparse import Namespace
 from pathlib import Path
 
 from scripts.local_journey import build_package
+from scripts.validate_local_authoring import validate_workspace
 
 
 class LocalJourneyWorkflowTest(unittest.TestCase):
+    def test_preview_workspaces_validate_as_independent_journeys(self):
+        root = Path(__file__).resolve().parents[1] / "examples" / "preview" / "local-journey"
+        workspaces = [root, root / "kansai-ramble"]
+        for workspace in workspaces:
+            validate_workspace(workspace)
+            self.assertTrue((workspace / "journey.json").is_file())
+            self.assertTrue((workspace / "stops.json").is_file())
+            self.assertTrue((workspace / "mementos.json").is_file())
+
     def test_package_keeps_only_selected_stops_and_copies_media(self):
         with tempfile.TemporaryDirectory() as directory:
             workspace = Path(directory)
             (workspace / "journey.json").write_text(
                 json.dumps(
                     {
+                        "schema": "felicia.local.journey.v1",
                         "id": "0190cbde-f300-7000-8000-111111111111",
                         "journal_id": "0190cbde-f300-7000-8000-000000000000",
                         "slug": "osaka-five-days",
@@ -28,9 +39,10 @@ class LocalJourneyWorkflowTest(unittest.TestCase):
             (workspace / "stops.json").write_text(
                 json.dumps(
                     {
+                        "schema": "felicia.local.stops.v1",
                         "stops": [
-                            {"candidate_key": "osaka", "selected": True},
-                            {"candidate_key": "noise", "selected": False},
+                            {"candidate_key": "osaka", "selected": True, "label": "Osaka"},
+                            {"candidate_key": "noise", "selected": False, "label": "Noise"},
                         ]
                     }
                 )
@@ -38,6 +50,7 @@ class LocalJourneyWorkflowTest(unittest.TestCase):
             (workspace / "mementos.json").write_text(
                 json.dumps(
                     {
+                        "schema": "felicia.local.mementos.v1",
                         "mementos": [
                             {
                                 "id": "0190cbde-f300-7000-8000-a00000000001",
@@ -62,11 +75,12 @@ class LocalJourneyWorkflowTest(unittest.TestCase):
                                 "id": "0190cbde-f300-7000-8000-a00000000002",
                                 "stop_key": "noise",
                                 "seq": 2,
-                                "kind": "note",
+                                "kind": "goods",
                                 "occurred_at": "2026-04-01T10:00:00Z",
                                 "occurred_tz": "UTC",
                                 "title": "Noise",
                                 "state": "draft",
+                                "kind_data": {},
                                 "media": [],
                             },
                         ]
@@ -89,9 +103,9 @@ class LocalJourneyWorkflowTest(unittest.TestCase):
     def test_package_rejects_private_and_unsupported_media(self):
         with tempfile.TemporaryDirectory() as directory:
             workspace = Path(directory)
-            (workspace / "journey.json").write_text(json.dumps({"id": "0190cbde-f300-7000-8000-111111111111", "journal_id": "0190cbde-f300-7000-8000-000000000000", "slug": "test", "title": "Test", "date_start": "2026-04-01", "date_end": "2026-04-01"}))
-            (workspace / "stops.json").write_text(json.dumps({"stops": [{"candidate_key": "stop", "selected": True}]}))
-            (workspace / "mementos.json").write_text(json.dumps({"mementos": [{"id": "0190cbde-f300-7000-8000-a00000000001", "stop_key": "stop", "seq": 1, "kind": "goods", "occurred_at": "2026-04-01T09:00:00Z", "media": [{"path": "secret.mp4", "kind": "video"}]}]}))
+            (workspace / "journey.json").write_text(json.dumps({"schema": "felicia.local.journey.v1", "id": "0190cbde-f300-7000-8000-111111111111", "journal_id": "0190cbde-f300-7000-8000-000000000000", "slug": "test", "title": "Test", "date_start": "2026-04-01", "date_end": "2026-04-01"}))
+            (workspace / "stops.json").write_text(json.dumps({"schema": "felicia.local.stops.v1", "stops": [{"candidate_key": "stop", "selected": True, "label": "Stop"}]}))
+            (workspace / "mementos.json").write_text(json.dumps({"schema": "felicia.local.mementos.v1", "mementos": [{"id": "0190cbde-f300-7000-8000-a00000000001", "stop_key": "stop", "seq": 1, "kind": "goods", "occurred_at": "2026-04-01T09:00:00Z", "state": "draft", "title": "Video", "kind_data": {}, "media": [{"path": "secret.mp4", "kind": "video"}]}]}))
             (workspace / "route.gpx").write_text("<gpx />")
             (workspace / "secret.mp4").write_bytes(b"video")
 

--- a/tests/test_local_journey.py
+++ b/tests/test_local_journey.py
@@ -50,6 +50,11 @@ class LocalJourneyWorkflowTest(unittest.TestCase):
                                 "place": "Osaka",
                                 "geom": [135.5, 34.7],
                                 "state": "published",
+                                "vendor": "Dotonbori Kitchen",
+                                "essay": "A receipt from the first night.",
+                                "price_amount": 1200,
+                                "price_currency": "JPY",
+                                "authored_fields": ["title", "vendor", "essay", "price_amount", "price_currency"],
                                 "kind_data": {"vendor": "sample"},
                                 "media": [{"path": "ticket.jpg", "caption": "ticket"}],
                             },
@@ -76,6 +81,8 @@ class LocalJourneyWorkflowTest(unittest.TestCase):
             with zipfile.ZipFile(output) as archive:
                 mementos = json.loads(archive.read("mementos.yaml"))
                 self.assertEqual(["Dotonbori receipt"], [m["title"] for m in mementos])
+                self.assertEqual("A receipt from the first night.", mementos[0]["essay"])
+                self.assertEqual(["title", "vendor", "essay", "price_amount", "price_currency"], mementos[0]["authored_fields"])
                 self.assertEqual(b"ticket", archive.read("media/ticket.jpg"))
                 self.assertIn(b"sha256:", archive.read("manifest.yaml"))
 

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,15 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P7D"
 
 [[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
 name = "babel"
 version = "2.18.0"
 source = { registry = "https://pypi.org/simple" }
@@ -102,6 +111,7 @@ source = { virtual = "." }
 
 [package.dev-dependencies]
 dev = [
+    { name = "jsonschema" },
     { name = "psycopg", extra = ["binary"] },
     { name = "ruff" },
 ]
@@ -115,6 +125,7 @@ docs = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "jsonschema", specifier = ">=4.23.0,<5" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2.0" },
     { name = "ruff", specifier = ">=0.12,<0.13" },
 ]
@@ -155,6 +166,33 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
 ]
 
 [[package]]
@@ -441,6 +479,19 @@ wheels = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
 name = "regex"
 version = "2026.5.9"
 source = { registry = "https://pypi.org/simple" }
@@ -493,6 +544,72 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "2026.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/2a/9618a122aeb2a169a28b03889a2995fe297588964333d4a7d67bdf46e147/rpds_py-2026.6.3.tar.gz", hash = "sha256:1cebd1337c242e4ec2293e541f712b2da849b29f48f0c293684b71c0632625d4", size = 64051, upload-time = "2026-06-30T07:17:53.009Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/36/7fbe9dcdaf857fb3f63c2a2284b62492d95f5e8334e947e5fb6e7f68c9be/rpds_py-2026.6.3-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:931908d9fc855d8f74783377822be318edb6dcb19e47169dc038f9a1bf60b06e", size = 344510, upload-time = "2026-06-30T07:15:57.921Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/54/f785cc3d3f60839ca57a5af4927a9f347b07b2799c373fc20f7949f87c7e/rpds_py-2026.6.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d7469697dce35be237db177d42e2a2ee26e6dcc5fc052078a6fefabd288c6edd", size = 339495, upload-time = "2026-06-30T07:15:59.238Z" },
+    { url = "https://files.pythonhosted.org/packages/63/ef/d4cdaf309e6b095b43597103cf8c0b951d6cca2acce68c474f75ec12e0c7/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bcfbcf66006befb9fd2aeaa9e01feaf881b4dc330a02ba07d2322b1c11be7b5d", size = 369454, upload-time = "2026-06-30T07:16:01.021Z" },
+    { url = "https://files.pythonhosted.org/packages/96/4a/9559a68b7ee15db09d7981212e8c2e219d2a1d6d4faa0391d813c3496a36/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:847927daf4cffbd4e90e42bc890069897101edd015f956cb8721b3473372edda", size = 374583, upload-time = "2026-06-30T07:16:02.287Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/75/8964aa7d2c6e8ac43eba8eb6e6b0fdda1f46d39f2fc3e6aa9f2cb17f485d/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:aca6c1ef08a82bfe327cc156da694660f599923e2e6665b6d81c9c2d0ac9ffc8", size = 492919, upload-time = "2026-06-30T07:16:03.723Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/97/6908094ac804115e65aedfd90f1b5fee4eebebd3f6c4cfc5419939267565/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ae50181a047c871561212bb97f7932a2d45fb53e947bd9b57ebad85b529cbc53", size = 383725, upload-time = "2026-06-30T07:16:05.305Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/9c/0d1fdc2e7aba23e290d603bc494e97bd205bae262ce33c6b32a69768ed5e/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc319e5a1de4b6913aac94bf6a2f9e847371e0a140a43dd4991db1a09bc2d504", size = 367255, upload-time = "2026-06-30T07:16:07.086Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/fe/f0209ca4a9ed074bc8acb44dfd0e81c3122e94c9689f5645b7973a866719/rpds_py-2026.6.3-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:e4316bf32babbed84e691e352faf967ce2f0f024174a8643c37c94a1080374fc", size = 379060, upload-time = "2026-06-30T07:16:08.525Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/8d/f1cc54c616b9d8897de8738aac148d20afca93f68187475fe194d09a71b9/rpds_py-2026.6.3-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8c6e5a2f750cc71c3e3b11d71661f21d6f9bc6cebc6564b1466417a1ec03ec77", size = 395960, upload-time = "2026-06-30T07:16:09.989Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/04/aafff00f73aeca2945f734f1d483c64ab8f472d0864ab02377fd8e89c3b2/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4470ce197d4090875cf6affbf1f853338387428df97c4fb7b7106317b8214698", size = 545356, upload-time = "2026-06-30T07:16:11.816Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/cc/e229663b9e4ddac5a4acbe9085dd80a71af2a5d356b8b39d6bff233f24b0/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ea964164cc9afa72d4d9b23cc28dafae93693c0a53e0b42acbff15b22c3f9ddd", size = 612319, upload-time = "2026-06-30T07:16:13.586Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7a/8a0e6d3e6cd066af108b71b43122c3fe158dd9eb86acac626593a2582eb1/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:639c8929aa0afe81be836b04de888460d6bed38b9c54cfc18da8f6bfabf5af5d", size = 573508, upload-time = "2026-06-30T07:16:15.23Z" },
+    { url = "https://files.pythonhosted.org/packages/87/03/2a69ab618a789cf6cf85c86bb844c62d090e700ab1a2aa676b3741b6c516/rpds_py-2026.6.3-cp314-cp314-win32.whl", hash = "sha256:882076c00c0a608b131187055ddc5ae29f2e7eaf870d6168980420d58528a5c8", size = 202504, upload-time = "2026-06-30T07:16:16.893Z" },
+    { url = "https://files.pythonhosted.org/packages/85/62/a3892ba945f4e24c78f352e5de3c7620d8479f73f211406a97263d13c7d2/rpds_py-2026.6.3-cp314-cp314-win_amd64.whl", hash = "sha256:0be972be84cfcaf46c8c6edf690ca0f154ac17babf1f6a955a51579b34ad2dc5", size = 220380, upload-time = "2026-06-30T07:16:18.108Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e7/c2bd44dc831931815ad11ebb5f430b5a0a4d3caa9de837107876c30c3432/rpds_py-2026.6.3-cp314-cp314-win_arm64.whl", hash = "sha256:2a9c6f195058cb45335e8cc3802745c603d716eb96bc9625950c1aac71c0c703", size = 215976, upload-time = "2026-06-30T07:16:19.654Z" },
+    { url = "https://files.pythonhosted.org/packages/79/9c/fff7b74bce9a091ec9a012a03f9ff5f69364eaf9451060dfc4486da2ffdd/rpds_py-2026.6.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:f90938e92afda60266da758ee7d363447f7f0138c9559f9e1811629580582d90", size = 346840, upload-time = "2026-06-30T07:16:21.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/44/77bcb1168b33704908295533d27f10eb811e9e3e193e8993dc99572211d3/rpds_py-2026.6.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ec829541c45bca16e61c7ae50c20501f213605beb75d1aba91a6ee37fbbb56a4", size = 340282, upload-time = "2026-06-30T07:16:22.875Z" },
+    { url = "https://files.pythonhosted.org/packages/87/3c/7a9081c7c9e645b39efe19e4ffbeccd80add246327cd9b888aecffd72317/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afd70d95892096cdb26f15a00c45907b17817577aa8d1c76b2dcc2788391f9e9", size = 370403, upload-time = "2026-06-30T07:16:24.415Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/69/af47021eb7dad6ff3396cb001c08f0f3c4d06c20253f75be6421a59fe6b7/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:29dfa0533a5d4c94d4dfa1b694fcb56c9c63aad8330ffdd816fd225d0a7a162f", size = 376055, upload-time = "2026-06-30T07:16:26.111Z" },
+    { url = "https://files.pythonhosted.org/packages/81/fc/a3bcf517084396a6dd258c592567a3c011ba4557f2fde23dceaf26e74f2e/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:af05d726809bff6b141be124d4c7ce998f9c9c7f30edb1f46c07aa103d540b41", size = 494419, upload-time = "2026-06-30T07:16:27.596Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/eb/13d529d1788135425c7bf207f8463458ca5d92e43f3f701365b83e9dffc1/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9826217f048f620d9a712672818bf231442c1b35d96b227a07eabd11b4bb6945", size = 384848, upload-time = "2026-06-30T07:16:29.183Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/f4/b7ac49f30013aba8f7b9566b1dd07e81de95e708c1374b7bacc5b9bc5c9c/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:536bceea4fa4acf7e1c61da2b5786304367c816c8895be71b8f537c480b0ea1f", size = 371369, upload-time = "2026-06-30T07:16:30.912Z" },
+    { url = "https://files.pythonhosted.org/packages/31/86/6260bafa622f788b07ddec0e52d810305c8b9b0b8c27f58a2ab04bf62b4f/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:bc0011654b91cc4fb2ae701bec0a0ba1e552c0714247fa7af6c59e0ccfa3a4e1", size = 379673, upload-time = "2026-06-30T07:16:32.486Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c3/03f1ee79a047b48daeca157c89a18509cde22b6b951d642b9b0af1be660a/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:539d75de9e0d536c84ff18dfeb805398e58227001ce09231a26a08b9aed1ee0e", size = 397500, upload-time = "2026-06-30T07:16:34.471Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/95/8ed0cd8c377dca12aea498f119fe639fc474d1461545c39d2b5872eb1c0f/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:166cf54d9f44fc6ceb53c7860258dde44a81406646de79f8ed3234fca3b6e538", size = 545978, upload-time = "2026-06-30T07:16:36.45Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f2/0eb57f0eaa83f8fc152a7e03de968ab77e1f00732bebc892b190c6eebde7/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:d34c20167764fbcf927194d532dd7e0c56772f0a5f943fa5ef9e9afbba8fb9db", size = 613350, upload-time = "2026-06-30T07:16:38.213Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/de/e0674bdbc3ef7634989b3f854c3f34bc1f587d36e5bfdc5c378d57034619/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ea7bb13b7c9a29791f87a0387ba7d3ad3a6d783d827e4d3f27b40a0ff44495e2", size = 576486, upload-time = "2026-06-30T07:16:39.797Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/f6/21101359743cd136ada781e8210a85769578422ba460672eea0e29739200/rpds_py-2026.6.3-cp314-cp314t-win32.whl", hash = "sha256:6de4744d05bd1aa1be4ed7ea1189e3979196808008113bbbf899a460966b925e", size = 201068, upload-time = "2026-06-30T07:16:41.316Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/b2/9574d4d44f7760c2aa32d92a0a4f41698e33f5b204a0bf5c9758f52c79d5/rpds_py-2026.6.3-cp314-cp314t-win_amd64.whl", hash = "sha256:c7b9a2f8f4d8e90af72571d3d495deebdd7e3c75451f5b41719aee166e940fc2", size = 220600, upload-time = "2026-06-30T07:16:43.091Z" },
+    { url = "https://files.pythonhosted.org/packages/08/ae/f23a2697e6ee6340a578b0f136be6483657bef0c6f9497b752bb5c0964bb/rpds_py-2026.6.3-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:e059c5dde6452b44424bd1834557556c226b57781dee1227af23518459722b13", size = 344726, upload-time = "2026-06-30T07:16:44.5Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/63/e7b3a1a5358dd32c930a1062d8e15b67fd6e8922e81df9e91706d66ee5c8/rpds_py-2026.6.3-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2f7c26fbc5acd2522b95d4177fe4710ffd8e9b20529e703ffbf8db4d93903f05", size = 339587, upload-time = "2026-06-30T07:16:46.255Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/64/10a85681916ca55fffb91b0a211f84e34297c109243484dd6394660a8a7c/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a3086b538543802f84c843911242db20447de00d8752dd0efc936dbcf02218ba", size = 369585, upload-time = "2026-06-30T07:16:48.101Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c2/baf95c7c38823e12ba34407c5f5767a89e5cf2233895e56f608167ae9493/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8f2e5c5ee828d42cb11760761c0af6507927bec42d0ad5458f97c9203b054617", size = 375479, upload-time = "2026-06-30T07:16:49.93Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/94/0aad06c72d65101e11d33528d438cda99a39ce0da99466e156158f2541d3/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ed0c1e5d10cdc7135537988c74a0188da68e2f3c30813ba3744ab1e42e0480f9", size = 492418, upload-time = "2026-06-30T07:16:51.641Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/17/de3f5a479a1f056535d7489819639d8cd591ea6281d700390b43b1abd745/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c2642a7603ec0b16ed77da4555db3b4b472341904873788327c0b0d7b95f1bb", size = 384123, upload-time = "2026-06-30T07:16:53.622Z" },
+    { url = "https://files.pythonhosted.org/packages/46/7d/bf09bd1b145bb2671c03e1e6d1ab8651858d90d8c7dfeadd85a37a934fd8/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8e4320744c1ffdd95a603def63344bfab2d33edeab301c5007e7de9f9f5b3885", size = 367351, upload-time = "2026-06-30T07:16:55.241Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ea/1bb734f314b8be319149ddee80b18bd41372bdcfbdf88d28131c0cd37719/rpds_py-2026.6.3-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:a9f4645593036b81bbdb36b9c8e0ea0d1c3fee968c4d59db0344c14087ef143a", size = 378827, upload-time = "2026-06-30T07:16:56.841Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/93/d9611e5b25e26df9a3649813ed66193ace9347a7c7fc4ab7cf70e94851c0/rpds_py-2026.6.3-cp315-cp315-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e55d236be29255554da47abe5c577637db7c24a02b8b46f0ca9524c855801868", size = 395966, upload-time = "2026-06-30T07:16:58.557Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/cb/99d77e16e5534ae1d90629bbe419ba6ee170833a6a85e3aa1cc41726fbbc/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:24e9c5386e16669b674a69c156c8eeefcb578f3b3397b713b08e6d60f3c7b187", size = 545680, upload-time = "2026-06-30T07:17:00.164Z" },
+    { url = "https://files.pythonhosted.org/packages/59/15/11a29755f790cef7a2f755e8e14f4f0c33f39489e1893a632a2eee59672b/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:c60924535c75f1566b6eb75b5c31a48a43fef04fa2d0d201acbad8a9969c6107", size = 611853, upload-time = "2026-06-30T07:17:01.962Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/0c27547e21644da938fb530f7e1a8148dd24d02db07e7a5f2567a17ce710/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:38a2fea2787428f811719ceb9114cb78964a3138838320c29ac39526c79c16ba", size = 573715, upload-time = "2026-06-30T07:17:03.693Z" },
+    { url = "https://files.pythonhosted.org/packages/29/71/4d8fcf700931815594bce892255bbd973b94efaf0fc1932b0590df18d886/rpds_py-2026.6.3-cp315-cp315-win32.whl", hash = "sha256:d483fe17f01ad64b7bf7cc38fcefff1ca9fb83f8c2b2542b68f97ffe0611b369", size = 202864, upload-time = "2026-06-30T07:17:05.746Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/62/b577562de0edbb55b2be85ce5fd09c33e386b9b13eee09833af4240fd5c4/rpds_py-2026.6.3-cp315-cp315-win_amd64.whl", hash = "sha256:67e3a721ffc5d8d2210d3671872298c4a84e4b8035cfe42ffd7cde35d772b146", size = 220430, upload-time = "2026-06-30T07:17:07.471Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/d6d0b2509825141eef60669a5739eec88dbc6a48053d6c92993a5704defe/rpds_py-2026.6.3-cp315-cp315-win_arm64.whl", hash = "sha256:6e84adbcf4bf841aed8116a8264b9f50b4cb3e7bd89b516122e616ac56ca269e", size = 215877, upload-time = "2026-06-30T07:17:09.008Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/bf/f3ea278f0afd615c1d0f19cb69043a41526e2bb600c2b536eb192218eb27/rpds_py-2026.6.3-cp315-cp315t-macosx_10_12_x86_64.whl", hash = "sha256:ae6dd8f10bd17aad820876d24caec9efdafd80a318d16c0a48edb5e136902c6b", size = 346933, upload-time = "2026-06-30T07:17:10.762Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/29/9907bdf1c5346763cf10b7f6852aad86652168c259def904cbe0082c5864/rpds_py-2026.6.3-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:bdbd97738551fca3917c1bd7188bec1920bb520104f28e7e1007f9ceb17b7690", size = 340274, upload-time = "2026-06-30T07:17:12.266Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/2c/8e03767b5778ef25cebf74a7a91a2c3806f8eced4c92cb7406bbe060756d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b95977e7211527ab0ba576e286d023389fbeeb32a6b7b771665d333c60e5342", size = 370763, upload-time = "2026-06-30T07:17:14.107Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/e1/df2a7e1ba2efd796af26194250b8d42c821b46592311595162af9ef0528d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d15fde0e6fb0d88a60d221204873743e5d9f0b7d29165e62cd86d0413ad74ba6", size = 376467, upload-time = "2026-06-30T07:17:15.76Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/de/8a0814d1946af29cb068fb259aa8622f856df1d0bab58429448726b537f5/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a136d453475ac0fcbda502ef1e6504bd28d6d904700915d278deeab0d00fe140", size = 496689, upload-time = "2026-06-30T07:17:17.308Z" },
+    { url = "https://files.pythonhosted.org/packages/df/f3/f19e0c852ba13694f5a79f3b719331051573cb5693feacf8a88ffffc3a71/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f826877d462181e5eb1c26a0026b8d0cab05d99844ecb6d8bf3627a2ca0c0442", size = 385340, upload-time = "2026-06-30T07:17:18.928Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ae/7ec3a9d2d4351f99e37bcb06b6b6f954512646bfdbf9742e1de727865daf/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:79486287de1730dbaff3dbd124d0ca4d2ef7f9d29bf2544f1f93c09b5bcbbd12", size = 372179, upload-time = "2026-06-30T07:17:20.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ac/9cee911dff2aaa9a5a8354f6610bf2e6a616de9197c5fff4f54f82585f1e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_31_riscv64.whl", hash = "sha256:808345f53cb952433ca2816f1604ff3515608a81784954f38d4452acfe8e61d5", size = 379993, upload-time = "2026-06-30T07:17:22.212Z" },
+    { url = "https://files.pythonhosted.org/packages/83/6b/7c2a07ba88d1e9a936612f7a5d067467ed03d971d5a06f7d309dff044a7e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1967debc37f64f2c4dc90a7f563aec558b471966e12adcac4e1c4240496b6ebf", size = 398909, upload-time = "2026-06-30T07:17:23.66Z" },
+    { url = "https://files.pythonhosted.org/packages/97/0b/776ffcb66783637b0031f6d58d6fb55913c8b5abf00aeecd46bf933fb477/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:f0840b5b17057f7fd918b76183a4b5a0635f43e14eb2ce60dce1d4ee4707ea00", size = 546584, upload-time = "2026-06-30T07:17:25.264Z" },
+    { url = "https://files.pythonhosted.org/packages/55/33/ba3bc04d7092bd553c9b2b195624992d2cc4f3de1f380b7b93cbee67bd79/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:faa679d19a6696fd54259ad321251ad77a13e70e03dd834daa762a44fb6196ef", size = 614357, upload-time = "2026-06-30T07:17:26.888Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/71/14edf065f04630b1a8472f7653cad03f6c478bcf95ea0e6aed55451e33ea/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:23a439f31ccbeff1574e24889128821d1f7917470e830cf6544dced1c662262a", size = 576533, upload-time = "2026-06-30T07:17:28.546Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/76/65002b08596c389105720a8c0d22298b8dc25a4baf89b2ce431343c8b1de/rpds_py-2026.6.3-cp315-cp315t-win32.whl", hash = "sha256:913ca42ccad3f8cc6e292b587ae8ae49c8c823e5dce51a736252fc7c7cdfa577", size = 201204, upload-time = "2026-06-30T07:17:30.193Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/97/d855d6b3c322d1f27e26f5241c42016b56cf01377ea8ed348285f54652f0/rpds_py-2026.6.3-cp315-cp315t-win_amd64.whl", hash = "sha256:ae3d4fe8c0b9213624fdce7279d70e3b148b682ca20719ebd193a23ebfa47324", size = 220719, upload-time = "2026-06-30T07:17:31.788Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This PR establishes the contract-first foundation for Felicia and implements the offline workflow against it.

- defines `felicia.canonical.v1` JSON Schema for journeys, routes, visits, stop candidates, mementos, media, provenance, and suggestions
- adds versioning/projection rules for canonical, workspace, CLI, admin API, storage, and public/static layers
- adds versioned Go capability traits under `core/contracts`
- adds canonical contract examples and schema regression tests
- adds a detailed `skills/felicia-cli/SKILL.md` for safe agent-operated planning, authoring, packaging, import, review, and preview
- keeps the editable workspace format as an adapter rather than the canonical contract
- hardens workflow isolation, PostgreSQL manual-authoring parity, typed intake plans, and multi-journey workspace discovery
- refreshes stale documentation and review evidence

## Verification

- `make check`
- repeated SQLite HTTP workflow
- disposable PostgreSQL HTTP workflow with Podman/PostGIS
- real CLI-generated plan validation
- canonical contract schema tests
- two-journey preview package build

## Scope boundary

The admin HTTP schemas and full public API OpenAPI projection remain the next contract projection task; this PR makes their canonical source and mapping boundary explicit without inventing unimplemented endpoints.

No secrets or external service credentials are committed.