### PR TITLE
fix: make Pages preview dependency-complete

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,9 @@ name = "felicia-docs"
 version = "0.1.0"
 description = "MkDocs preview tooling for felicia docs."
 requires-python = ">=3.14"
+dependencies = [
+  "jsonschema>=4.23.0,<5",
+]
 
 [dependency-groups]
 docs = [
@@ -15,7 +18,6 @@ docs = [
 ]
 dev = [
   "psycopg[binary]>=3.2.0",
-  "jsonschema>=4.23.0,<5",
   "ruff>=0.12,<0.13",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -108,10 +108,12 @@ wheels = [
 name = "felicia-docs"
 version = "0.1.0"
 source = { virtual = "." }
+dependencies = [
+    { name = "jsonschema" },
+]
 
 [package.dev-dependencies]
 dev = [
-    { name = "jsonschema" },
     { name = "psycopg", extra = ["binary"] },
     { name = "ruff" },
 ]
@@ -122,10 +124,10 @@ docs = [
 ]
 
 [package.metadata]
+requires-dist = [{ name = "jsonschema", specifier = ">=4.23.0,<5" }]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "jsonschema", specifier = ">=4.23.0,<5" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2.0" },
     { name = "ruff", specifier = ">=0.12,<0.13" },
 ]


### PR DESCRIPTION
## Summary

- declare `jsonschema` as a project runtime dependency for the CLI-backed preview
- remove the duplicate dev-group declaration
- regenerate `uv.lock`

## Why

The post-merge GitHub Pages build runs `uv run python scripts/felicia.py preview` in a fresh environment. The preview imports the canonical schema validator, but `jsonschema` was only declared in the dev dependency group, so Pages failed with `ModuleNotFoundError: No module named 'jsonschema'`.

## Verification

- `BASE_PATH=/ nix develop --command uv run python scripts/felicia.py preview`
- `make validate`
