### PR TITLE
feat: Site identity — design pick, style, site.json (ADMIN-02 M2)

### DIFF
--- a/apps/web-admin/e2e/authoring.spec.ts
+++ b/apps/web-admin/e2e/authoring.spec.ts
@@ -40,6 +40,15 @@ const MEMENTO_TITLE = "Admin GUI E2E Memento"
 const ESSAY_SENTINEL = "Felicia admin GUI E2E authored essay -- sentinel 9f3c2b1a"
 const GOODS_NAME = "E2E Souvenir"
 
+// ADMIN-02 M2: site identity constants, kept identical to the constants of
+// the same name in scripts/e2e_admin_gui.py for the same reason as above —
+// that script's filesystem-side check on the compiled api/v1/site.json
+// looks for these exact values.
+const SITE_TITLE = "Admin GUI E2E Site"
+const SITE_DESIGN = "v4"
+const SITE_DESIGN_LABEL = "Atlas"
+const SITE_ACCENT = "#336699"
+
 test.describe.serial("admin GUI closed loop (ADMIN-01.8)", () => {
   let page: Page
   // The promoted candidate's label (e.g. "明治神宮"), captured once it's
@@ -143,6 +152,48 @@ test.describe.serial("admin GUI closed loop (ADMIN-01.8)", () => {
     expect(publicResponse.ok()).toBeTruthy()
     const publicMementos = (await publicResponse.json()) as Array<{ essay?: string; title?: string }>
     expect(publicMementos.some((memento) => memento.essay === ESSAY_SENTINEL && memento.title === MEMENTO_TITLE)).toBeTruthy()
+  })
+
+  // ADMIN-02 M2: the Site & Deploy page's new Site identity section (design
+  // picker, title, accent) — still on /#/site from the previous step.
+  test("sets and saves the site identity (design, title, accent)", async () => {
+    await expect(page.getByRole("heading", { name: "Site identity" })).toBeVisible()
+
+    const designCard = page.getByRole("button", { name: new RegExp(SITE_DESIGN_LABEL) })
+    await designCard.click()
+    await expect(designCard).toHaveClass(/selected/)
+
+    await page.getByPlaceholder("Site title").fill(SITE_TITLE)
+    await page.getByLabel("Accent color").fill(SITE_ACCENT)
+
+    await page.getByRole("button", { name: "Save site settings" }).click()
+    await expect(page.getByText("Saved.")).toBeVisible()
+  })
+
+  test("site identity survives a reload", async () => {
+    await page.reload()
+    await expect(page.getByRole("heading", { name: "Site identity" })).toBeVisible()
+
+    const designCard = page.getByRole("button", { name: new RegExp(SITE_DESIGN_LABEL) })
+    await expect(designCard).toHaveClass(/selected/)
+    await expect(page.getByPlaceholder("Site title")).toHaveValue(SITE_TITLE)
+    await expect(page.getByLabel("Accent color")).toHaveValue(SITE_ACCENT)
+  })
+
+  test("building reflects the saved site identity in the live public API", async () => {
+    await page.getByRole("button", { name: "Build site" }).click()
+    await expect(page.getByText("Build complete.")).toBeVisible({ timeout: 15_000 })
+
+    // Same live/static-parity contract the journeys/mementos checks above
+    // rely on: the compiled artifact (checked filesystem-side by
+    // scripts/e2e_admin_gui.py's assert_site_settings after this spec exits)
+    // must match what the live endpoint serves.
+    const siteResponse = await page.request.get(`${API_BASE}/api/v1/site`)
+    expect(siteResponse.ok()).toBeTruthy()
+    const site = (await siteResponse.json()) as { title?: string; design?: string; accent?: string }
+    expect(site.title).toBe(SITE_TITLE)
+    expect(site.design).toBe(SITE_DESIGN)
+    expect(site.accent).toBe(SITE_ACCENT)
   })
 
   // ADMIN-02 M1 02.1a: the lifecycle now steps backward too. This reuses the

--- a/apps/web-admin/src/api.ts
+++ b/apps/web-admin/src/api.ts
@@ -513,6 +513,31 @@ export async function updateSiteOutDir(outDir: string): Promise<{ out_dir: strin
   return putJSON<{ out_dir: string }>("/api/admin/site", { out_dir: outDir })
 }
 
+// Site identity (ADMIN-02 M2 02.2a/02.2c): title/description/design/locale/
+// theme/accent, projected to the public reader's /api/v1/site.json through
+// the shared publication boundary. This is a DIFFERENT resource from
+// AdminSiteInfo/getSiteInfo above — that pair is process-level build config
+// (out_dir/preview_port) at the unrelated /api/admin/site path; this one is
+// /api/admin/site-settings, the author-facing "what does the site look like"
+// config. GET always returns a full record (server-side defaults on an empty
+// DB); PUT accepts a partial patch and returns the full updated record.
+export interface AdminSiteSettings {
+  title: string
+  description: string
+  design: "v1" | "v2" | "v3" | "v4"
+  default_language: "ja" | "en" | "zh"
+  default_theme: "dark" | "light"
+  accent: string
+}
+
+export async function getSiteSettings(): Promise<AdminSiteSettings> {
+  return getJSON<AdminSiteSettings>("/api/admin/site-settings")
+}
+
+export async function updateSiteSettings(patch: Partial<AdminSiteSettings>): Promise<AdminSiteSettings> {
+  return putJSON<AdminSiteSettings>("/api/admin/site-settings", patch)
+}
+
 // Local directory picker (ADMIN-02 staged-rebuild GUI): lists the
 // subdirectories of `path` (server-side root when path is omitted/empty) so
 // the Site & Deploy page can navigate into one and select it as the new

--- a/apps/web-admin/src/views/SiteDeploy.svelte
+++ b/apps/web-admin/src/views/SiteDeploy.svelte
@@ -1,6 +1,17 @@
 <script lang="ts">
   import { onMount } from "svelte"
-  import { browseDirectories, compileSite, getSiteInfo, updateSiteOutDir, type AdminBrowseResult, type AdminSiteInfo, type CompileReport } from "../api"
+  import {
+    browseDirectories,
+    compileSite,
+    getSiteInfo,
+    getSiteSettings,
+    updateSiteOutDir,
+    updateSiteSettings,
+    type AdminBrowseResult,
+    type AdminSiteInfo,
+    type AdminSiteSettings,
+    type CompileReport,
+  } from "../api"
 
   let info = $state<AdminSiteInfo | null>(null)
   let loading = $state(true)
@@ -18,11 +29,69 @@
   }
   let build = $state<BuildState>({ status: "idle", message: "" })
 
+  async function loadInfo() {
+    info = await getSiteInfo()
+  }
+
+  // --- Site identity (ADMIN-02 M2 02.2c) -------------------------------------
+  // `settings` is the last-saved-from-server record; `draft` is the editable
+  // copy the form binds to. Kept separate so a page reload (or a re-fetch
+  // after Build) can't silently clobber in-progress edits — only saveSettings
+  // re-derives draft from a fresh server response.
+  const designChoices: { id: AdminSiteSettings["design"]; label: string }[] = [
+    { id: "v1", label: "Map" },
+    { id: "v2", label: "Collection" },
+    { id: "v3", label: "Journal" },
+    { id: "v4", label: "Atlas" },
+  ]
+
+  type SiteIdentityDraft = Omit<AdminSiteSettings, "accent"> & { accent: string }
+
+  // <input type="color"> requires a valid #rrggbb value at all times, but the
+  // server allows an unset ("") accent. Falling back to a neutral default
+  // here (and always sending whatever the swatch currently shows on save) is
+  // simpler than tracking "did the user touch this field" — the tradeoff is
+  // that saving once an accent has never been set will persist this default
+  // rather than leaving accent "".
+  const FALLBACK_ACCENT = "#ea580c"
+
+  function draftFromSettings(source: AdminSiteSettings): SiteIdentityDraft {
+    return { ...source, accent: source.accent || FALLBACK_ACCENT }
+  }
+
+  let settings = $state<AdminSiteSettings | null>(null)
+  let draft = $state<SiteIdentityDraft | null>(null)
+
+  type SaveStatus = "idle" | "pending" | "success" | "error"
+  interface SaveState {
+    status: SaveStatus
+    message: string
+  }
+  let save = $state<SaveState>({ status: "idle", message: "" })
+
+  async function loadSettings() {
+    settings = await getSiteSettings()
+    draft = draftFromSettings(settings)
+  }
+
+  async function saveSettings() {
+    if (!draft) return
+    save = { status: "pending", message: "" }
+    try {
+      const updated = await updateSiteSettings(draft)
+      settings = updated
+      draft = draftFromSettings(updated)
+      save = { status: "success", message: "Saved." }
+    } catch (cause) {
+      save = { status: "error", message: actionErrorMessage(cause) }
+    }
+  }
+
   async function load() {
     loading = true
     error = ""
     try {
-      info = await getSiteInfo()
+      await Promise.all([loadInfo(), loadSettings()])
     } catch (cause) {
       error = actionErrorMessage(cause)
     } finally {
@@ -37,8 +106,9 @@
       build = { status: "success", message: "Build complete.", report }
       // Refresh site info so the preview link appears/updates once the
       // artifact is ready (artifact_ready flips from false to true on the
-      // very first build).
-      await load()
+      // very first build). Deliberately not the full load() — that would
+      // re-fetch settings and discard any unsaved site-identity edits.
+      await loadInfo()
     } catch (cause) {
       build = { status: "error", message: actionErrorMessage(cause) }
     }
@@ -197,6 +267,66 @@
         </div>
       {/if}
     </section>
+
+    {#if settings && draft}
+      {@const d = draft}
+      <section class="site-identity" aria-label="Site identity">
+        <h2>Site identity</h2>
+        <p class="trigger-note">Design, title, and style projected to the public site's <code>site.json</code>.</p>
+
+        <div class="design-cards">
+          {#each designChoices as choice (choice.id)}
+            <button type="button" class="design-card" class:selected={d.design === choice.id} onclick={() => (d.design = choice.id)}>
+              <span class="design-card-id">{choice.id}</span>
+              <span class="design-card-label">{choice.label}</span>
+            </button>
+          {/each}
+        </div>
+
+        <div class="identity-fields">
+          <label class="field field-wide">
+            <span class="field-label">Title</span>
+            <input type="text" bind:value={d.title} placeholder="Site title" />
+          </label>
+
+          <label class="field field-wide">
+            <span class="field-label">Description</span>
+            <textarea bind:value={d.description} placeholder="Site description" rows="3"></textarea>
+          </label>
+
+          <label class="field">
+            <span class="field-label">Default language</span>
+            <select bind:value={d.default_language}>
+              <option value="ja">Japanese</option>
+              <option value="en">English</option>
+              <option value="zh">Chinese</option>
+            </select>
+          </label>
+
+          <label class="field">
+            <span class="field-label">Default theme</span>
+            <select bind:value={d.default_theme}>
+              <option value="dark">Dark</option>
+              <option value="light">Light</option>
+            </select>
+          </label>
+
+          <label class="field field-accent">
+            <span class="field-label">Accent color</span>
+            <input type="color" bind:value={d.accent} />
+          </label>
+        </div>
+
+        <div class="save-row">
+          <button type="button" onclick={saveSettings} disabled={save.status === "pending"}>{save.status === "pending" ? "Saving…" : "Save site settings"}</button>
+          {#if save.status === "success"}
+            <span class="trigger-status trigger-status--success" role="status">{save.message}</span>
+          {:else if save.status === "error"}
+            <span class="trigger-status trigger-status--error" role="alert">{save.message}</span>
+          {/if}
+        </div>
+      </section>
+    {/if}
 
     <section class="build" aria-label="Build site">
       <div class="build-head">
@@ -364,6 +494,120 @@
     color: #6b5137;
     background: transparent;
     border: 1px solid #d8cdbb;
+  }
+  .site-identity {
+    margin-top: 32px;
+    padding: 20px 24px;
+    border: 1px solid #dfd4c1;
+    border-radius: 12px;
+    background: rgb(255 250 242 / 55%);
+  }
+  .site-identity h2 {
+    margin: 0;
+    font-family: Georgia, serif;
+    font-size: 22px;
+    font-weight: 500;
+  }
+  .design-cards {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+    gap: 10px;
+    margin-top: 16px;
+  }
+  .design-card {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    align-items: flex-start;
+    padding: 12px 14px;
+    border: 1px solid #d8cdbb;
+    border-radius: 9px;
+    background: #fffaf2;
+    text-align: left;
+  }
+  .design-card:hover,
+  .design-card:focus-visible {
+    border-color: #b98a5c;
+  }
+  .design-card.selected {
+    border-color: #9f522d;
+    background: rgb(159 82 45 / 8%);
+    box-shadow: inset 0 0 0 1px #9f522d;
+  }
+  .design-card-id {
+    font-family: Georgia, serif;
+    font-size: 15px;
+    font-weight: 600;
+    text-transform: uppercase;
+    color: #342a1e;
+  }
+  .design-card-label {
+    font-size: 12px;
+    color: #766956;
+  }
+  .identity-fields {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 16px;
+    margin-top: 20px;
+  }
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .field-wide {
+    grid-column: 1 / -1;
+  }
+  .field-label {
+    color: #766956;
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+  .field input[type="text"],
+  .field textarea,
+  .field select {
+    padding: 8px 10px;
+    border: 1px solid #d8cdbb;
+    border-radius: 7px;
+    background: #fffaf2;
+    color: #342a1e;
+    font-size: 13px;
+    font-family: inherit;
+  }
+  .field textarea {
+    resize: vertical;
+  }
+  .field-accent input[type="color"] {
+    width: 56px;
+    height: 36px;
+    padding: 2px;
+    border: 1px solid #d8cdbb;
+    border-radius: 7px;
+    background: #fffaf2;
+  }
+  .save-row {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    margin-top: 22px;
+  }
+  .save-row button {
+    border: 0;
+    border-radius: 7px;
+    padding: 8px 14px;
+    color: #fffaf2;
+    background: #9f522d;
+    font-size: 13px;
+    white-space: nowrap;
+  }
+  .save-row button:disabled {
+    opacity: 0.6;
+    cursor: default;
+  }
+  .save-row .trigger-status {
+    margin-top: 0;
   }
   .build {
     margin-top: 40px;

--- a/apps/web-public/src/App.svelte
+++ b/apps/web-public/src/App.svelte
@@ -1,81 +1,52 @@
 <script lang="ts">
-  import { designs, designFromHash } from "./designs"
+  import { designs } from "./designs"
   import type { Lang, Theme } from "./data"
-  import { message, resolveLocale } from "./i18n/catalog"
+  import { resolveLocale } from "./i18n/catalog"
+  import { loadSiteSettings, type ApiSiteSettings } from "./api/source"
 
-  // The demo is a deployable, immutable-data showcase that can switch between
-  // multiple front-of-house DESIGNS (the PM may supply several). Every design
-  // is a pure presentation over the same fixtures + {journey, memento} contract
-  // (felicia:decision:presentation-agnostic-contract); the registry in
-  // designs.ts is the single source of truth and this shell just resolves the
-  // active one from the URL hash and renders it, with a persistent switcher so
-  // any design is one click (and deep-linkable) away.
-  let hash = $state(location.hash)
-  const active = $derived(designFromHash(hash))
+  // The public reader is locked to a single design, chosen by the author from
+  // the admin GUI (FELICIA-ADMIN-02 M2) and served as part of `/api/v1/site`.
+  // The registry in designs.ts remains the source of truth for what designs
+  // exist; this shell just resolves the configured one and renders it.
+  let settings = $state<ApiSiteSettings | null>(null)
+
+  $effect(() => {
+    loadSiteSettings()
+      .then((s) => (settings = s))
+      .catch(() => {
+        // Absent/unreachable settings = current demo behavior: fall back to
+        // the default design (v1) and the existing lang/theme defaults below.
+      })
+  })
+
+  const active = $derived(designs.find((d) => d.id === settings?.design) ?? designs[0])
   const Active = $derived(active.component)
 
-  // lang/theme are shared across designs so switching keeps your reading state.
-  let lang: Lang = $state(resolveLocale(localStorage.getItem("felicia.locale") ?? navigator.language))
+  // lang/theme are shared across the mounted design so switching keeps your
+  // reading state. lang keeps its existing localStorage override precedence
+  // (captured before the persist effect below can write a fallback value
+  // into storage); theme has no persistence, so it simply switches its
+  // default source from a literal to the resolved site settings once they
+  // load.
+  const storedLocale = localStorage.getItem("felicia.locale")
+  let lang: Lang = $state(resolveLocale(storedLocale ?? navigator.language))
   let theme: Theme = $state("dark")
 
   $effect(() => localStorage.setItem("felicia.locale", lang))
 
-  function select(target: (typeof designs)[number]) {
-    location.hash = target.hash
-  }
+  $effect(() => {
+    if (!settings) return
+    if (!storedLocale) {
+      lang = settings.default_language
+    }
+    theme = settings.default_theme
+
+    if (/^#[0-9a-fA-F]{6}$/.test(settings.accent)) {
+      document.documentElement.style.setProperty("--accent", settings.accent)
+    }
+  })
 </script>
-
-<svelte:window on:hashchange={() => (hash = location.hash)} />
-
-<nav class="design-switcher" aria-label={message(lang, "system.design")}>
-  {#each designs as design (design.id)}
-    <button type="button" class="design-switcher__btn" class:active={design.id === active.id} aria-pressed={design.id === active.id} onclick={() => select(design)}>
-      {message(lang, design.labelKey)}
-    </button>
-  {/each}
-</nav>
 
 {#key active.id}
   <Active bind:lang bind:theme />
 {/key}
-
-<style>
-  .design-switcher {
-    position: fixed;
-    z-index: 1000;
-    bottom: 1rem;
-    left: 50%;
-    transform: translateX(-50%);
-    display: flex;
-    gap: 0.25rem;
-    padding: 0.25rem;
-    border-radius: 999px;
-    background: rgba(20, 18, 15, 0.72);
-    backdrop-filter: blur(8px);
-    box-shadow: 0 6px 24px rgba(0, 0, 0, 0.35);
-  }
-
-  .design-switcher__btn {
-    font: inherit;
-    font-size: 0.8rem;
-    line-height: 1;
-    padding: 0.5rem 0.9rem;
-    border: none;
-    border-radius: 999px;
-    background: transparent;
-    color: rgba(255, 255, 255, 0.72);
-    cursor: pointer;
-    transition:
-      background 0.15s ease,
-      color 0.15s ease;
-  }
-
-  .design-switcher__btn:hover {
-    color: #fff;
-  }
-
-  .design-switcher__btn.active {
-    background: #b45f26;
-    color: #fff;
-  }
-</style>

--- a/apps/web-public/src/api/source.ts
+++ b/apps/web-public/src/api/source.ts
@@ -8,6 +8,25 @@ function endpoint(path: string): string {
   return `${baseURL.replace(/\/$/, "")}${path}.json`
 }
 
+export interface ApiSiteSettings {
+  title: string
+  description: string
+  design: "v1" | "v2" | "v3" | "v4"
+  default_language: "ja" | "en" | "zh"
+  default_theme: "dark" | "light"
+  accent: string
+}
+
+export async function loadSiteSettings(): Promise<ApiSiteSettings> {
+  const url = endpoint("/api/v1/site")
+  const res = await fetch(url)
+  if (!res.ok) {
+    throw new Error(`Failed to load site settings: ${res.statusText}`)
+  }
+
+  return (await res.json()) as ApiSiteSettings
+}
+
 export async function loadJourney(id: string): Promise<Journey> {
   const journeyUrl = endpoint(`/api/v1/journeys/${id}`)
   const mementosUrl = endpoint(`/api/v1/journeys/${id}/mementos`)

--- a/apps/web-public/src/index.css
+++ b/apps/web-public/src/index.css
@@ -67,7 +67,7 @@ button {
   --card: rgba(255, 255, 255, 0.04);
   --chip-bg: #18181b;
   --chip-border: #52525b;
-  --accent-ink: #fdba74;
+  --accent-ink: var(--accent, #fdba74);
   --ctrl-bg: rgba(15, 23, 42, 0.82);
   --ctrl-invert: 1;
 }
@@ -83,7 +83,7 @@ button {
   --card: rgba(0, 0, 0, 0.03);
   --chip-bg: #ffffff;
   --chip-border: #d6d3d1;
-  --accent-ink: #ea580c;
+  --accent-ink: var(--accent, #ea580c);
   --ctrl-bg: rgba(255, 255, 255, 0.92);
   --ctrl-invert: 0;
 }

--- a/apps/web-public/src/v3/V3App.svelte
+++ b/apps/web-public/src/v3/V3App.svelte
@@ -392,7 +392,7 @@
 
       <header class="pointer-events-none absolute left-6 top-6 z-10 flex items-start gap-3">
         <div class="pointer-events-auto rounded-lg bg-paper-1/95 px-4 py-3 shadow-lg backdrop-blur">
-          <p class="m-0 font-mono text-[0.7rem] tracking-[0.3em] text-terracotta">F E L I C I A</p>
+          <p class="m-0 font-mono text-[0.7rem] tracking-[0.3em] text-accent">F E L I C I A</p>
           <h1 class="m-0 mt-1 font-mincho text-2xl font-bold text-ink">
             {t(selectedJourney.title)}
           </h1>
@@ -435,7 +435,7 @@
           <div class="flex items-center justify-between border-b border-dashed border-black/15 pb-3">
             <button
               type="button"
-              class="flex items-center gap-1 font-mono text-xs text-ink-soft disabled:opacity-30 disabled:cursor-not-allowed hover:text-terracotta transition cursor-pointer bg-transparent border-none p-0 focus:outline-none"
+              class="flex items-center gap-1 font-mono text-xs text-ink-soft disabled:opacity-30 disabled:cursor-not-allowed hover-accent transition cursor-pointer bg-transparent border-none p-0 focus:outline-none"
               disabled={selectedMementoIndex === 0}
               onclick={goToPrevMemento}
             >
@@ -446,7 +446,7 @@
             </span>
             <button
               type="button"
-              class="flex items-center gap-1 font-mono text-xs text-ink-soft disabled:opacity-30 disabled:cursor-not-allowed hover:text-terracotta transition cursor-pointer bg-transparent border-none p-0 focus:outline-none"
+              class="flex items-center gap-1 font-mono text-xs text-ink-soft disabled:opacity-30 disabled:cursor-not-allowed hover-accent transition cursor-pointer bg-transparent border-none p-0 focus:outline-none"
               disabled={selectedMementoIndex === selectedJourney.mementos.length - 1}
               onclick={goToNextMemento}
             >
@@ -455,7 +455,7 @@
           </div>
 
           <article class="rounded-lg border border-black/5 bg-paper-0 p-5 shadow-sm">
-            <p class="m-0 font-mono text-[0.68rem] uppercase tracking-[0.2em] text-terracotta">
+            <p class="m-0 font-mono text-[0.68rem] uppercase tracking-[0.2em] text-accent">
               {t(kindLabel[selectedMemento.kind])}
             </p>
             <h3 class="m-0 mt-1 font-mincho text-lg font-bold text-ink">
@@ -506,7 +506,7 @@
     --paper-1: #fdf9f0;
     --paper-2: #f3ecdb;
     --paper-3: #efe7d5;
-    --terracotta: #b45f26;
+    --terracotta: var(--accent, #b45f26);
     --hairline: rgba(90, 66, 30, 0.3);
     --hairline-strong: rgba(90, 66, 30, 0.4);
 
@@ -558,6 +558,18 @@
     background: #fffdf8;
     outline: 2px solid var(--terracotta);
     outline-offset: 2px;
+  }
+
+  /* Runtime-overridable equivalents of the static Tailwind `text-terracotta`
+     utility (bound to the build-time @theme token, not the `--terracotta`
+     custom property above) — used where accent-colored text needs to track
+     the author's chosen accent at runtime. */
+  .text-accent {
+    color: var(--terracotta);
+  }
+
+  .hover-accent:hover {
+    color: var(--terracotta);
   }
 
   .techo-frame {

--- a/apps/web-public/src/v4/V4App.svelte
+++ b/apps/web-public/src/v4/V4App.svelte
@@ -198,7 +198,7 @@
   .waypoints {
     --ink: #f5f5f5;
     --muted: #a8a8a8;
-    --orange: #d46728;
+    --orange: var(--accent, #d46728);
     min-height: 100%;
     height: 100%;
     overflow-y: auto;
@@ -211,7 +211,7 @@
   .waypoints.light {
     --ink: #2d2925;
     --muted: #706a65;
-    --orange: #b45f26;
+    --orange: var(--accent, #b45f26);
     background: #e7e0d5;
   }
 

--- a/core/domain/entity.go
+++ b/core/domain/entity.go
@@ -22,6 +22,29 @@ type Journal struct {
 	CreatedAt time.Time `json:"created_at"`
 }
 
+// SiteSettings is the journal-scoped public site identity/style
+// configuration the admin GUI authors and the publication boundary
+// projects to /api/v1/site.json (ADMIN-02 M2). It is identity-only this
+// milestone: deploy-target configuration gets its own table later.
+type SiteSettings struct {
+	JournalID       uuid.UUID `json:"journal_id"`
+	Title           string    `json:"title"`
+	Description     string    `json:"description"`
+	Design          string    `json:"design"`           // v1|v2|v3|v4
+	DefaultLanguage string    `json:"default_language"` // ja|en|zh
+	DefaultTheme    string    `json:"default_theme"`    // dark|light
+	Accent          string    `json:"accent"`           // "#rrggbb" or ""
+	CreatedAt       time.Time `json:"created_at"`
+	UpdatedAt       time.Time `json:"updated_at"`
+}
+
+// DefaultSiteSettings is the projection used when a journal has never saved
+// site settings — "absent settings" behaves like a v1 site in the default
+// language and theme, with no title/description/accent authored yet.
+func DefaultSiteSettings(journalID uuid.UUID) SiteSettings {
+	return SiteSettings{JournalID: journalID, Design: "v1", DefaultLanguage: "ja", DefaultTheme: "dark"}
+}
+
 // Journey represents a travel trip.
 type Journey struct {
 	ID             uuid.UUID           `json:"id"`
@@ -156,6 +179,14 @@ type Repository interface {
 	GetJournal(ctx context.Context, id uuid.UUID) (*Journal, error)
 	CreateJournal(ctx context.Context, journal *Journal) error
 	ResetMockJournal(ctx context.Context, id uuid.UUID) error
+	// GetSoleJournal returns the single journal row expected in this
+	// single-tenant deployment. Returns ErrNotFound when the database has
+	// not been bootstrapped yet.
+	GetSoleJournal(ctx context.Context) (*Journal, error)
+
+	// Site settings operations (ADMIN-02 M2)
+	GetSiteSettings(ctx context.Context, journalID uuid.UUID) (*SiteSettings, error)
+	UpsertSiteSettings(ctx context.Context, settings *SiteSettings) error
 
 	// Journey operations
 	GetJourney(ctx context.Context, id uuid.UUID) (*Journey, error)

--- a/core/ports/storage.go
+++ b/core/ports/storage.go
@@ -18,6 +18,17 @@ type JournalStore interface {
 	GetJournal(ctx context.Context, id uuid.UUID) (*domain.Journal, error)
 	CreateJournal(ctx context.Context, journal *domain.Journal) error
 	ResetMockJournal(ctx context.Context, id uuid.UUID) error
+	// GetSoleJournal returns the single journal row expected in this
+	// single-tenant deployment. Returns domain.ErrNotFound when the
+	// database has not been bootstrapped yet.
+	GetSoleJournal(ctx context.Context) (*domain.Journal, error)
+}
+
+// SiteSettingsStore persists the journal-scoped public site identity/style
+// settings (ADMIN-02 M2).
+type SiteSettingsStore interface {
+	GetSiteSettings(ctx context.Context, journalID uuid.UUID) (*domain.SiteSettings, error) // domain.ErrNotFound if absent
+	UpsertSiteSettings(ctx context.Context, settings *domain.SiteSettings) error
 }
 
 // JourneyStore is the narrow journey seam required by runtime workflows.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,9 +6,10 @@ Epics: [SQLite-backed GitHub Pages publication](roadmap/pages-v1-epic.md)
 all epic milestones M1–M4 landed, closed-loop browser E2E green; in
 review on the `feat/admin-gui-mvp` branch); and the active
 [GUI site configuration and deployment](roadmap/admin-gui-v2-epic.md)
-(M0 offline local deployment landed — Site & Deploy page with a Build
-action and a built-in preview server; design pick / style, GitHub Pages
-deploy with URL confirmation, and GUI resource uploads planned).
+(M0–M2 landed — Site & Deploy page with a Build action, a built-in preview
+server, authoring controls, and a Site identity section that picks the
+public design and style through a `site.json` projection; GitHub Pages
+deploy with URL confirmation and GUI resource uploads planned).
 The selected end-to-end journey and its per-stage status: [User journey](roadmap/user-journey.md).
 
 > Drafted 2026-07-16. This is a delivery roadmap, not a commitment to build every future seam in the current release.

--- a/docs/roadmap/admin-gui-v2-epic.md
+++ b/docs/roadmap/admin-gui-v2-epic.md
@@ -7,7 +7,7 @@ date: "2026-07-19"
 # Epic FELICIA-ADMIN-02 — GUI site configuration and deployment
 
 **Epic key:** `FELICIA-ADMIN-02`
-**Status:** M0 and M1 landed; M2–M4 planned. Delivery status is tracked in
+**Status:** M0–M2 landed; M3–M4 planned. Delivery status is tracked in
 [`../roadmap.md`](../roadmap.md); this document records scope and
 acceptance only.
 **Goal:** the author configures resources, picks the public design, builds,
@@ -95,7 +95,7 @@ Direct gaps found while operating the M0 build (2026-07-19 review):
 - **02.1e Topbar spacing.** Separate the Refresh button from the profile
   icon (mis-click risk flagged in review).
 
-### M2 — Site identity: design pick, style, `site.json` (planned)
+### M2 — Site identity: design pick, style, `site.json` (landed)
 
 - **02.2a `site.json` contract.** Journal-level site settings (site title
   and description, the single active design, default language, default

--- a/docs/roadmap/user-journey.md
+++ b/docs/roadmap/user-journey.md
@@ -101,8 +101,11 @@ projection:
   `--accent-ink`, v4's `--orange`, and v3's `--terracotta` plus its few
   Tailwind-utility-class spots) via a shared `--accent` CSS variable.
   Verified in the containerized toolchain: `make validate`, the extended
-  live/static parity check for `site.json`, and the existing
-  `make test-admin-e2e` closed-loop pass (10/10, no regression).
+  live/static parity check for `site.json`, and `make test-admin-e2e`
+  (13/13), which now drives the Site identity flow itself — picks a design,
+  saves title/accent, reloads to confirm persistence, builds, and checks
+  both the live `/api/v1/site` response and the compiled `site.json` on
+  disk.
 
 - **2026-07-22 (issue audit & milestone reconciliation)** — Conducted a full audit of open GitHub issues against implementation status. Verified completion and closed 21 issues across M0 (content & acceptance lock), M1 (canonical storage & public API projections), M2 (declarative templates & projections), M3 (admin authoring GUI MVP), M4 (ingestion connectors & intake planner), and epic FELICIA-PAGES-01 (#40–#50). Added 3 new enhancement issues on GitHub: #57 (automatic journey date bounds derivation), #58 (offline timezone resolution via `tzf`), and #59 (optional local AI agent ticket artwork generator for missing media in admin GUI). Updated roadmap and delivery trackers accordingly.
 

--- a/docs/roadmap/user-journey.md
+++ b/docs/roadmap/user-journey.md
@@ -87,6 +87,23 @@ projection:
 
 ## Status log
 
+- **2026-08-04 (epic ADMIN-02 M2)** — Site identity landed: a journal-scoped
+  `tb_site_settings` row (title, description, active design, default
+  language/theme, accent) is projected through the shared `publication`
+  boundary to `GET /api/v1/site(.json)`, with defaults applied when nothing
+  has been configured yet so the endpoint is never a 404. Authored from the
+  GUI via `GET/PUT /api/admin/site-settings` (Site & Deploy page gained a
+  Site identity section: 4 design cards, title/description, language/theme
+  selects, a native color picker for accent, one explicit Save action). The
+  public reader now boots into the configured design instead of the old
+  hash-based switcher (removed), and seeds its language/theme from the same
+  settings; the accent color is wired into all four designs (v1/v2 share
+  `--accent-ink`, v4's `--orange`, and v3's `--terracotta` plus its few
+  Tailwind-utility-class spots) via a shared `--accent` CSS variable.
+  Verified in the containerized toolchain: `make validate`, the extended
+  live/static parity check for `site.json`, and the existing
+  `make test-admin-e2e` closed-loop pass (10/10, no regression).
+
 - **2026-07-22 (issue audit & milestone reconciliation)** — Conducted a full audit of open GitHub issues against implementation status. Verified completion and closed 21 issues across M0 (content & acceptance lock), M1 (canonical storage & public API projections), M2 (declarative templates & projections), M3 (admin authoring GUI MVP), M4 (ingestion connectors & intake planner), and epic FELICIA-PAGES-01 (#40–#50). Added 3 new enhancement issues on GitHub: #57 (automatic journey date bounds derivation), #58 (offline timezone resolution via `tzf`), and #59 (optional local AI agent ticket artwork generator for missing media in admin GUI). Updated roadmap and delivery trackers accordingly.
 
 - **2026-07-19 (memento lifecycle + staged rebuild)** — Formalized the

--- a/migrations/00010_site_settings.sql
+++ b/migrations/00010_site_settings.sql
@@ -1,0 +1,19 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE TABLE tb_site_settings (
+    journal_id        UUID PRIMARY KEY REFERENCES tb_journal(id) ON DELETE CASCADE,
+    title             TEXT NOT NULL DEFAULT '',
+    description       TEXT NOT NULL DEFAULT '',
+    design            TEXT NOT NULL DEFAULT 'v1' CHECK (design IN ('v1','v2','v3','v4')),
+    default_language  TEXT NOT NULL DEFAULT 'ja' CHECK (default_language IN ('ja','en','zh')),
+    default_theme     TEXT NOT NULL DEFAULT 'dark' CHECK (default_theme IN ('dark','light')),
+    accent            TEXT NOT NULL DEFAULT '',
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TABLE IF EXISTS tb_site_settings;
+-- +goose StatementEnd

--- a/providers/contract/repository.go
+++ b/providers/contract/repository.go
@@ -147,6 +147,72 @@ func Run(t *testing.T, repo domain.Repository) {
 	if len(photos) != 1 || photos[0].ID != photo.ID {
 		t.Fatalf("unexpected photos: %#v", photos)
 	}
+
+	assertSiteSettings(t, repo, journal.ID)
+}
+
+// assertSiteSettings exercises the site settings round trip (ADMIN-02 M2):
+// not-found before any upsert, upsert-then-read equality, and upsert-again
+// replacing (not duplicating) the single row scoped to journalID.
+func assertSiteSettings(t *testing.T, repo domain.Repository, journalID uuid.UUID) {
+	t.Helper()
+	ctx := context.Background()
+
+	soleJournal, err := repo.GetSoleJournal(ctx)
+	if err != nil {
+		t.Fatalf("get sole journal: %v", err)
+	}
+	if soleJournal.ID != journalID {
+		t.Fatalf("get sole journal: got %s, want %s", soleJournal.ID, journalID)
+	}
+
+	if _, err := repo.GetSiteSettings(ctx, journalID); !errors.Is(err, domain.ErrNotFound) {
+		t.Fatalf("get site settings before upsert: got %v, want domain.ErrNotFound", err)
+	}
+
+	settings := &domain.SiteSettings{
+		JournalID:       journalID,
+		Title:           "Contract Journal",
+		Description:     "A contract test journal",
+		Design:          "v2",
+		DefaultLanguage: "en",
+		DefaultTheme:    "light",
+		Accent:          "#ea580c",
+	}
+	if err := repo.UpsertSiteSettings(ctx, settings); err != nil {
+		t.Fatalf("upsert site settings: %v", err)
+	}
+	fetched, err := repo.GetSiteSettings(ctx, journalID)
+	if err != nil {
+		t.Fatalf("get site settings: %v", err)
+	}
+	if fetched.Title != settings.Title || fetched.Description != settings.Description ||
+		fetched.Design != settings.Design || fetched.DefaultLanguage != settings.DefaultLanguage ||
+		fetched.DefaultTheme != settings.DefaultTheme || fetched.Accent != settings.Accent {
+		t.Fatalf("unexpected site settings after upsert: %#v", fetched)
+	}
+
+	replacement := &domain.SiteSettings{
+		JournalID:       journalID,
+		Title:           "Replaced Title",
+		Description:     "Replaced description",
+		Design:          "v3",
+		DefaultLanguage: "zh",
+		DefaultTheme:    "dark",
+		Accent:          "#123456",
+	}
+	if err := repo.UpsertSiteSettings(ctx, replacement); err != nil {
+		t.Fatalf("upsert site settings again: %v", err)
+	}
+	replaced, err := repo.GetSiteSettings(ctx, journalID)
+	if err != nil {
+		t.Fatalf("get site settings after replace: %v", err)
+	}
+	if replaced.Title != replacement.Title || replaced.Design != replacement.Design ||
+		replaced.DefaultLanguage != replacement.DefaultLanguage || replaced.DefaultTheme != replacement.DefaultTheme ||
+		replaced.Accent != replacement.Accent {
+		t.Fatalf("site settings did not replace, got %#v", replaced)
+	}
 }
 
 func assertJourney(t *testing.T, repo domain.Repository, expected *domain.Journey) {

--- a/providers/postgres/db/models.go
+++ b/providers/postgres/db/models.go
@@ -78,6 +78,18 @@ type TbMementoPhoto struct {
 	CreatedAt   pgtype.Timestamptz
 }
 
+type TbSiteSetting struct {
+	JournalID       uuid.UUID
+	Title           string
+	Description     string
+	Design          string
+	DefaultLanguage string
+	DefaultTheme    string
+	Accent          string
+	CreatedAt       pgtype.Timestamptz
+	UpdatedAt       pgtype.Timestamptz
+}
+
 type TbSourceObservation struct {
 	ID               uuid.UUID
 	RunID            uuid.UUID

--- a/providers/postgres/db/query.sql.go
+++ b/providers/postgres/db/query.sql.go
@@ -418,6 +418,40 @@ func (q *Queries) GetPhoto(ctx context.Context, id uuid.UUID) (TbMementoPhoto, e
 	return i, err
 }
 
+const getSiteSettings = `-- name: GetSiteSettings :one
+SELECT journal_id, title, description, design, default_language, default_theme, accent, created_at, updated_at
+FROM tb_site_settings
+WHERE journal_id = $1
+`
+
+func (q *Queries) GetSiteSettings(ctx context.Context, journalID uuid.UUID) (TbSiteSetting, error) {
+	row := q.db.QueryRow(ctx, getSiteSettings, journalID)
+	var i TbSiteSetting
+	err := row.Scan(
+		&i.JournalID,
+		&i.Title,
+		&i.Description,
+		&i.Design,
+		&i.DefaultLanguage,
+		&i.DefaultTheme,
+		&i.Accent,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const getSoleJournal = `-- name: GetSoleJournal :one
+SELECT id, created_at FROM tb_journal LIMIT 1
+`
+
+func (q *Queries) GetSoleJournal(ctx context.Context) (TbJournal, error) {
+	row := q.db.QueryRow(ctx, getSoleJournal)
+	var i TbJournal
+	err := row.Scan(&i.ID, &i.CreatedAt)
+	return i, err
+}
+
 const listJourneys = `-- name: ListJourneys :many
 SELECT id, journal_id, slug, source_ref, title, place, country, region, date_start, date_end, ST_AsBinary(gps_route) AS gps_route_wkb, authored_fields, created_at, updated_at
 FROM tb_journeys
@@ -996,6 +1030,44 @@ func (q *Queries) UpsertPhoto(ctx context.Context, arg UpsertPhotoParams) error 
 		arg.Seq,
 		arg.TakenAt,
 		arg.SourceRef,
+	)
+	return err
+}
+
+const upsertSiteSettings = `-- name: UpsertSiteSettings :exec
+INSERT INTO tb_site_settings (
+    journal_id, title, description, design, default_language, default_theme, accent, created_at, updated_at
+) VALUES (
+    $1, $2, $3, $4, $5, $6, $7, NOW(), NOW()
+) ON CONFLICT (journal_id) DO UPDATE SET
+    title = EXCLUDED.title,
+    description = EXCLUDED.description,
+    design = EXCLUDED.design,
+    default_language = EXCLUDED.default_language,
+    default_theme = EXCLUDED.default_theme,
+    accent = EXCLUDED.accent,
+    updated_at = NOW()
+`
+
+type UpsertSiteSettingsParams struct {
+	JournalID       uuid.UUID
+	Title           string
+	Description     string
+	Design          string
+	DefaultLanguage string
+	DefaultTheme    string
+	Accent          string
+}
+
+func (q *Queries) UpsertSiteSettings(ctx context.Context, arg UpsertSiteSettingsParams) error {
+	_, err := q.db.Exec(ctx, upsertSiteSettings,
+		arg.JournalID,
+		arg.Title,
+		arg.Description,
+		arg.Design,
+		arg.DefaultLanguage,
+		arg.DefaultTheme,
+		arg.Accent,
 	)
 	return err
 }

--- a/providers/postgres/queries/query.sql
+++ b/providers/postgres/queries/query.sql
@@ -46,6 +46,28 @@ INSERT INTO tb_journal (id, created_at) VALUES ($1, $2);
 -- name: ResetMockJournal :exec
 DELETE FROM tb_journal WHERE id = $1;
 
+-- name: GetSoleJournal :one
+SELECT id, created_at FROM tb_journal LIMIT 1;
+
+-- name: GetSiteSettings :one
+SELECT journal_id, title, description, design, default_language, default_theme, accent, created_at, updated_at
+FROM tb_site_settings
+WHERE journal_id = $1;
+
+-- name: UpsertSiteSettings :exec
+INSERT INTO tb_site_settings (
+    journal_id, title, description, design, default_language, default_theme, accent, created_at, updated_at
+) VALUES (
+    $1, $2, $3, $4, $5, $6, $7, NOW(), NOW()
+) ON CONFLICT (journal_id) DO UPDATE SET
+    title = EXCLUDED.title,
+    description = EXCLUDED.description,
+    design = EXCLUDED.design,
+    default_language = EXCLUDED.default_language,
+    default_theme = EXCLUDED.default_theme,
+    accent = EXCLUDED.accent,
+    updated_at = NOW();
+
 -- name: GetJourney :one
 SELECT id, journal_id, slug, source_ref, title, place, country, region, date_start, date_end, ST_AsBinary(gps_route) AS gps_route_wkb, authored_fields, created_at, updated_at
 FROM tb_journeys

--- a/providers/postgres/repository.go
+++ b/providers/postgres/repository.go
@@ -17,12 +17,14 @@ import (
 	"github.com/paulmach/orb/encoding/wkb"
 
 	"github.com/azusachino/felicia/core/domain"
+	"github.com/azusachino/felicia/core/ports"
 	"github.com/azusachino/felicia/providers/postgres/db"
 )
 
 // Compile-time check that pgRepository satisfies the domain contract.
 var _ domain.Repository = (*pgRepository)(nil)
 var _ domain.ObservationStore = (*pgRepository)(nil)
+var _ ports.SiteSettingsStore = (*pgRepository)(nil)
 
 type pgRepository struct {
 	q  *db.Queries
@@ -62,6 +64,60 @@ func (r *pgRepository) CreateJournal(ctx context.Context, journal *domain.Journa
 func (r *pgRepository) ResetMockJournal(ctx context.Context, id uuid.UUID) error {
 	if err := r.q.ResetMockJournal(ctx, id); err != nil {
 		return fmt.Errorf("reset mock journal %s: %w", id, err)
+	}
+	return nil
+}
+
+// GetSoleJournal returns the single journal row expected in this
+// single-tenant deployment.
+func (r *pgRepository) GetSoleJournal(ctx context.Context) (*domain.Journal, error) {
+	row, err := r.q.GetSoleJournal(ctx)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, domain.ErrNotFound
+		}
+		return nil, fmt.Errorf("get sole journal: %w", err)
+	}
+	return &domain.Journal{
+		ID:        row.ID,
+		CreatedAt: fromTimestamptz(row.CreatedAt),
+	}, nil
+}
+
+// Site settings operations (ADMIN-02 M2)
+
+func (r *pgRepository) GetSiteSettings(ctx context.Context, journalID uuid.UUID) (*domain.SiteSettings, error) {
+	row, err := r.q.GetSiteSettings(ctx, journalID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, domain.ErrNotFound
+		}
+		return nil, fmt.Errorf("get site settings %s: %w", journalID, err)
+	}
+	return &domain.SiteSettings{
+		JournalID:       row.JournalID,
+		Title:           row.Title,
+		Description:     row.Description,
+		Design:          row.Design,
+		DefaultLanguage: row.DefaultLanguage,
+		DefaultTheme:    row.DefaultTheme,
+		Accent:          row.Accent,
+		CreatedAt:       fromTimestamptz(row.CreatedAt),
+		UpdatedAt:       fromTimestamptz(row.UpdatedAt),
+	}, nil
+}
+
+func (r *pgRepository) UpsertSiteSettings(ctx context.Context, settings *domain.SiteSettings) error {
+	if err := r.q.UpsertSiteSettings(ctx, db.UpsertSiteSettingsParams{
+		JournalID:       settings.JournalID,
+		Title:           settings.Title,
+		Description:     settings.Description,
+		Design:          settings.Design,
+		DefaultLanguage: settings.DefaultLanguage,
+		DefaultTheme:    settings.DefaultTheme,
+		Accent:          settings.Accent,
+	}); err != nil {
+		return fmt.Errorf("upsert site settings %s: %w", settings.JournalID, err)
 	}
 	return nil
 }

--- a/providers/sqlite/schema.sql
+++ b/providers/sqlite/schema.sql
@@ -124,3 +124,15 @@ CREATE INDEX IF NOT EXISTS stop_candidates_journey_idx
   ON tb_stop_candidates(journey_id, arrive);
 CREATE INDEX IF NOT EXISTS stop_candidate_evidence_candidate_idx
   ON tb_stop_candidate_evidence(candidate_id);
+
+CREATE TABLE IF NOT EXISTS tb_site_settings (
+  journal_id TEXT PRIMARY KEY REFERENCES tb_journals(id) ON DELETE CASCADE,
+  title TEXT NOT NULL DEFAULT '',
+  description TEXT NOT NULL DEFAULT '',
+  design TEXT NOT NULL DEFAULT 'v1' CHECK (design IN ('v1', 'v2', 'v3', 'v4')),
+  default_language TEXT NOT NULL DEFAULT 'ja' CHECK (default_language IN ('ja', 'en', 'zh')),
+  default_theme TEXT NOT NULL DEFAULT 'dark' CHECK (default_theme IN ('dark', 'light')),
+  accent TEXT NOT NULL DEFAULT '',
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);

--- a/providers/sqlite/sitesettings.go
+++ b/providers/sqlite/sitesettings.go
@@ -1,0 +1,77 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/azusachino/felicia/core/domain"
+)
+
+const siteSettingsColumns = `journal_id, title, description, design, default_language, default_theme, accent, created_at, updated_at`
+
+// GetSiteSettings retrieves the identity/style settings saved for one
+// journal. Returns domain.ErrNotFound when no row has been saved yet —
+// callers fall back to domain.DefaultSiteSettings.
+func (r *Repository) GetSiteSettings(ctx context.Context, journalID uuid.UUID) (*domain.SiteSettings, error) {
+	row := r.db.QueryRowContext(ctx, "SELECT "+siteSettingsColumns+" FROM tb_site_settings WHERE journal_id = ?", idString(journalID))
+	settings, err := scanSiteSettings(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, domain.ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get site settings %s: %w", journalID, err)
+	}
+	return settings, nil
+}
+
+// UpsertSiteSettings replaces the single settings row for a journal.
+func (r *Repository) UpsertSiteSettings(ctx context.Context, settings *domain.SiteSettings) error {
+	if settings == nil || settings.JournalID == uuid.Nil {
+		return errors.New("site settings journal ID is required")
+	}
+	ts := now()
+	_, err := r.db.ExecContext(ctx, `INSERT INTO tb_site_settings(journal_id, title, description, design, default_language, default_theme, accent, created_at, updated_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(journal_id) DO UPDATE SET
+  title=excluded.title,
+  description=excluded.description,
+  design=excluded.design,
+  default_language=excluded.default_language,
+  default_theme=excluded.default_theme,
+  accent=excluded.accent,
+  updated_at=excluded.updated_at`,
+		idString(settings.JournalID), settings.Title, settings.Description, settings.Design,
+		settings.DefaultLanguage, settings.DefaultTheme, settings.Accent, ts, ts)
+	if err != nil {
+		return fmt.Errorf("upsert site settings %s: %w", settings.JournalID, err)
+	}
+	return nil
+}
+
+// scanSiteSettings reads one row via the shared scanner interface (store.go),
+// used identically by *sql.Row and *sql.Rows.
+func scanSiteSettings(row scanner) (*domain.SiteSettings, error) {
+	var rawJournalID, title, description, design, defaultLanguage, defaultTheme, accent, created, updated string
+	if err := row.Scan(&rawJournalID, &title, &description, &design, &defaultLanguage, &defaultTheme, &accent, &created, &updated); err != nil {
+		return nil, err
+	}
+	journalID, err := parseID(rawJournalID)
+	if err != nil {
+		return nil, err
+	}
+	return &domain.SiteSettings{
+		JournalID:       journalID,
+		Title:           title,
+		Description:     description,
+		Design:          design,
+		DefaultLanguage: defaultLanguage,
+		DefaultTheme:    defaultTheme,
+		Accent:          accent,
+		CreatedAt:       readTime(sql.NullString{String: created, Valid: true}),
+		UpdatedAt:       readTime(sql.NullString{String: updated, Valid: true}),
+	}, nil
+}

--- a/providers/sqlite/store.go
+++ b/providers/sqlite/store.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"embed"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -29,6 +30,7 @@ var _ ports.MediaStore = (*Repository)(nil)
 var _ ports.RouteStore = (*Repository)(nil)
 var _ ports.ObservationStore = (*Repository)(nil)
 var _ ports.StopCandidateStore = (*Repository)(nil)
+var _ ports.SiteSettingsStore = (*Repository)(nil)
 
 // Repository persists the canonical model in a local SQLite database.
 type Repository struct {
@@ -262,6 +264,26 @@ func (r *Repository) EnsureJournal(ctx context.Context, journal *domain.Journal)
 func (r *Repository) ResetMockJournal(ctx context.Context, id uuid.UUID) error {
 	_, err := r.db.ExecContext(ctx, "DELETE FROM tb_journals WHERE id = ?", idString(id))
 	return err
+}
+
+// GetSoleJournal retrieves the single journal row expected in this
+// single-tenant deployment. Returns domain.ErrNotFound when the database
+// has not been bootstrapped yet.
+func (r *Repository) GetSoleJournal(ctx context.Context) (*domain.Journal, error) {
+	var id, created string
+	err := r.db.QueryRowContext(ctx, "SELECT id, created_at FROM tb_journals LIMIT 1").Scan(&id, &created)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, domain.ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get sole journal: %w", err)
+	}
+	parsed, err := parseID(id)
+	if err != nil {
+		return nil, err
+	}
+	t, _ := time.Parse(time.RFC3339Nano, created)
+	return &domain.Journal{ID: parsed, CreatedAt: t}, nil
 }
 
 // GetJourney retrieves a journey by ID.

--- a/publication/compiler.go
+++ b/publication/compiler.go
@@ -3,10 +3,13 @@ package publication
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/google/uuid"
 	"github.com/paulmach/orb"
+
+	"github.com/azusachino/felicia/core/domain"
 )
 
 // StaticJourney is the public journey detail projection.
@@ -63,6 +66,49 @@ type GeoJSONGeometry struct {
 	Coordinates any    `json:"coordinates"`
 }
 
+// StaticSiteSettings is the public site identity/style projection served
+// identically at /api/v1/site.json (static) and /api/v1/site (live).
+type StaticSiteSettings struct {
+	Title           string `json:"title"`
+	Description     string `json:"description"`
+	Design          string `json:"design"`
+	DefaultLanguage string `json:"default_language"`
+	DefaultTheme    string `json:"default_theme"`
+	Accent          string `json:"accent"`
+}
+
+// NewStaticSiteSettings projects domain site settings into the public shape.
+func NewStaticSiteSettings(settings domain.SiteSettings) StaticSiteSettings {
+	return StaticSiteSettings{
+		Title:           settings.Title,
+		Description:     settings.Description,
+		Design:          settings.Design,
+		DefaultLanguage: settings.DefaultLanguage,
+		DefaultTheme:    settings.DefaultTheme,
+		Accent:          settings.Accent,
+	}
+}
+
+// ResolveSiteSettings resolves the sole journal's site settings, falling
+// back to domain.DefaultSiteSettings when none have been saved yet. Both
+// StaticCompiler.Compile and the live handleGetPublicSite call this one
+// function so the two surfaces can never diverge on how "absent settings"
+// is interpreted.
+func ResolveSiteSettings(ctx context.Context, read ReadModel) (domain.SiteSettings, error) {
+	journal, err := read.GetSoleJournal(ctx)
+	if err != nil {
+		return domain.SiteSettings{}, err
+	}
+	settings, err := read.GetSiteSettings(ctx, journal.ID)
+	if errors.Is(err, domain.ErrNotFound) {
+		return domain.DefaultSiteSettings(journal.ID), nil
+	}
+	if err != nil {
+		return domain.SiteSettings{}, err
+	}
+	return *settings, nil
+}
+
 // StaticCompiler writes the public JSON tree and referenced media files.
 type StaticCompiler struct{}
 
@@ -80,6 +126,19 @@ func (StaticCompiler) Compile(ctx context.Context, input Input, read ReadModel, 
 
 	index := make([]JourneyListItem, 0, len(journeys))
 	report := BuildReport{}
+
+	// Site identity/style is independent of journey/memento content and is
+	// always written, even on a fresh DB where it reflects
+	// domain.DefaultSiteSettings (ADMIN-02 M2 §4, "absent settings = current
+	// demo behavior").
+	settings, err := ResolveSiteSettings(ctx, read)
+	if err != nil {
+		return report, fmt.Errorf("resolve site settings: %w", err)
+	}
+	if err := output.WriteJSON("api/v1/site.json", NewStaticSiteSettings(settings)); err != nil {
+		return report, fmt.Errorf("write site settings: %w", err)
+	}
+
 	for _, journey := range journeys {
 		if len(allowed) > 0 && !allowed[journey.ID] {
 			continue

--- a/publication/projection.go
+++ b/publication/projection.go
@@ -77,6 +77,11 @@ type ReadModel interface {
 	ListJourneys(context.Context) ([]*domain.Journey, error)
 	ListMementosByJourney(context.Context, uuid.UUID) ([]*domain.Memento, error)
 	ListPhotosByMemento(context.Context, uuid.UUID) ([]*domain.MementoPhoto, error)
+	// GetSoleJournal and GetSiteSettings back ResolveSiteSettings (ADMIN-02
+	// M2), the shared resolver both the static compiler and the live
+	// handler call so site.json never diverges between the two surfaces.
+	GetSoleJournal(context.Context) (*domain.Journal, error)
+	GetSiteSettings(context.Context, uuid.UUID) (*domain.SiteSettings, error)
 }
 
 // MediaSource opens a source object by its canonical object key.

--- a/publication/public_test.go
+++ b/publication/public_test.go
@@ -76,9 +76,11 @@ func TestNewStaticMementoCarriesAuthoredFields(t *testing.T) {
 }
 
 type fakeReadModel struct {
-	journeys []*domain.Journey
-	mementos map[uuid.UUID][]*domain.Memento
-	photos   map[uuid.UUID][]*domain.MementoPhoto
+	journeys     []*domain.Journey
+	mementos     map[uuid.UUID][]*domain.Memento
+	photos       map[uuid.UUID][]*domain.MementoPhoto
+	journal      *domain.Journal
+	siteSettings map[uuid.UUID]*domain.SiteSettings
 }
 
 func (f *fakeReadModel) ListJourneys(context.Context) ([]*domain.Journey, error) {
@@ -91,6 +93,21 @@ func (f *fakeReadModel) ListMementosByJourney(_ context.Context, id uuid.UUID) (
 
 func (f *fakeReadModel) ListPhotosByMemento(_ context.Context, id uuid.UUID) ([]*domain.MementoPhoto, error) {
 	return f.photos[id], nil
+}
+
+func (f *fakeReadModel) GetSoleJournal(context.Context) (*domain.Journal, error) {
+	if f.journal == nil {
+		return nil, domain.ErrNotFound
+	}
+	return f.journal, nil
+}
+
+func (f *fakeReadModel) GetSiteSettings(_ context.Context, journalID uuid.UUID) (*domain.SiteSettings, error) {
+	settings, ok := f.siteSettings[journalID]
+	if !ok {
+		return nil, domain.ErrNotFound
+	}
+	return settings, nil
 }
 
 type fakeMediaSource struct{}
@@ -149,7 +166,8 @@ func TestCompileEmitsPublishedOnlyAndSkipsUnpublishedJourneys(t *testing.T) {
 			publishedJourney.ID: {publishedMemento, draftMemento},
 			draftJourney.ID:     {draftOnlyMemento},
 		},
-		photos: map[uuid.UUID][]*domain.MementoPhoto{},
+		photos:  map[uuid.UUID][]*domain.MementoPhoto{},
+		journal: &domain.Journal{ID: journalID},
 	}
 	writer := &memoryArtifactWriter{}
 
@@ -186,5 +204,35 @@ func TestCompileEmitsPublishedOnlyAndSkipsUnpublishedJourneys(t *testing.T) {
 	}
 	if !strings.Contains(string(mementosJSON), "published essay") {
 		t.Errorf("authored essay missing from the public artifact: %s", mementosJSON)
+	}
+}
+
+// TestCompileWritesSiteSettingsWithDefaultsOnFreshDB asserts api/v1/site.json
+// is always written, even on a fresh DB with a bootstrapped journal but no
+// saved site settings — reflecting domain.DefaultSiteSettings (ADMIN-02 M2 §4).
+func TestCompileWritesSiteSettingsWithDefaultsOnFreshDB(t *testing.T) {
+	journalID := uuid.New()
+	read := &fakeReadModel{journal: &domain.Journal{ID: journalID}}
+	writer := &memoryArtifactWriter{}
+
+	report, err := StaticCompiler{}.Compile(context.Background(), Input{}, read, fakeMediaSource{}, writer)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if report.Journeys != 0 {
+		t.Errorf("report.Journeys = %d, want 0 on a fresh DB", report.Journeys)
+	}
+
+	raw, ok := writer.json["api/v1/site.json"]
+	if !ok {
+		t.Fatal("api/v1/site.json was not written on a fresh DB")
+	}
+	var got StaticSiteSettings
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal site.json: %v", err)
+	}
+	want := NewStaticSiteSettings(domain.DefaultSiteSettings(journalID))
+	if got != want {
+		t.Errorf("site.json = %+v, want defaults %+v", got, want)
 	}
 }

--- a/scripts/e2e_admin_gui.py
+++ b/scripts/e2e_admin_gui.py
@@ -65,6 +65,14 @@ MEMENTO_TITLE = "Admin GUI E2E Memento"
 ESSAY_SENTINEL = "Felicia admin GUI E2E authored essay -- sentinel 9f3c2b1a"
 GOODS_NAME = "E2E Souvenir"
 
+# ADMIN-02 M2: site identity constants, kept identical to the constants of
+# the same name in apps/web-admin/e2e/authoring.spec.ts for the same reason
+# as the constants above -- this script's filesystem-side check on the
+# compiled api/v1/site.json looks for these exact values.
+SITE_TITLE = "Admin GUI E2E Site"
+SITE_DESIGN = "v4"
+SITE_ACCENT = "#336699"
+
 # A minimal two-point timestamped track. The intake planner only needs it to
 # satisfy the local-authoring package schema (route.gpx is required
 # alongside journey.json/stops.json/mementos.json) — the actual stop
@@ -275,6 +283,25 @@ def assert_compiled_artifact(out_dir: Path, journey_id: str) -> None:
     print("compiled artifact contains the authored essay -- filesystem check passed")
 
 
+def assert_site_settings(out_dir: Path) -> None:
+    """Re-reads the compiled api/v1/site.json directly off disk (ADMIN-02 M2):
+    the Playwright spec already asserts the live /api/v1/site endpoint after
+    saving and rebuilding, so this is the same live/static-parity
+    double-check assert_compiled_artifact does for the journey/memento data.
+    """
+    site_path = out_dir / "api" / "v1" / "site.json"
+    if not site_path.is_file():
+        raise AssertionError(f"compiled artifact is missing site.json: {site_path}")
+    site = json.loads(site_path.read_text(encoding="utf-8"))
+    if site.get("title") != SITE_TITLE:
+        raise AssertionError(f"compiled site.json title mismatch: {site!r}")
+    if site.get("design") != SITE_DESIGN:
+        raise AssertionError(f"compiled site.json design mismatch: {site!r}")
+    if site.get("accent") != SITE_ACCENT:
+        raise AssertionError(f"compiled site.json accent mismatch: {site!r}")
+    print("compiled artifact reflects the saved site identity -- filesystem check passed")
+
+
 def run_admin_gui_e2e() -> None:
     with tempfile.TemporaryDirectory(prefix="felicia-admin-gui-e2e-") as root_dir:
         root = Path(root_dir)
@@ -338,6 +365,7 @@ def run_admin_gui_e2e() -> None:
                 assert_preview_server(preview_port)
 
         assert_compiled_artifact(out_dir, journey_id)
+        assert_site_settings(out_dir)
 
     print("admin GUI E2E passed")
 

--- a/scripts/test_journey_workflow.py
+++ b/scripts/test_journey_workflow.py
@@ -352,11 +352,17 @@ def run_static_parity_check(context: ServerContext) -> None:
         expect_aliases_match("/api/v1/journeys", "/api/v1/journeys.json")
         expect_aliases_match(journey_path, journey_path + ".json")
         expect_aliases_match(mementos_path, mementos_path + ".json")
+        expect_aliases_match("/api/v1/site", "/api/v1/site.json")
 
         expect_json_parity(
             "journeys index",
             fetch_raw("/api/v1/journeys"),
             read_static_file(out_dir, "api/v1/journeys.json"),
+        )
+        expect_json_parity(
+            "site settings",
+            fetch_raw("/api/v1/site"),
+            read_static_file(out_dir, "api/v1/site.json"),
         )
         expect_json_parity(
             "journey detail",

--- a/server/api/publicsite.go
+++ b/server/api/publicsite.go
@@ -1,0 +1,37 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/azusachino/felicia/publication"
+)
+
+// handleGetPublicSite serves the public site identity/style projection
+// (title, description, design, default language/theme, accent). It shares
+// publication.ResolveSiteSettings with the static compiler so the live
+// endpoint and the compiled api/v1/site.json artifact never diverge on how
+// "absent settings" is interpreted (ADMIN-02 M2).
+func (s *Server) handleGetPublicSite(w http.ResponseWriter, r *http.Request) {
+	cacheKey := "felicia:public:site"
+	if cached, err := s.cache.Get(r.Context(), cacheKey); err == nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(cached))
+		return
+	}
+
+	settings, err := publication.ResolveSiteSettings(r.Context(), s.repo)
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	projection := publication.NewStaticSiteSettings(settings)
+
+	jsonData, err := json.Marshal(projection)
+	if err == nil {
+		_ = s.cache.Set(r.Context(), cacheKey, string(jsonData))
+	}
+
+	respondJSON(w, http.StatusOK, projection)
+}

--- a/server/api/publicsite_test.go
+++ b/server/api/publicsite_test.go
@@ -1,0 +1,68 @@
+package api_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/azusachino/felicia/server/api"
+)
+
+// handleGetPublicSite must reflect an admin PUT immediately: the admin write
+// invalidates the public cache, so the next live GET recomputes from the
+// repository rather than serving a stale cached projection.
+func TestHandleGetPublicSiteReflectsAdminPut(t *testing.T) {
+	handler := api.NewServer(newMockRepository(), nil, api.NewCacheManager("", testLogger), testLogger, nil, api.RouteConfig{}).Handler()
+
+	// Defaults before any admin write — never a 404.
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/site", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("get public site (defaults) = %d, want 200 (%s)", w.Code, w.Body)
+	}
+	// Capture the raw body before decodeSiteSettings drains w.Body (it reads
+	// via json.Decoder, which consumes the recorder's buffer).
+	firstBody := w.Body.String()
+	defaults := decodeSiteSettings(t, w)
+	if defaults.Design != "v1" || defaults.DefaultLanguage != "ja" || defaults.DefaultTheme != "dark" {
+		t.Fatalf("unexpected defaults: %+v", defaults)
+	}
+
+	// The .json alias shares the same handler and must match the same JSON
+	// content. Trim trailing whitespace since a cache-hit response (raw
+	// json.Marshal output, no caching in this test though) and a cache-miss
+	// response (respondJSON's encoder, which appends "\n") can differ only
+	// by that incidental trailing byte — see handleGetPublicJourneys for the
+	// same existing pattern.
+	w2 := httptest.NewRecorder()
+	handler.ServeHTTP(w2, httptest.NewRequest(http.MethodGet, "/api/v1/site.json", nil))
+	if w2.Code != http.StatusOK || strings.TrimRight(w2.Body.String(), "\n") != strings.TrimRight(firstBody, "\n") {
+		t.Fatalf("site.json alias = %d %q, want 200 matching /api/v1/site body %q", w2.Code, w2.Body.String(), firstBody)
+	}
+
+	body, _ := json.Marshal(map[string]any{
+		"title":  "Aaron's Waypoints",
+		"design": "v4",
+		"accent": "#123abc",
+	})
+	req := httptest.NewRequest(http.MethodPut, "/api/admin/site-settings", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("put site settings = %d, want 200 (%s)", w.Code, w.Body)
+	}
+
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/site", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("get public site (after put) = %d, want 200 (%s)", w.Code, w.Body)
+	}
+	got := decodeSiteSettings(t, w)
+	if got.Title != "Aaron's Waypoints" || got.Design != "v4" || got.Accent != "#123abc" {
+		t.Errorf("public site after put = %+v, want the saved values reflected", got)
+	}
+}

--- a/server/api/server.go
+++ b/server/api/server.go
@@ -206,6 +206,8 @@ func (s *Server) Handler() http.Handler {
 		r.Get("/journeys.json", s.handleGetPublicJourneys)
 		r.Get("/journeys/{id}.json", s.handleGetPublicJourneyDetails)
 		r.Get("/journeys/{id}/mementos.json", s.handleGetPublicMementos)
+		r.Get("/site", s.handleGetPublicSite)
+		r.Get("/site.json", s.handleGetPublicSite)
 	})
 
 	// Authoring Admin API (Valkey Invalidation on Write)
@@ -238,6 +240,8 @@ func (s *Server) Handler() http.Handler {
 		r.Post("/stop-candidates/{id}/promote", s.handlePromoteStopCandidate)
 		r.Get("/site", s.handleSiteInfo)
 		r.Put("/site", s.handlePutSite)
+		r.Get("/site-settings", s.handleGetSiteSettings)
+		r.Put("/site-settings", s.handlePutSiteSettings)
 		r.Get("/browse", s.handleBrowseDirectories)
 		r.Get("/build-status", s.handleBuildStatus)
 		r.Get("/journeys/{id}/build-status", s.handleJourneyBuildStatus)

--- a/server/api/server_test.go
+++ b/server/api/server_test.go
@@ -66,6 +66,11 @@ var (
 	_ ports.StopCandidateStore = (*mockRepository)(nil)
 )
 
+// mockJournalID is the fixed "sole journal" ID GetSoleJournal returns —
+// this single-tenant mock never tracks journal bootstrap state, mirroring
+// GetJournal's always-succeeds behavior below.
+var mockJournalID = uuid.MustParse("00000000-0000-0000-0000-000000000001")
+
 type mockRepository struct {
 	journeys       map[uuid.UUID]*domain.Journey
 	mementos       map[uuid.UUID]*domain.Memento
@@ -75,6 +80,7 @@ type mockRepository struct {
 	displayRoute   orb.MultiLineString
 	snappedPoint   *orb.Point
 	stopCandidates map[uuid.UUID]*domain.StopCandidate
+	siteSettings   map[uuid.UUID]*domain.SiteSettings
 }
 
 func newMockRepository() *mockRepository {
@@ -83,6 +89,7 @@ func newMockRepository() *mockRepository {
 		mementos:       make(map[uuid.UUID]*domain.Memento),
 		photos:         make(map[uuid.UUID]*domain.MementoPhoto),
 		stopCandidates: make(map[uuid.UUID]*domain.StopCandidate),
+		siteSettings:   make(map[uuid.UUID]*domain.SiteSettings),
 	}
 }
 
@@ -91,6 +98,23 @@ func (m *mockRepository) GetJournal(_ context.Context, id uuid.UUID) (*domain.Jo
 }
 
 func (m *mockRepository) CreateJournal(_ context.Context, _ *domain.Journal) error {
+	return nil
+}
+
+func (m *mockRepository) GetSoleJournal(_ context.Context) (*domain.Journal, error) {
+	return &domain.Journal{ID: mockJournalID, CreatedAt: time.Now()}, nil
+}
+
+func (m *mockRepository) GetSiteSettings(_ context.Context, journalID uuid.UUID) (*domain.SiteSettings, error) {
+	settings, ok := m.siteSettings[journalID]
+	if !ok {
+		return nil, domain.ErrNotFound
+	}
+	return settings, nil
+}
+
+func (m *mockRepository) UpsertSiteSettings(_ context.Context, settings *domain.SiteSettings) error {
+	m.siteSettings[settings.JournalID] = settings
 	return nil
 }
 

--- a/server/api/sitesettings_admin.go
+++ b/server/api/sitesettings_admin.go
@@ -1,0 +1,133 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"regexp"
+
+	"github.com/azusachino/felicia/core/domain"
+	"github.com/azusachino/felicia/publication"
+)
+
+// Site identity & style settings (ADMIN-02 M2): GET/PUT /api/admin/site-settings.
+// This is deliberately a separate file and resource from sitesettings.go's
+// /api/admin/site, which owns unrelated process configuration (out_dir,
+// preview_port) — same-ish name, different concept; do not merge them.
+
+// accentPattern is the bare hex format the admin UI's <input type="color">
+// already emits ("#rrggbb"); empty means "unset".
+var accentPattern = regexp.MustCompile(`^#[0-9a-fA-F]{6}$`)
+
+// handleGetSiteSettings resolves the sole journal's site identity/style
+// settings, defaulting (200, not 404) when none have been saved yet.
+func (s *Server) handleGetSiteSettings(w http.ResponseWriter, r *http.Request) {
+	settings, err := publication.ResolveSiteSettings(r.Context(), s.repo)
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	respondJSON(w, http.StatusOK, publication.NewStaticSiteSettings(settings))
+}
+
+// putSiteSettingsRequest is a partial update: only non-nil fields are
+// applied onto the current (or default) settings, so the admin GUI's single
+// "Save site settings" action can send just the fields it edited.
+type putSiteSettingsRequest struct {
+	Title           *string `json:"title"`
+	Description     *string `json:"description"`
+	Design          *string `json:"design"`
+	DefaultLanguage *string `json:"default_language"`
+	DefaultTheme    *string `json:"default_theme"`
+	Accent          *string `json:"accent"`
+}
+
+// handlePutSiteSettings applies a partial update to the site identity/style
+// settings and invalidates the public cache so the live endpoint and the
+// next static compile both reflect it immediately. No optimistic
+// concurrency: single-row, low-contention, out of this milestone's scope.
+func (s *Server) handlePutSiteSettings(w http.ResponseWriter, r *http.Request) {
+	var req putSiteSettingsRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		respondError(w, http.StatusBadRequest, "invalid request JSON")
+		return
+	}
+
+	var issues []domain.Issue
+	if req.Design != nil && !validSiteDesign(*req.Design) {
+		issues = append(issues, domain.Issue{Field: "design", Code: "invalid_enum"})
+	}
+	if req.DefaultLanguage != nil && !validSiteLanguage(*req.DefaultLanguage) {
+		issues = append(issues, domain.Issue{Field: "default_language", Code: "invalid_enum"})
+	}
+	if req.DefaultTheme != nil && !validSiteTheme(*req.DefaultTheme) {
+		issues = append(issues, domain.Issue{Field: "default_theme", Code: "invalid_enum"})
+	}
+	if req.Accent != nil && *req.Accent != "" && !accentPattern.MatchString(*req.Accent) {
+		issues = append(issues, domain.Issue{Field: "accent", Code: "invalid_format"})
+	}
+	if len(issues) > 0 {
+		respondJSON(w, http.StatusUnprocessableEntity, map[string]any{
+			"error":  "validation failed",
+			"issues": issues,
+		})
+		return
+	}
+
+	current, err := publication.ResolveSiteSettings(r.Context(), s.repo)
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if req.Title != nil {
+		current.Title = *req.Title
+	}
+	if req.Description != nil {
+		current.Description = *req.Description
+	}
+	if req.Design != nil {
+		current.Design = *req.Design
+	}
+	if req.DefaultLanguage != nil {
+		current.DefaultLanguage = *req.DefaultLanguage
+	}
+	if req.DefaultTheme != nil {
+		current.DefaultTheme = *req.DefaultTheme
+	}
+	if req.Accent != nil {
+		current.Accent = *req.Accent
+	}
+
+	if err := s.repo.UpsertSiteSettings(r.Context(), &current); err != nil {
+		respondError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	s.cache.InvalidateAll(r.Context())
+	respondJSON(w, http.StatusOK, publication.NewStaticSiteSettings(current))
+}
+
+func validSiteDesign(value string) bool {
+	switch value {
+	case "v1", "v2", "v3", "v4":
+		return true
+	default:
+		return false
+	}
+}
+
+func validSiteLanguage(value string) bool {
+	switch value {
+	case "ja", "en", "zh":
+		return true
+	default:
+		return false
+	}
+}
+
+func validSiteTheme(value string) bool {
+	switch value {
+	case "dark", "light":
+		return true
+	default:
+		return false
+	}
+}

--- a/server/api/sitesettings_admin_test.go
+++ b/server/api/sitesettings_admin_test.go
@@ -1,0 +1,144 @@
+package api_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/azusachino/felicia/server/api"
+)
+
+type siteSettingsPayload struct {
+	Title           string `json:"title"`
+	Description     string `json:"description"`
+	Design          string `json:"design"`
+	DefaultLanguage string `json:"default_language"`
+	DefaultTheme    string `json:"default_theme"`
+	Accent          string `json:"accent"`
+}
+
+func decodeSiteSettings(t *testing.T, w *httptest.ResponseRecorder) siteSettingsPayload {
+	t.Helper()
+	var got siteSettingsPayload
+	if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+		t.Fatalf("decode site settings: %v (%s)", err, w.Body)
+	}
+	return got
+}
+
+// A fresh DB (no site settings saved yet, only the always-present sole
+// journal) must resolve to defaults with a 200 — never a 404 — matching the
+// static compiler's "absent settings = current demo behavior" (ADMIN-02 M2 §4).
+func TestGetSiteSettingsDefaultsOnEmptyDB(t *testing.T) {
+	handler := api.NewServer(newMockRepository(), nil, api.NewCacheManager("", testLogger), testLogger, nil, api.RouteConfig{}).Handler()
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/admin/site-settings", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("get site settings on empty DB = %d, want 200 (%s)", w.Code, w.Body)
+	}
+
+	got := decodeSiteSettings(t, w)
+	want := siteSettingsPayload{Design: "v1", DefaultLanguage: "ja", DefaultTheme: "dark"}
+	if got != want {
+		t.Errorf("defaults = %+v, want %+v", got, want)
+	}
+}
+
+func TestPutSiteSettingsValidRoundTrip(t *testing.T) {
+	handler := api.NewServer(newMockRepository(), nil, api.NewCacheManager("", testLogger), testLogger, nil, api.RouteConfig{}).Handler()
+
+	body, _ := json.Marshal(map[string]any{
+		"title":            "Aaron's Waypoints",
+		"description":      "A travel journal",
+		"design":           "v3",
+		"default_language": "en",
+		"default_theme":    "light",
+		"accent":           "#ea580c",
+	})
+	req := httptest.NewRequest(http.MethodPut, "/api/admin/site-settings", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("put site settings = %d, want 200 (%s)", w.Code, w.Body)
+	}
+	want := siteSettingsPayload{
+		Title: "Aaron's Waypoints", Description: "A travel journal", Design: "v3",
+		DefaultLanguage: "en", DefaultTheme: "light", Accent: "#ea580c",
+	}
+	if got := decodeSiteSettings(t, w); got != want {
+		t.Errorf("put response = %+v, want %+v", got, want)
+	}
+
+	// The save round-trips through a subsequent GET.
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/admin/site-settings", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("get after put = %d, want 200 (%s)", w.Code, w.Body)
+	}
+	if got := decodeSiteSettings(t, w); got != want {
+		t.Errorf("get after put = %+v, want %+v", got, want)
+	}
+}
+
+func TestPutSiteSettingsRejectsInvalidFields(t *testing.T) {
+	cases := []struct {
+		name  string
+		field string
+		body  map[string]any
+	}{
+		{"invalid design", "design", map[string]any{"design": "v9"}},
+		{"invalid default_language", "default_language", map[string]any{"default_language": "fr"}},
+		{"invalid default_theme", "default_theme", map[string]any{"default_theme": "sepia"}},
+		{"invalid accent", "accent", map[string]any{"accent": "orange"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := api.NewServer(newMockRepository(), nil, api.NewCacheManager("", testLogger), testLogger, nil, api.RouteConfig{}).Handler()
+			body, _ := json.Marshal(tc.body)
+			req := httptest.NewRequest(http.MethodPut, "/api/admin/site-settings", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+			if w.Code != http.StatusUnprocessableEntity {
+				t.Fatalf("%s: status = %d, want 422 (%s)", tc.name, w.Code, w.Body)
+			}
+			var res map[string]any
+			if err := json.NewDecoder(w.Body).Decode(&res); err != nil {
+				t.Fatalf("decode error response: %v", err)
+			}
+			issues, ok := res["issues"].([]any)
+			if !ok || len(issues) == 0 {
+				t.Fatalf("%s: expected validation issues, got %v", tc.name, res)
+			}
+			found := false
+			for _, raw := range issues {
+				issue, ok := raw.(map[string]any)
+				if ok && issue["Field"] == tc.field {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("%s: issues %v do not mention field %q", tc.name, issues, tc.field)
+			}
+		})
+	}
+}
+
+// An accent of "" (unsetting it) is legal — only a non-empty, malformed value
+// is rejected.
+func TestPutSiteSettingsAllowsClearingAccent(t *testing.T) {
+	handler := api.NewServer(newMockRepository(), nil, api.NewCacheManager("", testLogger), testLogger, nil, api.RouteConfig{}).Handler()
+
+	body, _ := json.Marshal(map[string]any{"accent": ""})
+	req := httptest.NewRequest(http.MethodPut, "/api/admin/site-settings", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("clear accent status = %d, want 200 (%s)", w.Code, w.Body)
+	}
+}


### PR DESCRIPTION
## Summary

Lands epic FELICIA-ADMIN-02 milestone M2: the author picks the public design and site style entirely from the admin GUI, and it's served identically by the live API and the static compiler.

- **02.2a — `site.json` contract**: journal-scoped `tb_site_settings` (title, description, active design, default language/theme, accent), following the existing "everything hangs off one journal row" convention (ADR-0001) rather than an artificial standalone singleton. `publication.ResolveSiteSettings` is the one shared resolver both the static compiler and the live API call, applying defaults when nothing has been configured yet. `GET /api/v1/site(.json)` (live/static parity, manifest-tracked) and `GET/PUT /api/admin/site-settings` (kept separate from the existing, unrelated `/api/admin/site` out_dir/preview_port resource).
- **02.2b — reader lock**: the public reader now boots into the configured design instead of the old hash-based switcher (removed), seeds default language/theme from the same settings, and applies the accent color across all four designs via a shared `--accent` CSS variable (v1/v2 share `--accent-ink`, v4's `--orange`, v3's `--terracotta` plus its Tailwind-utility-class spots).
- **02.2c — admin UI**: the Site & Deploy page gained a Site identity section (4 design cards, title/description, language/theme selects, a native color picker for accent, one explicit Save action), positioned above the existing Build section (configure → build → preview).
- **Test extension**: the admin GUI closed-loop E2E now drives the Site identity flow itself — picks a design, saves title/accent, reloads to confirm persistence, rebuilds, and checks both the live `/api/v1/site` response and the compiled `site.json` on disk.

Docs-sync: `docs/roadmap.md`, `docs/roadmap/admin-gui-v2-epic.md` (M2 marked landed), and `docs/roadmap/user-journey.md` status log updated in this PR per `AGENTS.md`.

## Notable decisions

- `tb_site_settings.journal_id` is a real FK to `tb_journal` (1:1), not a bare `id=1` singleton — matches the codebase's existing convention that every table hangs off the journal root even with only one row today, so a future multi-journal migration is additive rather than a reshape. Added `GetSoleJournal` since nothing resolved "the" journal generically before.
- Accent is stored as a bare `#rrggbb` hex string, validated server-side; the admin UI uses a native `<input type="color">`.
- `tb_site_settings` stays identity-only this milestone — deploy-target config (M3) gets its own table later.

## Test plan

All run in the containerized nix devshell (this repo's standing verification rule):

- [x] `make validate` (fmt/vet/lint/test/test-features/build/web-check/web-admin-check) — green
- [x] `make test-workflow` — live/static `site.json` parity check passes, no regression
- [x] `make test-admin-e2e` — 13/13 passing (10 pre-existing + 3 new site-identity steps), no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)