### PR TITLE
docs: freeze frontend style direction and write v1 acceptance scenarios (M0)

### DIFF
--- a/docs/adr/0031-frontend-style-map-first-and-shared-element-open.md
+++ b/docs/adr/0031-frontend-style-map-first-and-shared-element-open.md
@@ -1,0 +1,83 @@
+---
+id: "0031"
+title: "Frontend Style: Map-First Layout and Shared-Element Open"
+status: "accepted"
+date: "2026-08-04"
+decisions:
+  - "felicia:decision:frontend-style"
+related: ["0002"]
+supersedes: []
+---
+
+# ADR 0031: Frontend Style — Map-First Layout and Shared-Element Open
+
+## Context
+
+[`docs/research/ux-restyle.md`](../research/ux-restyle.md) (2026-07-02) diagnosed the
+early reader prototype — a dead entry state (the index was unreachable on first load),
+no signature open moment (mementos didn't behave like physical objects being opened),
+scaffolding leaking into the public reader, and a clashing visual identity (a warm JR
+ticket next to generic Tailwind kind badges).
+
+The note committed several directions as **high confidence** — warm paper as the
+material system for every `kind`, killing the authoring scaffolding out of the reader,
+fixing the entry so the index is always reachable, and ragged-right essay typography —
+but left two **genuine taste decisions** explicitly open, asked of the author on
+2026-07-02 with no answer until now (M0 issue #16, "Freeze memento visual and motion
+direction," tracked this gap):
+
+1. **Layout / navigation model** — index rail + detail vs. map-first fixed entry vs.
+   immersive scrollytelling.
+2. **Signature open interaction** — shared-element morph vs. tear/unfold vs. flip.
+
+In the time since, `apps/web-public/src/{v1,v2,v3,v4}` grew four parallel reader
+designs (`v1` "Map", `v2` "Collection", `v3` "Journal", `v4` "Atlas") as prior
+exploration, but none of them is a direct, committed answer to either fork — they
+predate this decision, not implement it.
+
+## Decision
+
+Settled 2026-08-04, author's call:
+
+1. **Layout / navigation model: map-first, fixed entry.** A full-bleed map stays the
+   hero. The reader lands on a journey-overview card (title, dates, memento count)
+   plus a viewport-anchored index toggle — not a persistent side rail. This is the
+   smallest structural change from the diagnosed prototype and keeps the map as the
+   index, matching [ADR-0002](0002-mementos-not-tickets.md)'s "the map is the index"
+   framing.
+2. **Signature open interaction: shared-element morph.** The map stub grows into the
+   full stub in the detail view — one continuous object, not a separate open/close
+   panel. This is the option ux-restyle.md judged best reinforces map-as-index.
+
+The other "high confidence" items from ux-restyle.md are frozen alongside these two
+forks, as the same issue (#16) scoped them together:
+
+3. **Warm paper is the system.** Every `kind` renders as a designed paper object in
+   one warm accent scale (amber → orange) — ticket (admission stock), transit (the
+   existing きっぷ magnetic ticket, kept as-is), stamp/goshuin (ink-on-washi), goods
+   (hang-tag/kraft label), receipt (thermal-roll paper). No Tailwind-badge kind
+   coloring.
+4. **Entry is never dead.** The index (journey overview + memento quick-list) is
+   reachable from first load, via a viewport-anchored affordance rather than one
+   anchored to a panel that can slide away.
+5. **Essay typography.** Ragged-right (no `justify`), a wider reading measure, and
+   raised leading (~1.7).
+
+## Consequences
+
+- This freezes the fork so implementation doesn't reopen it (the acceptance bar
+  issue #16 set) — `docs/research/ux-restyle.md`'s "Open forks" section and
+  `docs/direction.md`'s open-question line are updated to point here instead of
+  leaving the question open.
+- **None of the four existing prototype designs is a clean match for "map-first,
+  fixed entry."** `v1` is an always-visible left index rail (closer to the rejected
+  "index rail + detail" option); `v3` is a two-page book-spread; `v4` is scroll-driven
+  ("immersive scrollytelling," the other rejected option). Building the reader that
+  actually matches this decision — full-bleed map, a journey-overview card, a
+  viewport-anchored toggle instead of a persistent rail, and the shared-element open —
+  is real follow-up implementation work, out of scope for this ADR. Whether that means
+  adapting the closest existing prototype or building fresh is a call for whoever picks
+  up that implementation issue.
+- Per-kind stub material design (tokens, exact CSS) still needs a follow-up frontend
+  style spec (ux-restyle.md's own next step) before implementation — this ADR freezes
+  the _direction_, not a component spec.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -4,28 +4,29 @@ This directory stores the immutable records of design and architecture choices m
 
 ## Index of Decisions
 
-| ID                                                           | Title                                                  | Date       | Status   |
-| ------------------------------------------------------------ | ------------------------------------------------------ | ---------- | -------- |
-| [0001](0001-personal-now-product-ready.md)                   | Personal-Now, Product-Ready Direction                  | 2026-06-12 | Accepted |
-| [0002](0002-mementos-not-tickets.md)                         | Mementos as the Core Unit                              | 2026-06-14 | Accepted |
-| [0003](0003-presentation-agnostic-contract.md)               | Presentation-Agnostic Contract                         | 2026-07-08 | Accepted |
-| [0004](0004-jp-first-i18n.md)                                | Japanese-First i18n                                    | 2026-07-01 | Accepted |
-| [0005](0005-place-as-derived-visit.md)                       | Places as Derived Visits                               | 2026-07-09 | Accepted |
-| [0006](0006-memento-template-registry.md)                    | Declarative Memento Template Registry                  | 2026-07-09 | Accepted |
-| [0007](0007-backend-stack.md)                                | Backend Stack (PostgreSQL 18 & Go)                     | 2026-07-08 | Accepted |
-| [0008](0008-single-user-local-first-ssg.md)                  | Single-User Local-First & SSG Compiler Model           | 2026-07-09 | Accepted |
-| [0016](0016-four-module-go-workspace.md)                     | Four-Module Go Workspace Boundaries                    | 2026-07-14 | Accepted |
-| [0017](0017-sqlite-first-storage.md)                         | SQLite-First Storage with Optional PostgreSQL          | 2026-07-14 | Accepted |
-| [0018](0018-api-runtime-separation.md)                       | API Transport and Runtime Separation                   | 2026-07-14 | Accepted |
-| [0019](0019-authored-content-and-system-locales.md)          | Authored Content and System Locales                    | 2026-07-14 | Accepted |
-| [0020](0020-root-module-retirement.md)                       | Retire the Transitional Root Go Module                 | 2026-07-14 | Accepted |
-| [0021](0021-runtime-configuration-and-database-modes.md)     | Runtime Configuration and Database Modes               | 2026-07-14 | Accepted |
-| [0022](0022-unified-intake-and-draft-pipeline.md)            | Unified Intake and Draft Pipeline                      | 2026-07-16 | Accepted |
-| [0023](0023-portable-journey-package.md)                     | Portable Journey Package for Import and Agents         | 2026-07-16 | Accepted |
-| [0024](0024-optional-ai-enrichment.md)                       | Optional OCR and AI Enrichment                         | 2026-07-16 | Accepted |
-| [0025](0025-static-and-self-hosted-modes.md)                 | Static and Self-Hosted Product Modes                   | 2026-07-17 | Accepted |
-| [0026](0026-local-first-media-and-blob-storage.md)           | Local-First Media with Pluggable Blob Storage          | 2026-07-17 | Accepted |
-| [0027](0027-provider-matrix-and-application-composition.md)  | Provider Matrix and Application Composition            | 2026-07-17 | Accepted |
-| [0028](0028-cli-compiler-and-shared-publication-boundary.md) | CLI Compiler and Shared Publication Boundary           | 2026-07-17 | Proposed |
-| [0029](0029-community-go-workspace-layout.md)                | Community-Shaped Go Workspace Layout                   | 2026-07-17 | Accepted |
-| [0030](0030-intake-planning-contract.md)                     | Intake Planning Contract and Candidate Review Boundary | 2026-07-18 | Proposed |
+| ID                                                               | Title                                                    | Date       | Status   |
+| ---------------------------------------------------------------- | -------------------------------------------------------- | ---------- | -------- |
+| [0001](0001-personal-now-product-ready.md)                       | Personal-Now, Product-Ready Direction                    | 2026-06-12 | Accepted |
+| [0002](0002-mementos-not-tickets.md)                             | Mementos as the Core Unit                                | 2026-06-14 | Accepted |
+| [0003](0003-presentation-agnostic-contract.md)                   | Presentation-Agnostic Contract                           | 2026-07-08 | Accepted |
+| [0004](0004-jp-first-i18n.md)                                    | Japanese-First i18n                                      | 2026-07-01 | Accepted |
+| [0005](0005-place-as-derived-visit.md)                           | Places as Derived Visits                                 | 2026-07-09 | Accepted |
+| [0006](0006-memento-template-registry.md)                        | Declarative Memento Template Registry                    | 2026-07-09 | Accepted |
+| [0007](0007-backend-stack.md)                                    | Backend Stack (PostgreSQL 18 & Go)                       | 2026-07-08 | Accepted |
+| [0008](0008-single-user-local-first-ssg.md)                      | Single-User Local-First & SSG Compiler Model             | 2026-07-09 | Accepted |
+| [0016](0016-four-module-go-workspace.md)                         | Four-Module Go Workspace Boundaries                      | 2026-07-14 | Accepted |
+| [0017](0017-sqlite-first-storage.md)                             | SQLite-First Storage with Optional PostgreSQL            | 2026-07-14 | Accepted |
+| [0018](0018-api-runtime-separation.md)                           | API Transport and Runtime Separation                     | 2026-07-14 | Accepted |
+| [0019](0019-authored-content-and-system-locales.md)              | Authored Content and System Locales                      | 2026-07-14 | Accepted |
+| [0020](0020-root-module-retirement.md)                           | Retire the Transitional Root Go Module                   | 2026-07-14 | Accepted |
+| [0021](0021-runtime-configuration-and-database-modes.md)         | Runtime Configuration and Database Modes                 | 2026-07-14 | Accepted |
+| [0022](0022-unified-intake-and-draft-pipeline.md)                | Unified Intake and Draft Pipeline                        | 2026-07-16 | Accepted |
+| [0023](0023-portable-journey-package.md)                         | Portable Journey Package for Import and Agents           | 2026-07-16 | Accepted |
+| [0024](0024-optional-ai-enrichment.md)                           | Optional OCR and AI Enrichment                           | 2026-07-16 | Accepted |
+| [0025](0025-static-and-self-hosted-modes.md)                     | Static and Self-Hosted Product Modes                     | 2026-07-17 | Accepted |
+| [0026](0026-local-first-media-and-blob-storage.md)               | Local-First Media with Pluggable Blob Storage            | 2026-07-17 | Accepted |
+| [0027](0027-provider-matrix-and-application-composition.md)      | Provider Matrix and Application Composition              | 2026-07-17 | Accepted |
+| [0028](0028-cli-compiler-and-shared-publication-boundary.md)     | CLI Compiler and Shared Publication Boundary             | 2026-07-17 | Proposed |
+| [0029](0029-community-go-workspace-layout.md)                    | Community-Shaped Go Workspace Layout                     | 2026-07-17 | Accepted |
+| [0030](0030-intake-planning-contract.md)                         | Intake Planning Contract and Candidate Review Boundary   | 2026-07-18 | Proposed |
+| [0031](0031-frontend-style-map-first-and-shared-element-open.md) | Frontend Style: Map-First Layout and Shared-Element Open | 2026-08-04 | Accepted |

--- a/docs/direction.md
+++ b/docs/direction.md
@@ -88,7 +88,10 @@ them. Detail in [`archive/design.md`](archive/design.md).
 - **Stub rendering** — _resolved_ to **template-first** (rendered from data; photographed
   stub is the bonus), per mementos-not-tickets. Still open: _which_ `kind` forms ship first
   and how much design each earns.
-- **Ticket-open animation** — flip vs. shared-element morph vs. tear/unfold; prototype later.
+- **Ticket-open animation** — _resolved_ to **shared-element morph** (2026-08-04), per
+  [ADR-0031](adr/0031-frontend-style-map-first-and-shared-element-open.md), alongside
+  the map-first/fixed-entry layout decision. Still open: the frontend style spec
+  (per-kind stub anatomy, motion timing) and building a reader that matches it.
 - **I18n shape** — how much of the first demo/spec is translated vs. just architected for
   Japanese/English/Chinese; Japanese should be the primary review path.
 

--- a/docs/release/v1-acceptance.md
+++ b/docs/release/v1-acceptance.md
@@ -1,0 +1,112 @@
+---
+title: "v1 Acceptance Scenarios and Privacy Invariants"
+status: "active"
+date: "2026-08-04"
+---
+
+# v1 acceptance scenarios and privacy invariants
+
+This is the R0 deliverable [`docs/roadmap.md`](../roadmap.md) names — "write the v1
+acceptance scenarios and privacy invariants" — consolidated into one document instead
+of staying scattered across `direction.md`, the ADRs, and each milestone's own exit
+check. It does not introduce new decisions; it restates what's already committed
+elsewhere as one testable checklist, so a reviewer can verify v1 without re-deriving
+the invariants from prose.
+
+**Open item:** every scenario below is written against "the selected real journey" —
+per M0 issue #7, no specific real trip has been designated as the v1 acceptance
+fixture yet (only synthetic/example data exists: `examples/preview/local-journey`,
+`tests/fixtures/local-journey-mixed-state`, and the E2E harnesses' seeded journeys).
+Selecting one and inventorying its route/visits/mementos/essays/photos is separate,
+pending work — this document is written so that step is a drop-in, not a rewrite.
+
+## Acceptance scenarios
+
+Each scenario restates a milestone's exit check from [`roadmap.md`](../roadmap.md) as
+a concrete pass/fail check against the selected real journey, once chosen.
+
+### Reader (R2)
+
+1. A first-time visitor loads the public site with no prior state and can identify
+   that a journey index exists, without already knowing the map UI (roadmap R2 exit
+   check; tracked open by issue #37 until 2026-08-04, since closed against the
+   current default reader's index rail).
+2. From the index, the visitor opens the selected journey, sees its route on a dark
+   MapLibre map with visit/memento markers, and the layout is usable on both desktop
+   and mobile viewports.
+3. Clicking a memento animates it open (per [ADR-0031](../adr/0031-frontend-style-map-first-and-shared-element-open.md),
+   the committed shared-element morph once implemented) into its essay and photo
+   gallery, and the visitor can return to the map/index afterward.
+4. The reader is verified in Japanese, English, and Chinese system UI; authored
+   content (titles, essays, captions) renders exactly as entered, with no automatic
+   translation.
+5. Keyboard navigation reaches every interactive element, and `prefers-reduced-motion`
+   is honored for the open interaction.
+
+### Authoring and publish (R3)
+
+6. The selected journey can be created or repaired entirely through the admin UI —
+   journey metadata, mementos (driven by the declarative template registry), and
+   photo curation with captions/ordering.
+7. A draft can be previewed as it will appear publicly before publishing.
+8. Publishing is an explicit, separate action from saving a draft; unpublished
+   content never appears through the public API or the compiled static artifact
+   (enforced by the shared `publication` boundary and covered by the live/static
+   parity check in `scripts/test_journey_workflow.py`).
+9. Re-running an import after authoring never overwrites already-authored fields
+   (field-scoped importer, [ADR-0022](../adr/0022-unified-intake-and-draft-pipeline.md)) —
+   editing a field by hand and then re-importing the same source leaves the authored
+   value intact.
+10. A stale-write (editing the same memento from two contexts) surfaces a revision
+    conflict instead of silently discarding one side's edit.
+
+### Ingestion (R4)
+
+11. Importing the selected journey's real GPX/Dawarich/Immich sources produces no
+    duplicate mementos on a second run, and any incomplete/missing source data
+    leaves an auditable result rather than a silent gap.
+
+### Deployment (R5)
+
+12. The compiled static artifact, deployed via the GitHub Pages workflow (or an
+    equivalent supported host), serves the selected journey identically to what the
+    live admin-mode API would serve for the same published state — verified by the
+    live/static parity check, not by manual comparison.
+13. The owner can publish a new memento to the selected journey and see it appear at
+    the public URL without a developer's help.
+
+## Privacy invariants
+
+These are enforced properties, not aspirations — each one names where it's actually
+checked in code/tests, per [ADR-0025](../adr/0025-static-and-self-hosted-modes.md) and
+[ADR-0026](../adr/0026-local-first-media-and-blob-storage.md).
+
+1. **Drafts and originals never leave the machine.** The compiled static artifact
+   contains only `published` content, EXIF-stripped public media derivatives, and
+   rounded geometry. The admin app itself is never part of a deployed artifact.
+2. **No raw GPS in public responses.** Public projections (`publication/public.go`,
+   the live `/api/v1` handlers) never expose unrounded coordinates or a private
+   track's full-precision points — checked by the roadmap's stated verification gate
+   ("no raw GPS in public responses") but **not yet backed by an automated geometry-
+   rounding check in code** (confirmed gap — no `Round(` call exists in the Go
+   codebase today; tracked by open issue #27, not yet closed).
+3. **Public images are resized and EXIF-stripped.** Every media file that crosses the
+   public media boundary is a processed derivative, never the original upload —
+   **also not yet automated as a compile-time or test-time check** (same gap as #2,
+   tracked by issue #27/#24).
+4. **A journey without published mementos has no public projection at all**, on
+   either the live API or the static compiler — enforced by the shared `publication`
+   package and covered by `scripts/test_journey_workflow.py`'s unpublished-journey
+   exclusion check.
+5. **Re-import never overwrites authored fields.** The field-scoped importer upserts
+   only source-derived fields; anything the author has edited by hand is preserved
+   across re-import — enforced by `runtime/importer/` and its contract tests.
+6. **No credentials inside felicia.** No provider or deployment path stores third-
+   party credentials in the database or the compiled artifact; GitHub deployment (M3
+   of epic ADMIN-02) reuses the operator's own `git` credentials rather than storing
+   a token.
+
+Invariants 2 and 3 above are stated in the roadmap's verification gates but are
+**not yet enforced by an automated check** — this document surfaces that gap
+explicitly (feeding open issues #24 and #27) rather than letting the informal
+"we round geometry / strip EXIF" claim stand unverified.

--- a/docs/research/ux-restyle.md
+++ b/docs/research/ux-restyle.md
@@ -76,32 +76,39 @@ Drop `justify` → ragged-right. Widen the reading measure, raise leading (~1.7 
 consider a serif for essay body to lean _travel book_ over _dashboard_ (ties to the layout
 fork below).
 
-## Open forks — your call
+## Open forks — settled
 
-These are genuine taste decisions, left undecided (asked 2026-07-02, author away):
+> **2026-08-04: both forks settled.** See
+> [ADR-0031](../adr/0031-frontend-style-map-first-and-shared-element-open.md) —
+> **map-first, fixed entry** + **shared-element morph**. Kept here for the rejected
+> alternatives' rationale; do not reopen this debate in implementation.
 
-1. **Layout / navigation model.**
-   - _Index rail + detail_ — left rail lists journeys → mementos (photo-count badge, sort
-     toggle), map center, paper detail panel. Proven (this is liuaaron); fixes the dead entry
-     structurally.
-   - _Map-first, fixed entry_ — keep the single right glass panel over a full-bleed map, but
-     land on a journey-overview card + a viewport-anchored index toggle. Smallest change;
-     keeps the map the hero. **(current lean)**
-   - _Immersive scrollytelling_ — scroll drives the camera along the route; mementos surface
-     as reached. Cinematic; biggest build.
+These were genuine taste decisions, left undecided from 2026-07-02 (author away) until
+ADR-0031:
 
-2. **Signature open interaction.**
-   - _Shared-element morph_ — the map stub grows into the full stub in the detail view; one
-     continuous object. Best reinforces map-as-index. **(current lean)**
-   - _Tear / unfold_ — perforated stub tears along its dashed line to reveal the essay.
-     Tactile; thematically perfect for "warm paper is the system."
-   - _Flip_ — front (stub face) → back (essay + photos). Cheapest to do well.
+1. **Layout / navigation model.** → **Decided: map-first, fixed entry.**
+   - _Index rail + detail_ (rejected) — left rail lists journeys → mementos
+     (photo-count badge, sort toggle), map center, paper detail panel. Proven (this is
+     liuaaron); fixes the dead entry structurally.
+   - _Map-first, fixed entry_ (**decided**) — keep the single right glass panel over a
+     full-bleed map, but land on a journey-overview card + a viewport-anchored index
+     toggle. Smallest change; keeps the map the hero.
+   - _Immersive scrollytelling_ (rejected) — scroll drives the camera along the route;
+     mementos surface as reached. Cinematic; biggest build.
+
+2. **Signature open interaction.** → **Decided: shared-element morph.**
+   - _Shared-element morph_ (**decided**) — the map stub grows into the full stub in
+     the detail view; one continuous object. Best reinforces map-as-index.
+   - _Tear / unfold_ (rejected) — perforated stub tears along its dashed line to
+     reveal the essay. Tactile; thematically perfect for "warm paper is the system."
+   - _Flip_ (rejected) — front (stub face) → back (essay + photos). Cheapest to do
+     well.
 
 ## Implications & next step
 
-- No app code yet — this stays research. When the two forks settle, promote a **frontend
-  style spec** (design tokens, per-kind stub anatomy, motion spec) and _then_ refactor `web/`.
-- The refactor is mostly `index.css` (tokens + per-kind stub CSS) + `App.tsx` entry-state and
-  scaffolding removal; the domain model and map wiring are sound.
-- Candidate ADR once forks settle: `felicia:decision:frontend-style` — "warm paper as the
-  system, scaffolding out of the reader, [layout] + [open-anim]."
+- ADR-0031 freezes the _direction_; a **frontend style spec** (design tokens, per-kind
+  stub anatomy, motion spec) is still the next step before implementation.
+- None of the four current reader prototypes (`apps/web-public/src/{v1,v2,v3,v4}`) is
+  a clean match for the decided layout — `v1` is an index rail, `v3` is a book-spread,
+  `v4` is scroll-driven. Building (or adapting a prototype into) the reader that
+  actually matches ADR-0031 is separate follow-up implementation work.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -67,7 +67,8 @@ Deliverables:
 - Choose the first two visual open interactions and memento forms to polish; the current lean is warm paper plus a shared-element morph.
 - Freeze the public read contract and the authoring write contract.
 - Select one real journey and define its route, visits, mementos, essays, and photos.
-- Write the v1 acceptance scenarios and privacy invariants.
+- Write the v1 acceptance scenarios and privacy invariants —
+  [`docs/release/v1-acceptance.md`](release/v1-acceptance.md).
 - Define the import-package manifest, review states, and agent confirmation boundary.
 
 Exit check: a reviewer can describe the complete author and reader journey without falling back to an archived design draft.


### PR DESCRIPTION
## Summary

Advances M0 issue #7 and closes #16, per the author's decisions on the two forks `docs/research/ux-restyle.md` left open since 2026-07-02:

- **Layout / navigation model → map-first, fixed entry** (full-bleed map hero, journey-overview card + viewport-anchored index toggle, not a persistent side rail).
- **Signature open interaction → shared-element morph** (the map stub grows into the full stub in the detail view).

Both are formalized in [ADR-0031](https://github.com/azusachino/felicia/blob/docs/m0-content-lock/docs/adr/0031-frontend-style-map-first-and-shared-element-open.md), alongside the other "high confidence" items from `ux-restyle.md` that issue #16 scoped together: warm paper as the material system for every memento `kind`, killing reader scaffolding, fixing the dead entry, and ragged-right essay typography. `ux-restyle.md` and `direction.md` now point at the ADR instead of leaving the question open.

**Honest gap called out, not hidden**: none of the four current reader prototypes (`apps/web-public/src/{v1,v2,v3,v4}`) is a clean match for the decided layout — v1 is an index rail, v3 is a book-spread, v4 is scroll-driven. Building (or adapting a prototype into) a reader that actually matches ADR-0031 is separate follow-up implementation work, out of scope here.

Also adds `docs/release/v1-acceptance.md` for the other #7 deliverable — consolidates the v1 acceptance scenarios and privacy invariants that were scattered across `direction.md`, the ADRs, and each roadmap milestone's own exit check into one testable checklist. It flags two privacy invariants (geometry rounding, EXIF stripping) that are stated as requirements in the roadmap but have no automated check backing them yet — feeding that gap back into open issues #24/#27 instead of letting it stand unverified.

**Still open** (the other #7 gap, not resolved by this PR): no specific real trip has been designated as the v1 acceptance fixture yet — only synthetic/example data exists. `v1-acceptance.md` is written so that selection is a drop-in once the author provides it, not a rewrite.

## Test plan

Docs-only change.

- [x] `make fmt-check` — green (containerized nix devshell)

🤖 Generated with [Claude Code](https://claude.com/claude-code)