### PR TITLE
feat: shared-element open, close control, and a11y polish for the v1 reader (#15, #32)

### DIFF
--- a/apps/web-public/src/data.ts
+++ b/apps/web-public/src/data.ts
@@ -72,6 +72,7 @@ export const uiText = {
   journeys: "ui.journeys",
   all: "ui.all",
   story: "ui.story",
+  close: "ui.close",
 } satisfies Record<string, MessageKey>
 
 export interface MementoCard {

--- a/apps/web-public/src/i18n/catalog.ts
+++ b/apps/web-public/src/i18n/catalog.ts
@@ -16,6 +16,7 @@ export type MessageKey =
   | "ui.journeys"
   | "ui.all"
   | "ui.story"
+  | "ui.close"
 
 export type Catalog = Record<MessageKey, string>
 
@@ -36,6 +37,7 @@ export const catalogs: Record<Locale, Catalog> = {
     "ui.journeys": "旅の記録",
     "ui.all": "すべて表示",
     "ui.story": "物語",
+    "ui.close": "閉じる",
   },
   en: {
     "design.map": "Map",
@@ -53,6 +55,7 @@ export const catalogs: Record<Locale, Catalog> = {
     "ui.journeys": "Journeys",
     "ui.all": "View all",
     "ui.story": "The Story",
+    "ui.close": "Close",
   },
   zh: {
     "design.map": "地图",
@@ -70,6 +73,7 @@ export const catalogs: Record<Locale, Catalog> = {
     "ui.journeys": "旅程",
     "ui.all": "查看全部",
     "ui.story": "故事",
+    "ui.close": "关闭",
   },
 }
 

--- a/apps/web-public/src/index.css
+++ b/apps/web-public/src/index.css
@@ -88,6 +88,20 @@ button {
   --ctrl-invert: 0;
 }
 
+/* Visually hidden but screen-reader-audible — used for live-region
+   announcements (e.g. v1's "memento selected" status). */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  white-space: nowrap;
+  border: 0;
+  clip: rect(0, 0, 0, 0);
+}
+
 .maplibregl-ctrl-group {
   background: var(--ctrl-bg) !important;
   border: 1px solid var(--border) !important;
@@ -290,6 +304,19 @@ button {
   @apply flex min-h-full flex-col gap-5;
 }
 
+/* Sticky within .detail-panel's own scroll (there's no separate inner
+   scroll wrapper here, unlike v4) so it stays reachable while scrolled. */
+.detail-close {
+  @apply sticky top-0 z-10 flex h-8 w-8 shrink-0 items-center justify-center self-end rounded-full text-base leading-none;
+  color: var(--text);
+  background: var(--ctrl-bg);
+  border: 1px solid var(--border);
+}
+
+.detail-close:hover {
+  background: var(--hover);
+}
+
 .section-head {
   @apply flex flex-col gap-2;
 }
@@ -436,6 +463,17 @@ button {
 
 .map-marker--stamp {
   @apply border-red-300;
+}
+
+/* Shared-element open (ADR-0031): a transient stand-in for the clicked
+   imperative marker, positioned via JS (map.project) in viewport space so
+   it can crossfade into the detail panel's .stub-card regardless of DOM
+   parent. Decorative — aria-hidden, and never receives pointer input. */
+.marker-ghost {
+  position: fixed;
+  z-index: 40;
+  pointer-events: none;
+  transform: translate(-50%, -50%);
 }
 
 /* v3 (techo) place markers — created imperatively, so styled globally. A place

--- a/apps/web-public/src/v1/V1App.svelte
+++ b/apps/web-public/src/v1/V1App.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   import maplibregl, { type StyleSpecification } from "maplibre-gl"
   import { onMount, tick } from "svelte"
-  import { fade, fly } from "svelte/transition"
+  import { cubicOut } from "svelte/easing"
+  import { crossfade, fade } from "svelte/transition"
   import { loadJourneys } from "../api/source"
-  import { kindLabel, uiText, type Coordinates, type Journey, type L, type Lang, type Memento, type Station, type Theme } from "../data"
+  import { kindLabel, uiText, type Coordinates, type Journey, type L, type Lang, type Memento, type MementoKind, type Station, type Theme } from "../data"
   import { message, type MessageKey } from "../i18n/catalog"
 
   // v1 — the liuaaron-aligned map reader: journey index rail -> map hero ->
@@ -22,10 +23,35 @@
   // eslint-disable-next-line svelte/prefer-svelte-reactivity -- imperative maplibre marker cache, not reactive UI state
   const markers = new Map<string, maplibregl.Marker>()
 
+  // Shared-element open: a transient "ghost" stands in for the clicked
+  // (imperative, non-Svelte) map marker so a crossfade pair has something to
+  // grow from — see selectMemento() / markerScreenPos() (ADR-0031).
+  let ghostVisible = false
+  let ghostKey = ""
+  let ghostOrigin: { x: number; y: number } | undefined
+  let ghostKind: MementoKind | undefined
+  let detailHeadingEl: HTMLHeadingElement | undefined
+  let prefersReducedMotion = false
+
+  const [sendStub, receiveStub] = crossfade({
+    duration: (d: number) => (prefersReducedMotion ? 0 : Math.min(500, 220 + Math.sqrt(d) * 8)),
+    easing: cubicOut,
+    fallback(node) {
+      const opacity = +getComputedStyle(node).opacity || 1
+      return {
+        duration: prefersReducedMotion ? 0 : 260,
+        easing: cubicOut,
+        css: (t: number) => `opacity: ${t * opacity}`,
+      }
+    },
+  })
+
   $: t = (value: L | MessageKey) => (typeof value === "string" ? message(lang, value) : value[lang])
   $: stationName = (s: Station) => (lang === "en" ? s.name : s.ja)
   $: selectedJourney = journeys.find((j) => j.id === selectedJourneyId) ?? journeys[0]
   $: countLabel = (n: number) => (lang === "en" ? `${n} mementos` : `${n}件`)
+  $: liveMessage = selected ? `${t(kindLabel[selected.kind])}: ${t(selected.title)}` : ""
+  $: ghostSeq = selectedJourney ? selectedJourney.mementos.findIndex((m) => m.id === ghostKey) + 1 : 0
 
   function routesGeoJson() {
     return {
@@ -148,11 +174,57 @@
     selected = journey.mementos[0]
     updateJourneyLayers(journey)
     fitJourney(journey)
+    void focusDetailHeading()
   }
 
-  function selectMemento(memento: Memento) {
-    selected = memento
+  // Screen-space position (viewport-relative, for position:fixed) of a
+  // memento's imperative map marker, if the map + marker for it exist yet.
+  function markerScreenPos(memento: Memento) {
+    if (!map || !mapContainer || !markers.has(memento.id)) return undefined
+    const point = map.project(memento.coords)
+    const rect = mapContainer.getBoundingClientRect()
+    return { x: rect.left + point.x, y: rect.top + point.y }
+  }
+
+  async function selectMemento(memento: Memento, { focusHeading = true } = {}) {
+    const origin = prefersReducedMotion ? undefined : markerScreenPos(memento)
+    if (origin) {
+      // Render the ghost at the marker for one tick, then swap it out for
+      // the real stub-card in the same flush that selects the memento —
+      // crossfade pairs the ghost's out-transition with the stub-card's
+      // in-transition (same key) and morphs between their positions.
+      ghostOrigin = origin
+      ghostKind = memento.kind
+      ghostKey = memento.id
+      ghostVisible = true
+      await tick()
+      selected = memento
+      ghostVisible = false
+    } else {
+      selected = memento
+    }
     focusMap(memento)
+    if (focusHeading) await focusDetailHeading()
+  }
+
+  async function focusDetailHeading() {
+    await tick()
+    detailHeadingEl?.focus()
+  }
+
+  // "Close" in v1's always-visible 3-column layout means returning to a
+  // neutral state — the journey's first memento — and moving focus back to
+  // the index rail rather than hiding the (non-modal) detail panel.
+  async function closeDetail() {
+    if (!selectedJourney) return
+    const first = selectedJourney.mementos[0]
+    if (first && first.id !== selected?.id) {
+      await selectMemento(first, { focusHeading: false })
+    } else {
+      fitJourney(selectedJourney)
+    }
+    await tick()
+    document.querySelector<HTMLButtonElement>(".timeline-item.active")?.focus()
   }
 
   function focusMap(memento: Memento) {
@@ -255,15 +327,24 @@
         isLoading = false
       })
 
+    const motionQuery = window.matchMedia("(prefers-reduced-motion: reduce)")
+    prefersReducedMotion = motionQuery.matches
+    const onMotionChange = (event: MediaQueryListEvent) => {
+      prefersReducedMotion = event.matches
+    }
+    motionQuery.addEventListener("change", onMotionChange)
+
     return () => {
       markers.forEach((marker) => marker.remove())
       markers.clear()
       map?.remove()
+      motionQuery.removeEventListener("change", onMotionChange)
     }
   })
 </script>
 
 <main class="app-shell" class:theme-light={theme === "light"}>
+  <div class="sr-only" role="status" aria-live="polite">{liveMessage}</div>
   {#if isLoading}
     <div class="v1-status">Loading…</div>
   {:else if error}
@@ -328,18 +409,31 @@
     <!-- Map: the hero. -->
     <section class="map-stage" aria-label="Journey map">
       <div bind:this={mapContainer} class="map-canvas"></div>
+      {#if ghostVisible && ghostOrigin}
+        <div
+          class="marker-ghost map-marker map-marker--{ghostKind}"
+          style="left: {ghostOrigin.x}px; top: {ghostOrigin.y}px"
+          aria-hidden="true"
+          in:receiveStub={{ key: ghostKey }}
+          out:sendStub={{ key: ghostKey }}
+        >
+          <span>{ghostSeq}</span>
+        </div>
+      {/if}
     </section>
 
     <!-- Detail: the memento opened — paper stub + essay + gallery. -->
     <aside class="detail-panel" aria-label="Memento detail">
       {#key selected.id}
-        <div class="detail-inner" in:fade={{ duration: 220 }}>
+        <div class="detail-inner" in:fade={{ duration: prefersReducedMotion ? 0 : 220 }}>
+          <button type="button" class="detail-close" aria-label={t(uiText.close)} on:click={closeDetail}>×</button>
+
           <div class="section-head">
             <p class="eyebrow">{t(kindLabel[selected.kind])}</p>
-            <h2>{t(selected.title)}</h2>
+            <h2 tabindex="-1" bind:this={detailHeadingEl}>{t(selected.title)}</h2>
           </div>
 
-          <div class="stub-card {selected.kind}" in:fly={{ y: 12, duration: 320, delay: 60 }}>
+          <div class="stub-card {selected.kind}" in:receiveStub={{ key: selected.id }} out:sendStub={{ key: selected.id }}>
             {#if selected.kind === "transit" && selected.transit}
               <div class="ticket-face">
                 <div class="ticket-line">


### PR DESCRIPTION
## Summary

Advances #15 (memento open/essay/gallery flow) and #32 (responsive/locale/a11y polish) against the current default public reader (`apps/web-public/src/v1/V1App.svelte`).

- **Shared-element morph**, per [ADR-0031](https://github.com/azusachino/felicia/blob/main/docs/adr/0031-frontend-style-map-first-and-shared-element-open.md): the plain `fade`/`fly` detail-panel entrance is replaced with a `crossfade` pair. Since the clicked map marker is an imperative, non-Svelte MapLibre element, a transient "ghost" positioned via `map.project()` stands in as the crossfade's origin — the marker visibly grows into the full paper stub in the detail panel.
- **Close/return control**: v1's always-visible 3-column layout has no modal to dismiss, so closing returns to the journey's first memento and moves focus back to the active rail item.
- **`prefers-reduced-motion`**: collapses the morph/fade durations to 0 and skips the ghost dance entirely.
- **A11y**: an `aria-live="polite"` region announces the selected memento; focus moves to the detail heading after a marker/timeline selection.

**Correcting an earlier audit finding**: essay typography, captions, and gallery were already adequate on inspection — untouched here. The claim "v1 has zero `@media` rules" (used to justify #32 as still open) was a false negative: it only checked `V1App.svelte`'s own near-empty `<style>` block, missing that v1's real CSS — including a working `@media (max-width: 1000px)` breakpoint — lives in the shared `index.css`.

**Deliberately out of scope**: the larger ADR-0031 layout fork (map-first, fixed entry). None of the four current reader designs (v1–v4) match that decision yet; building the reader that does is separate, larger follow-up work — this PR only touches the open-interaction/close/motion/a11y layer within v1's existing layout.

## Test plan

- [x] `make web-check` (svelte-check + eslint + prettier) — green, verified independently in the containerized nix devshell (not just the implementing agent's self-report)
- [x] Manual code review of the crossfade key-pairing logic (ghost `out` / stub-card `in`, same `selected.id` key) and the reduced-motion/focus-management paths
- [ ] **Not done**: live browser verification of the actual animation. This sandbox has no local Bun toolchain or a running API server to preview against, and standing one up (nix-container build + a host-side static preview) was a bigger lift than this change's scope — flagging honestly rather than claiming a visual check that didn't happen. Happy to set this up if a reviewer wants to see it move before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)