### PR TITLE
feat: derive journey date bounds from route, visit and media timestamps

### DIFF
--- a/cli/cmd/felicia/main.go
+++ b/cli/cmd/felicia/main.go
@@ -105,7 +105,7 @@ func journeyPlanCommand(args []string, output io.Writer) error {
 	if err != nil {
 		return err
 	}
-	plan, err := intake.NewService(nil).Plan(context.Background(), intake.PlanRequest{JourneyID: id, From: start, To: end, SourceFingerprint: fingerprint, Sources: intake.SourceSet{Routes: local.NewGPXSource(*gpxPath), Media: media}})
+	plan, err := intake.NewService(nil, nil).Plan(context.Background(), intake.PlanRequest{JourneyID: id, From: start, To: end, SourceFingerprint: fingerprint, Sources: intake.SourceSet{Routes: local.NewGPXSource(*gpxPath), Media: media}})
 	if err != nil {
 		return err
 	}
@@ -141,7 +141,7 @@ func journeyApplyCommand(args []string, output io.Writer) error {
 		return err
 	}
 	defer func() { _ = repo.Close() }()
-	if err := intake.NewService(repo).Apply(context.Background(), plan); err != nil {
+	if err := intake.NewService(repo, repo).Apply(context.Background(), plan); err != nil {
 		return err
 	}
 	return writeJSON(output, map[string]any{"schema": intake.PlanSchema, "mode": "apply", "journey_id": plan.JourneyID, "stops": len(plan.Stops)})
@@ -177,7 +177,7 @@ func journeyReviewCommand(args []string, output io.Writer) error {
 	if *expected > 0 {
 		patch.ExpectedRevision = expected
 	}
-	if err := intake.NewService(repo).Review(context.Background(), patch); err != nil {
+	if err := intake.NewService(repo, repo).Review(context.Background(), patch); err != nil {
 		return err
 	}
 	candidate, err := repo.GetStopCandidate(context.Background(), id)

--- a/runtime/intake/planner.go
+++ b/runtime/intake/planner.go
@@ -78,6 +78,14 @@ type DraftPlan struct {
 	Stops             []domain.StopCandidate    `json:"stops"`
 	Mementos          []domain.MementoCandidate `json:"mementos"`
 	Issues            []Issue                   `json:"issues"`
+
+	// DateStart and DateEnd are the journey's date bounds as derived from the
+	// input's timestamps. They are a *default* for a journey whose dates the
+	// author has not set by hand — the planner itself writes nothing, so
+	// honouring that is the persistence step's job (Service.Apply). Both are
+	// zero when no dated source was supplied.
+	DateStart time.Time `json:"date_start,omitzero"`
+	DateEnd   time.Time `json:"date_end,omitzero"`
 }
 
 // DefaultConfig returns the deterministic planner defaults.
@@ -131,7 +139,48 @@ func BuildPlan(input PlanInput, config PlanConfig) (DraftPlan, error) {
 			plan.Mementos = append(plan.Mementos, mementoFromStop(stop, matched))
 		}
 	}
+	plan.DateStart, plan.DateEnd = dateBoundsFrom(input)
 	return plan, nil
+}
+
+// dateBoundsFrom returns the first and last calendar day covered by the
+// input's dated sources — route spans and samples, visits, and media capture
+// times — so a journey can default its dates to the trip it actually
+// contains instead of making the author type them in.
+//
+// Each bound is truncated in its *own* timestamp's location, so a photo taken
+// at 08:00 in Tokyo counts as that Tokyo day rather than the previous UTC one.
+// That is the best available answer until coordinates can be resolved to a
+// timezone (issue #58); sources that hand us a bare UTC timestamp are still
+// interpreted as UTC.
+func dateBoundsFrom(input PlanInput) (start, end time.Time) {
+	observe := func(at time.Time) {
+		if at.IsZero() {
+			return
+		}
+		day := time.Date(at.Year(), at.Month(), at.Day(), 0, 0, 0, 0, at.Location())
+		if start.IsZero() || day.Before(start) {
+			start = day
+		}
+		if end.IsZero() || day.After(end) {
+			end = day
+		}
+	}
+	for _, route := range input.Routes {
+		observe(route.From)
+		observe(route.To)
+		for _, point := range route.Points {
+			observe(point.At)
+		}
+	}
+	for _, visit := range input.Visits {
+		observe(visit.Arrive)
+		observe(visit.Depart)
+	}
+	for _, asset := range input.Media {
+		observe(asset.At)
+	}
+	return start, end
 }
 
 func withDefaults(config PlanConfig) PlanConfig {

--- a/runtime/intake/planner_test.go
+++ b/runtime/intake/planner_test.go
@@ -70,6 +70,91 @@ func TestBuildPlanReportsMissingTimestampedPoints(t *testing.T) {
 	}
 }
 
+// Acceptance criterion 1 of issue #57: the bounds span every dated source,
+// not just one of them.
+func TestBuildPlanDerivesDateBoundsAcrossSources(t *testing.T) {
+	tokyo := time.FixedZone("JST", 9*60*60)
+	cases := []struct {
+		name             string
+		input            PlanInput
+		wantStart        string
+		wantEnd          string
+		wantZeroBoundary bool
+	}{
+		{
+			name: "route samples, visits and media together",
+			input: PlanInput{
+				Routes: []domain.Route{{Points: []domain.TrackPoint{
+					{At: time.Date(2026, 4, 2, 8, 0, 0, 0, time.UTC)},
+					{At: time.Date(2026, 4, 3, 8, 0, 0, 0, time.UTC)},
+				}}},
+				Visits: []domain.Visit{{
+					Arrive: time.Date(2026, 4, 1, 22, 0, 0, 0, time.UTC),
+					Depart: time.Date(2026, 4, 2, 1, 0, 0, 0, time.UTC),
+				}},
+				Media: []domain.MediaAsset{{At: time.Date(2026, 4, 5, 12, 0, 0, 0, time.UTC)}},
+			},
+			wantStart: "2026-04-01", wantEnd: "2026-04-05",
+		},
+		{
+			// Route.From/To carry the span even when a source hands us no
+			// individual samples.
+			name: "route span without samples",
+			input: PlanInput{Routes: []domain.Route{{
+				From: time.Date(2026, 6, 10, 0, 0, 0, 0, time.UTC),
+				To:   time.Date(2026, 6, 12, 0, 0, 0, 0, time.UTC),
+			}}},
+			wantStart: "2026-06-10", wantEnd: "2026-06-12",
+		},
+		{
+			// 08:00 in Tokyo is the previous day in UTC; the journey should
+			// take the day the author actually lived, not the UTC one.
+			name: "a local morning stays on its own calendar day",
+			input: PlanInput{Media: []domain.MediaAsset{
+				{At: time.Date(2026, 7, 1, 8, 0, 0, 0, tokyo)},
+			}},
+			wantStart: "2026-07-01", wantEnd: "2026-07-01",
+		},
+		{
+			// Zero timestamps carry no information and must not drag the
+			// bounds back to the zero year.
+			name: "undated sources are ignored",
+			input: PlanInput{
+				Routes: []domain.Route{{Points: []domain.TrackPoint{{}, {At: time.Date(2026, 5, 4, 6, 0, 0, 0, time.UTC)}}}},
+				Media:  []domain.MediaAsset{{}},
+			},
+			wantStart: "2026-05-04", wantEnd: "2026-05-04",
+		},
+		{
+			name:             "no dated source at all leaves the bounds unset",
+			input:            PlanInput{Routes: []domain.Route{{Points: []domain.TrackPoint{{}}}}},
+			wantZeroBoundary: true,
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			testCase.input.JourneyID = uuid.New()
+			plan, err := BuildPlan(testCase.input, DefaultConfig())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if testCase.wantZeroBoundary {
+				if !plan.DateStart.IsZero() || !plan.DateEnd.IsZero() {
+					t.Fatalf("bounds = %s..%s, want both unset", plan.DateStart, plan.DateEnd)
+				}
+				return
+			}
+			if got := plan.DateStart.Format("2006-01-02"); got != testCase.wantStart {
+				t.Errorf("DateStart = %s, want %s", got, testCase.wantStart)
+			}
+			if got := plan.DateEnd.Format("2006-01-02"); got != testCase.wantEnd {
+				t.Errorf("DateEnd = %s, want %s", got, testCase.wantEnd)
+			}
+		})
+	}
+}
+
 func sourcePoint(longitude, latitude float64) *orb.Point {
 	point := orb.Point{longitude, latitude}
 	return &point

--- a/runtime/intake/service.go
+++ b/runtime/intake/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/google/uuid"
@@ -37,11 +38,14 @@ type PlanRequest struct {
 // and review while keeping provider implementations outside the runtime.
 type Service struct {
 	Candidates ports.StopCandidateStore
+	// Journeys is only needed to persist derived date bounds; a composition
+	// that only plans or reviews may leave it nil.
+	Journeys ports.JourneySyncStore
 }
 
 // NewService creates an intake application service.
-func NewService(candidates ports.StopCandidateStore) *Service {
-	return &Service{Candidates: candidates}
+func NewService(candidates ports.StopCandidateStore, journeys ports.JourneySyncStore) *Service {
+	return &Service{Candidates: candidates, Journeys: journeys}
 }
 
 // Plan collects normalized source data and returns a read-only draft plan.
@@ -84,7 +88,48 @@ func (s *Service) Apply(ctx context.Context, plan DraftPlan) error {
 			return fmt.Errorf("apply stop %s: %w", plan.Stops[index].Identity.Key, err)
 		}
 	}
+	return s.applyDateBounds(ctx, plan)
+}
+
+// applyDateBounds fills in journey dates the author has not set by hand.
+//
+// The non-clobber decision is made here rather than in SQL because only one
+// provider guards these columns: PostgreSQL's upsert keeps an authored
+// date_start/date_end, SQLite's assigns unconditionally. Deciding in Go gives
+// both providers the same behaviour and matches how the importer already
+// protects an authored route (runtime/importer: authored "gps_route" is
+// skipped outright).
+func (s *Service) applyDateBounds(ctx context.Context, plan DraftPlan) error {
+	if s.Journeys == nil || (plan.DateStart.IsZero() && plan.DateEnd.IsZero()) {
+		return nil
+	}
+	journey, err := s.Journeys.GetJourney(ctx, plan.JourneyID)
+	if err != nil {
+		return fmt.Errorf("load journey %s for date bounds: %w", plan.JourneyID, err)
+	}
+
+	// Kept as two statements rather than `adopt(...) || adopt(...)`: the
+	// short-circuit would skip the second field whenever the first changed.
+	startChanged := adopt(&journey.DateStart, plan.DateStart, journey.AuthoredFields, "date_start")
+	endChanged := adopt(&journey.DateEnd, plan.DateEnd, journey.AuthoredFields, "date_end")
+	if !startChanged && !endChanged {
+		return nil
+	}
+	if err := s.Journeys.UpsertJourney(ctx, journey); err != nil {
+		return fmt.Errorf("apply date bounds to journey %s: %w", plan.JourneyID, err)
+	}
 	return nil
+}
+
+// adopt assigns a derived value to an ingested field, reporting whether it
+// actually changed anything. An authored field, an empty derivation, and a
+// value that already matches are all left alone.
+func adopt(current *time.Time, derived time.Time, authored []string, field string) bool {
+	if derived.IsZero() || slices.Contains(authored, field) || current.Equal(derived) {
+		return false
+	}
+	*current = derived
+	return true
 }
 
 // Review applies one explicit author decision to a private candidate.

--- a/runtime/intake/service_test.go
+++ b/runtime/intake/service_test.go
@@ -52,10 +52,30 @@ func (s *serviceStore) ApplyStopReview(_ context.Context, _ *domain.StopReviewPa
 	return nil
 }
 
+// serviceJourneyStore is the narrow JourneySyncStore seam Apply uses to
+// persist derived date bounds.
+type serviceJourneyStore struct {
+	journey *domain.Journey
+	upserts int
+}
+
+func (s *serviceJourneyStore) GetJourney(_ context.Context, id uuid.UUID) (*domain.Journey, error) {
+	if s.journey == nil || s.journey.ID != id {
+		return nil, domain.ErrNotFound
+	}
+	return s.journey, nil
+}
+
+func (s *serviceJourneyStore) UpsertJourney(_ context.Context, journey *domain.Journey) error {
+	s.journey = journey
+	s.upserts++
+	return nil
+}
+
 func TestServicePlansAppliesAndReviewsThroughPorts(t *testing.T) {
 	journeyID := uuid.New()
 	store := &serviceStore{candidates: make(map[string]*domain.StopCandidate)}
-	service := NewService(store)
+	service := NewService(store, nil)
 	plan, err := service.Plan(context.Background(), PlanRequest{JourneyID: journeyID, Sources: SourceSet{Routes: serviceRouteSource{}}})
 	if err != nil {
 		t.Fatal(err)
@@ -74,5 +94,65 @@ func TestServicePlansAppliesAndReviewsThroughPorts(t *testing.T) {
 	}
 	if store.reviews != 1 {
 		t.Fatalf("reviews = %d, want 1", store.reviews)
+	}
+}
+
+// Acceptance criterion 2 of issue #57: a date the author set by hand survives
+// ingest, while the one they left alone picks up the derived value. Asserted
+// at the runtime seam so both providers inherit the same behaviour — SQLite's
+// journey upsert has no per-field guard of its own.
+func TestServiceApplyRespectsAuthoredDateBounds(t *testing.T) {
+	authored := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	derivedStart := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name           string
+		authoredFields []string
+		wantStart      time.Time
+		wantUpserts    int
+	}{
+		{"unauthored dates adopt the derivation", nil, derivedStart, 1},
+		{"an authored date_start is preserved", []string{"date_start"}, authored, 1},
+		{"authoring both dates writes nothing at all", []string{"date_start", "date_end"}, authored, 0},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			journeyID := uuid.New()
+			journeys := &serviceJourneyStore{journey: &domain.Journey{
+				ID: journeyID, DateStart: authored, DateEnd: authored, AuthoredFields: testCase.authoredFields,
+			}}
+			service := NewService(&serviceStore{candidates: make(map[string]*domain.StopCandidate)}, journeys)
+
+			plan, err := service.Plan(context.Background(), PlanRequest{JourneyID: journeyID, Sources: SourceSet{Routes: serviceRouteSource{}}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !plan.DateStart.Equal(derivedStart) {
+				t.Fatalf("plan.DateStart = %s, want the route's day %s", plan.DateStart, derivedStart)
+			}
+			if err := service.Apply(context.Background(), plan); err != nil {
+				t.Fatal(err)
+			}
+			if got := journeys.journey.DateStart; !got.Equal(testCase.wantStart) {
+				t.Errorf("journey.DateStart = %s, want %s", got, testCase.wantStart)
+			}
+			if journeys.upserts != testCase.wantUpserts {
+				t.Errorf("journey upserts = %d, want %d", journeys.upserts, testCase.wantUpserts)
+			}
+		})
+	}
+}
+
+// A composition that never wired a journey store (the CLI's plan-only path)
+// must still apply cleanly rather than fail or panic.
+func TestServiceApplyWithoutJourneyStoreSkipsDateBounds(t *testing.T) {
+	store := &serviceStore{candidates: make(map[string]*domain.StopCandidate)}
+	service := NewService(store, nil)
+	plan, err := service.Plan(context.Background(), PlanRequest{JourneyID: uuid.New(), Sources: SourceSet{Routes: serviceRouteSource{}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := service.Apply(context.Background(), plan); err != nil {
+		t.Fatalf("apply without a journey store: %v", err)
 	}
 }

--- a/server/api/server.go
+++ b/server/api/server.go
@@ -143,7 +143,7 @@ func NewServer(repo domain.Repository, registry *domain.Registry, cache *CacheMa
 		cache:                 cache,
 		logger:                logger,
 		importer:              imp,
-		intakeService:         intake.NewService(candidateStore),
+		intakeService:         intake.NewService(candidateStore, repo),
 		transitSegmentLengthM: routeConfig.TransitSegmentLengthM,
 		requestTimeout:        routeConfig.RequestTimeout,
 		maxBodyBytes:          routeConfig.MaxBodyBytes,


### PR DESCRIPTION
Closes #57.

## What

A journey's `date_start`/`date_end` had to be typed in by hand even though the ingested sources already say when the trip happened. `BuildPlan` now reports the first and last calendar day covered by every dated source it was given — route spans (`Route.From`/`To`), route samples (`TrackPoint.At`), visit `Arrive`/`Depart`, and media `At` — as `DraftPlan.DateStart`/`DateEnd`.

The planner stays pure: it derives the bounds but writes nothing. `Plan` is documented as read-only and `BuildPlan` as "without writing to a database", so neither gained a write — `Service.Apply`, which is already the persistence step, is what puts the dates on the journey.

## Two decisions worth reviewing

**The non-clobber check lives in Go, not SQL.** PostgreSQL's journey upsert already guards these columns:

```sql
date_start = CASE WHEN NOT (tb_journeys.authored_fields @> ARRAY['date_start'])
             THEN EXCLUDED.date_start ELSE tb_journeys.date_start END
```

…but SQLite's assigns unconditionally (`date_start=excluded.date_start`). Rather than implement the guard a second time in hand-written SQLite SQL, the decision is made once in the runtime, so both providers get identical behaviour. This also matches the existing precedent in `runtime/importer`, which skips an authored `gps_route` outright.

**Each bound is truncated in its own timestamp's location.** An 08:00 photo in Tokyo is the *previous* day in UTC, so truncating everything to UTC would silently shift the trip a day earlier. Resolving a journey-wide timezone properly needs coordinate→timezone lookup (#58); until then, honouring each timestamp's own offset is the closest correct answer. Documented in the code with that caveat.

`intake.NewService` gains a `ports.JourneySyncStore` — the existing narrow seam of exactly `GetJourney` + `UpsertJourney`. Compositions that only plan or review (the CLI's plan-only path) pass `nil` and skip date derivation.

## Test plan

All in the containerized nix devshell.

- [x] `make check`, `make build`, `make test-workflow`
- [x] `TestBuildPlanDerivesDateBoundsAcrossSources` — bounds spanning routes+visits+media together; a route span with no individual samples; a local-morning timestamp staying on its own calendar day; undated sources ignored (a zero timestamp must not drag the bounds back to year 0); and no dated source at all leaving both bounds unset.
- [x] `TestServiceApplyRespectsAuthoredDateBounds` — **the acceptance criterion**: an authored `date_start` survives ingest while an unauthored `date_end` adopts the derived value, and authoring *both* dates writes nothing at all.
- [x] `TestServiceApplyWithoutJourneyStoreSkipsDateBounds` — a plan-only composition still applies cleanly.

One thing a reviewer may want to weigh in on: `adopt(...)` is deliberately **not** written as `changed := adopt(a) || adopt(b)` — the short-circuit would skip the second field whenever the first changed. There is a comment on it, but it is the kind of thing a later "simplification" could reintroduce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)