### PR TITLE
feat: give each memento kind its own paper material in the v1 reader

### DIFF
--- a/apps/web-public/src/index.css
+++ b/apps/web-public/src/index.css
@@ -70,6 +70,7 @@ button {
   --accent-ink: var(--accent, #fdba74);
   --ctrl-bg: rgba(15, 23, 42, 0.82);
   --ctrl-invert: 1;
+  --stub-shade: rgba(0, 0, 0, 0.5);
 }
 
 .app-shell.theme-light {
@@ -86,6 +87,7 @@ button {
   --accent-ink: var(--accent, #ea580c);
   --ctrl-bg: rgba(255, 255, 255, 0.92);
   --ctrl-invert: 0;
+  --stub-shade: rgba(60, 40, 20, 0.3);
 }
 
 /* Visually hidden but screen-reader-audible — used for live-region
@@ -383,6 +385,8 @@ button {
   @apply flex justify-between border-t border-black/20 pt-3 font-semibold;
 }
 
+/* v2's generic stamp/goods faces. v1 renders a designed material per kind
+   instead — see "v1 per-kind stub materials" below. */
 .goods-face {
   background: linear-gradient(135deg, #fef3c7, #fb7185 48%, #7c3aed);
   color: #241203;
@@ -410,6 +414,372 @@ button {
 
 .stamp-face strong {
   @apply border-y-4 border-red-700 py-5 text-center text-red-800;
+}
+
+/* v1 per-kind stub materials ---------------------------------------------------
+   Warm paper is the system: every kind is a designed paper object and the kind
+   is read from form and material, never from a coloured pill. `transit` keeps
+   `.ticket-face` above unchanged — it is the exemplar the other five are
+   siblings of. Warm in both themes, like the ticket.
+
+   Three of them are genuinely *cut*: the swing tag's hole, the receipt's torn
+   hem and the admission perforation are clip-path/mask cut-outs in the
+   silhouette, not lines drawn on a rectangle. That means the card can no longer
+   draw a rounded box + rectangular shadow behind them; the shadow moves onto
+   the card as a filter so it follows the real edge. */
+
+.stub-card:has(.tag-face),
+.stub-card:has(.thermal-face),
+.stub-card:has(.admission-face) {
+  overflow: visible;
+  border-radius: 0;
+  box-shadow: none;
+  filter: drop-shadow(0 0.75rem 1.4rem var(--stub-shade));
+}
+
+/* stamp — ink on washi ------------------------------------------------------ */
+
+.washi-face {
+  @apply relative min-h-48 py-6 pl-6 pr-28;
+  background-color: #f1ebdd;
+  /* Paper tooth: two crossed fibre rulings plus an uneven sheet tone. */
+  background-image:
+    repeating-linear-gradient(91deg, rgba(122, 92, 48, 0.055) 0 1px, transparent 1px 6px), repeating-linear-gradient(2deg, rgba(122, 92, 48, 0.04) 0 1px, transparent 1px 9px),
+    radial-gradient(120% 90% at 12% 0%, rgba(255, 253, 246, 0.9), transparent 62%), radial-gradient(90% 80% at 100% 100%, rgba(168, 138, 88, 0.22), transparent 72%);
+  color: #241a10;
+}
+
+.washi-seal {
+  @apply absolute grid h-[4.4rem] w-[4.4rem] place-items-center text-lg font-bold leading-none;
+  top: 1.3rem;
+  right: 1.3rem;
+  background: #b0342a;
+  border: 0.2rem solid #b0342a;
+  /* The paper-coloured gutter inside the frame is what makes it read as a seal. */
+  box-shadow: inset 0 0 0 0.09rem rgba(242, 236, 223, 0.92);
+  color: #f6efe0;
+  letter-spacing: 0.1em;
+  writing-mode: vertical-rl;
+  text-orientation: upright;
+  transform: rotate(-1.5deg);
+}
+
+.washi-sub {
+  @apply m-0 text-xs font-semibold uppercase tracking-[0.2em];
+  color: rgba(36, 26, 16, 0.62);
+}
+
+.washi-name {
+  @apply mt-6 block font-mincho text-4xl font-black leading-tight;
+  color: #1c1208;
+  /* A hair of ink bleed — brushed rather than typeset. */
+  text-shadow: 0 0 1px rgba(28, 18, 8, 0.4);
+}
+
+.washi-deity {
+  @apply m-0 mt-3 font-mincho text-sm;
+  color: rgba(36, 26, 16, 0.72);
+}
+
+.washi-date {
+  @apply mt-5 block text-xs font-semibold tracking-[0.14em];
+  color: rgba(36, 26, 16, 0.55);
+}
+
+/* goods — kraft swing tag --------------------------------------------------- */
+
+.tag-face {
+  @apply relative flex min-h-48 flex-col px-6 pb-6 pt-14;
+  background-color: #c29a68;
+  background-image:
+    repeating-linear-gradient(114deg, rgba(74, 46, 18, 0.07) 0 2px, transparent 2px 9px), repeating-linear-gradient(-38deg, rgba(255, 247, 233, 0.09) 0 1px, transparent 1px 6px),
+    radial-gradient(120% 70% at 50% 0%, rgba(246, 226, 192, 0.55), transparent 58%), radial-gradient(90% 80% at 100% 100%, rgba(66, 40, 14, 0.2), transparent 70%);
+  color: #35200c;
+  /* Clipped shoulders give the swing-tag silhouette… */
+  clip-path: polygon(1.5rem 0, calc(100% - 1.5rem) 0, 100% 1.5rem, 100% 100%, 0 100%, 0 1.5rem);
+  /* …and the string hole is punched clean through the tag and its eyelet. */
+  mask-image: radial-gradient(circle at 50% 1.65rem, transparent 0 0.36rem, #000 0.42rem);
+  mask-repeat: no-repeat;
+}
+
+.tag-eyelet {
+  @apply pointer-events-none absolute h-6 w-6 rounded-full;
+  top: 0.9rem;
+  left: 50%;
+  margin-left: -0.75rem;
+  background: radial-gradient(circle at 35% 30%, #f4ead8, #9b8360 55%, #6b5636);
+  box-shadow: 0 0.05rem 0.12rem rgba(40, 24, 8, 0.5);
+}
+
+.tag-kind {
+  @apply m-0 text-[0.68rem] font-bold uppercase tracking-[0.22em];
+  color: rgba(53, 32, 12, 0.68);
+}
+
+.tag-name {
+  @apply mt-3 block text-3xl font-black leading-tight;
+  color: #2a190a;
+}
+
+.tag-source {
+  @apply m-0 mt-2 text-sm font-semibold;
+  color: rgba(53, 32, 12, 0.75);
+}
+
+.tag-foot {
+  @apply mt-auto flex items-baseline justify-between gap-3 pt-4 text-xs font-semibold uppercase tracking-[0.16em];
+  border-top: 1px solid rgba(66, 40, 14, 0.35);
+  color: rgba(53, 32, 12, 0.72);
+}
+
+.tag-foot b {
+  @apply text-base tracking-normal;
+  color: #2a190a;
+}
+
+/* receipt — thermal roll ----------------------------------------------------- */
+
+.thermal-face {
+  /* A zigzag tile is contiguous when its width ≈ 1.93 × its depth. */
+  --tear: 0.5rem;
+  --zig: 0.96rem;
+
+  @apply relative mx-auto flex w-full max-w-[17.5rem] flex-col gap-3 px-5 pb-8 pt-6 text-sm;
+  background-color: #f4f1e7;
+  background-image: linear-gradient(180deg, rgba(255, 253, 246, 0.78), rgba(228, 219, 200, 0.6)), repeating-linear-gradient(0deg, rgba(58, 47, 28, 0.035) 0 1px, transparent 1px 4px);
+  color: #2b2418;
+  font-family: "Share Tech Mono", ui-monospace, SFMono-Regular, monospace;
+  /* Body, plus a row of downward wedges that really removes the bottom hem. */
+  mask-image: linear-gradient(#000 0 0), conic-gradient(from 135deg at top, #0000, #000 1deg 89deg, #0000 90deg);
+  mask-size:
+    100% calc(100% - var(--tear)),
+    var(--zig) var(--tear);
+  mask-position:
+    top left,
+    bottom left;
+  mask-repeat: no-repeat, repeat-x;
+}
+
+.thermal-head {
+  @apply flex flex-col items-center gap-1 text-center;
+}
+
+.thermal-head strong {
+  @apply text-lg font-normal uppercase leading-tight tracking-[0.2em];
+}
+
+.thermal-head span {
+  @apply text-[0.7rem] uppercase tracking-[0.16em];
+  color: rgba(43, 36, 24, 0.62);
+}
+
+.thermal-rule {
+  @apply h-0;
+  border-top: 1px dashed rgba(43, 36, 24, 0.45);
+}
+
+.thermal-items {
+  @apply m-0 flex list-none flex-col p-0 text-[0.8rem];
+}
+
+.thermal-items li {
+  @apply flex justify-between gap-3 py-1;
+  border-bottom: 1px dotted rgba(43, 36, 24, 0.28);
+}
+
+.thermal-date {
+  color: rgba(43, 36, 24, 0.66);
+}
+
+/* No label: a double rule with the sum right-aligned under it is how a till
+   roll says "total" in any language. */
+.thermal-total {
+  @apply flex justify-end pt-3;
+  border-top: 3px double rgba(43, 36, 24, 0.55);
+}
+
+.thermal-total b {
+  @apply text-xl font-normal;
+}
+
+.thermal-code {
+  /* Three periods that never line up — irregular bars, not a hatch. */
+  @apply h-9 w-full;
+  background-image:
+    repeating-linear-gradient(90deg, #241a10 0 2px, transparent 2px 5px), repeating-linear-gradient(90deg, #241a10 0 1px, transparent 1px 4px),
+    repeating-linear-gradient(90deg, #241a10 0 3px, transparent 3px 11px);
+}
+
+.thermal-foot {
+  @apply m-0 text-center text-[0.68rem] uppercase tracking-[0.2em];
+  color: rgba(43, 36, 24, 0.62);
+}
+
+/* live — admission stock ------------------------------------------------------ */
+
+.admission-face {
+  --perf: 6.75rem;
+  --notch: 0.5rem;
+
+  @apply relative grid min-h-52;
+  grid-template-columns: minmax(0, 1fr) var(--perf);
+  background-color: #f0e2c4;
+  background-image:
+    radial-gradient(120% 100% at 0% 0%, rgba(255, 249, 233, 0.95), transparent 60%), repeating-linear-gradient(45deg, rgba(120, 82, 30, 0.05) 0 1px, transparent 1px 5px),
+    repeating-linear-gradient(-45deg, rgba(120, 82, 30, 0.05) 0 1px, transparent 1px 5px);
+  box-shadow: inset 0 0 0 1px rgba(80, 52, 18, 0.32);
+  color: #33230f;
+  /* Notches genuinely bitten out of the top and bottom edge at the perforation. */
+  clip-path: polygon(
+    0 0,
+    calc(100% - var(--perf) - var(--notch)) 0,
+    calc(100% - var(--perf)) var(--notch),
+    calc(100% - var(--perf) + var(--notch)) 0,
+    100% 0,
+    100% 100%,
+    calc(100% - var(--perf) + var(--notch)) 100%,
+    calc(100% - var(--perf)) calc(100% - var(--notch)),
+    calc(100% - var(--perf) - var(--notch)) 100%,
+    0 100%
+  );
+  /* One full-width band, tiled down the card, holed at the perforation line —
+     the dashes are holes you can see the panel through. */
+  mask-image: radial-gradient(circle at calc(100% - var(--perf)) 50%, transparent 0 0.11rem, #000 0.15rem);
+  mask-size: 100% 0.62rem;
+  mask-repeat: repeat-y;
+}
+
+.admission-face::before {
+  @apply pointer-events-none absolute;
+  content: "";
+  inset: 0.45rem calc(var(--perf) + 0.5rem) 0.45rem 0.45rem;
+  border: 1px solid rgba(80, 52, 18, 0.28);
+}
+
+.admission-main {
+  @apply flex flex-col gap-1 py-7 pl-7 pr-5;
+}
+
+.admission-venue {
+  @apply m-0 text-[0.68rem] font-bold uppercase tracking-[0.22em];
+  color: rgba(51, 35, 15, 0.66);
+}
+
+.admission-artist {
+  @apply mt-2 block text-3xl font-black leading-tight;
+  color: #27190a;
+}
+
+.admission-meta {
+  @apply mt-auto flex flex-wrap gap-x-4 gap-y-1 pt-5 text-xs font-semibold uppercase tracking-[0.16em];
+  color: rgba(51, 35, 15, 0.78);
+}
+
+.admission-link {
+  @apply mt-2 self-start text-[0.68rem] font-bold uppercase tracking-[0.16em] underline underline-offset-4;
+  color: rgba(51, 35, 15, 0.72);
+}
+
+.admission-link:hover {
+  color: #27190a;
+}
+
+.admission-link:focus-visible {
+  outline: 2px solid #27190a;
+  outline-offset: 3px;
+}
+
+.admission-stub {
+  @apply flex flex-col items-center justify-between gap-3 py-5 pr-3 text-center;
+  /* Clear the punched perforation. */
+  padding-left: 0.85rem;
+}
+
+.admission-stub-kind,
+.admission-stub-seat {
+  @apply text-[0.6rem] font-bold uppercase tracking-[0.2em];
+  color: rgba(51, 35, 15, 0.62);
+}
+
+.admission-stub-name {
+  @apply min-h-0 overflow-hidden text-sm font-bold leading-none;
+  color: #27190a;
+  writing-mode: vertical-rl;
+  letter-spacing: 0.1em;
+}
+
+/* souvenir — postcard back ------------------------------------------------------ */
+
+.postcard-face {
+  @apply relative grid min-h-52;
+  grid-template-columns: minmax(0, 1.35fr) minmax(0, 0.9fr);
+  background-color: #f3ecdc;
+  background-image: radial-gradient(120% 100% at 100% 0%, rgba(255, 252, 244, 0.92), transparent 55%), repeating-linear-gradient(0deg, rgba(90, 66, 32, 0.03) 0 1px, transparent 1px 3px);
+  color: #2f2415;
+}
+
+.postcard-note {
+  @apply flex flex-col gap-3 p-5 font-spectral;
+}
+
+.postcard-dateline {
+  @apply m-0 text-[0.7rem] font-semibold uppercase tracking-[0.18em];
+  color: rgba(47, 36, 21, 0.6);
+}
+
+.postcard-message {
+  @apply m-0 text-[0.95rem] italic leading-7;
+  color: rgba(47, 36, 21, 0.88);
+}
+
+/* An unwritten postcard is still a postcard: rule the message area rather than
+   leave a blank half when `note` was never authored. */
+.postcard-rules {
+  @apply mt-1 block h-24 w-full;
+  background-image: repeating-linear-gradient(180deg, transparent 0 1.45rem, rgba(70, 50, 24, 0.16) 1.45rem 1.5rem);
+}
+
+.postcard-address {
+  @apply relative flex flex-col gap-2 p-5 pt-24;
+  /* The divider down the middle is the postcard's whole tell. */
+  border-left: 1px solid rgba(70, 50, 24, 0.38);
+}
+
+.postcard-address strong {
+  @apply block pb-1 text-xl font-semibold leading-tight;
+  border-bottom: 1px solid rgba(70, 50, 24, 0.22);
+}
+
+.postcard-address span {
+  @apply block pb-1 text-sm;
+  border-bottom: 1px solid rgba(70, 50, 24, 0.22);
+  color: rgba(47, 36, 21, 0.72);
+}
+
+.postcard-stamp {
+  @apply absolute grid h-[3.8rem] w-[3.1rem] place-items-center text-lg;
+  top: 1.1rem;
+  right: 1.1rem;
+  z-index: 1;
+  background: rgba(255, 253, 247, 0.9);
+  border: 0.16rem dotted rgba(70, 50, 24, 0.42);
+  color: rgba(47, 36, 21, 0.5);
+}
+
+.postcard-postmark {
+  @apply pointer-events-none absolute h-[3.4rem] w-[3.4rem] rounded-full;
+  top: 0.5rem;
+  right: 2.6rem;
+  z-index: 2;
+  border: 1.5px solid rgba(70, 50, 24, 0.55);
+  transform: rotate(-14deg);
+}
+
+.postcard-postmark::after {
+  @apply absolute rounded-full;
+  content: "";
+  inset: 0.3rem;
+  border: 1px solid rgba(70, 50, 24, 0.42);
 }
 
 /* Essay + gallery --------------------------------------------------------- */

--- a/apps/web-public/src/v1/V1App.svelte
+++ b/apps/web-public/src/v1/V1App.svelte
@@ -48,6 +48,38 @@
 
   $: t = (value: L | MessageKey) => (typeof value === "string" ? message(lang, value) : value[lang])
   $: stationName = (s: Station) => (lang === "en" ? s.name : s.ja)
+
+  // kind_data is the template registry's untyped bag (ADR-0006): read it
+  // defensively so a memento authored with only its required field still
+  // renders a deliberate stub rather than an empty box.
+  $: kindText = (key: string): string => {
+    const value = selected?.kindData?.[key]
+    return typeof value === "string" ? value.trim() : ""
+  }
+  // `station` / `venue` fields carry `{ name, coords }` rather than a bare string.
+  $: kindName = (key: string): string => {
+    const value = selected?.kindData?.[key]
+    if (typeof value === "string") return value.trim()
+    if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+      const name = (value as Record<string, unknown>).name
+      if (typeof name === "string") return name.trim()
+    }
+    return ""
+  }
+  // Receipt `items` is authored as free text; accept a list too.
+  $: kindLines = (key: string): string[] => {
+    const value = selected?.kindData?.[key]
+    const raw: unknown[] = Array.isArray(value) ? value : kindText(key).split("\n")
+    return raw.map((line) => (typeof line === "string" ? line.trim() : "")).filter(Boolean)
+  }
+
+  function linkHost(url: string): string {
+    try {
+      return new URL(url).host
+    } catch {
+      return ""
+    }
+  }
   $: selectedJourney = journeys.find((j) => j.id === selectedJourneyId) ?? journeys[0]
   $: countLabel = (n: number) => (lang === "en" ? `${n} mementos` : `${n}件`)
   $: liveMessage = selected ? `${t(kindLabel[selected.kind])}: ${t(selected.title)}` : ""
@@ -451,18 +483,93 @@
                 </div>
               </div>
             {:else if selected.kind === "stamp"}
-              <div class="stamp-face">
-                <span>御朱印</span>
-                <strong>{t(selected.place)}</strong>
-                <small>{t(selected.date)}</small>
+              <!-- 御朱印 — ink on washi; the vermilion seal block is the signature. -->
+              <div class="washi-face">
+                <span class="washi-seal" aria-hidden="true">御朱印</span>
+                <p class="washi-sub">{kindText("shrine_or_temple") || t(selected.place)}</p>
+                <strong class="washi-name">{kindText("name") || t(selected.title)}</strong>
+                {#if kindText("deity")}
+                  <p class="washi-deity">{kindText("deity")}</p>
+                {/if}
+                <small class="washi-date">{t(selected.date)}</small>
+              </div>
+            {:else if selected.kind === "receipt"}
+              <!-- Thermal roll — narrow measure, monospace, genuinely torn hem. -->
+              <div class="thermal-face">
+                <div class="thermal-head">
+                  <strong>{kindText("shop") || t(selected.vendor) || t(selected.title)}</strong>
+                  <span>{t(selected.place)}</span>
+                </div>
+                <div class="thermal-rule"></div>
+                <ul class="thermal-items">
+                  <li class="thermal-date"><span>{t(selected.date)}</span></li>
+                  {#each kindLines("items") as item, index (`${item}:${index}`)}
+                    <li><span>{item}</span></li>
+                  {/each}
+                </ul>
+                <div class="thermal-total">
+                  <b>{selected.price || kindText("total")}</b>
+                </div>
+                <div class="thermal-code" aria-hidden="true"></div>
+                <p class="thermal-foot">{t(selected.title)}</p>
+              </div>
+            {:else if selected.kind === "live"}
+              <!-- Admission stock — the tear-off stub is cut out of the card. -->
+              <div class="admission-face">
+                <div class="admission-main">
+                  <p class="admission-venue">{kindName("venue") || t(selected.place)}</p>
+                  <strong class="admission-artist">{kindText("artist") || t(selected.title)}</strong>
+                  <div class="admission-meta">
+                    <span>{t(selected.date)}</span>
+                    {#if kindText("seat")}
+                      <span>{kindText("seat")}</span>
+                    {/if}
+                  </div>
+                  {#if linkHost(kindText("setlist_url"))}
+                    <a class="admission-link" href={kindText("setlist_url")} target="_blank" rel="noopener noreferrer">
+                      {linkHost(kindText("setlist_url"))} ↗
+                    </a>
+                  {/if}
+                </div>
+                <div class="admission-stub">
+                  <span class="admission-stub-kind">{t(kindLabel.live)}</span>
+                  <span class="admission-stub-name">{kindText("artist") || t(selected.title)}</span>
+                  <span class="admission-stub-seat">{kindText("seat") || t(selected.date)}</span>
+                </div>
+              </div>
+            {:else if selected.kind === "souvenir"}
+              <!-- Postcard back — divider rule, stamp box, postmark. -->
+              <div class="postcard-face">
+                <div class="postcard-note">
+                  <p class="postcard-dateline">{[t(selected.place), t(selected.date)].filter(Boolean).join(" — ")}</p>
+                  {#if kindText("note")}
+                    <p class="postcard-message">{kindText("note")}</p>
+                  {:else}
+                    <span class="postcard-rules" aria-hidden="true"></span>
+                  {/if}
+                </div>
+                <div class="postcard-address">
+                  <span class="postcard-stamp" aria-hidden="true">〒</span>
+                  <span class="postcard-postmark" aria-hidden="true"></span>
+                  <strong>{kindText("name") || t(selected.title)}</strong>
+                  <span>{kindText("origin") || t(selected.place)}</span>
+                </div>
               </div>
             {:else}
-              <div class="goods-face">
-                <span>{t(kindLabel.goods)}</span>
-                <strong>{t(selected.title)}</strong>
-                {#if t(selected.vendor) || selected.price}
-                  <small>{[t(selected.vendor), selected.price].filter(Boolean).join(" · ")}</small>
-                {/if}
+              <!-- Goods — kraft swing tag; the hole and the clipped shoulders are real. -->
+              <div class="tag-face">
+                <span class="tag-eyelet" aria-hidden="true"></span>
+                <p class="tag-kind">{t(kindLabel.goods)}</p>
+                <strong class="tag-name">{kindText("name") || t(selected.title)}</strong>
+                <p class="tag-source">
+                  {[kindText("shop") || t(selected.vendor), kindText("manufacturer")].filter(Boolean).join(" · ") || t(selected.place)}
+                </p>
+                <div class="tag-foot">
+                  <span>{t(selected.date)}</span>
+                  {#if selected.price}
+                    <b>{selected.price}</b>
+                  {/if}
+                </div>
               </div>
             {/if}
           </div>


### PR DESCRIPTION
## What

`ux-restyle.md`'s diagnosis was that stubs **"don't feel like things"**, and [ADR-0031](https://github.com/azusachino/felicia/blob/main/docs/adr/0031-frontend-style-map-first-and-shared-element-open.md) committed to *warm paper as the system*, with kind read from **form and material, not a coloured pill**.

v1 still rendered three looks for six kinds — `transit` and `stamp` had faces, and `goods`/`receipt`/`souvenir`/`live` all fell through to one `.goods-face` whose `linear-gradient(135deg, #fef3c7, #fb7185 48%, #7c3aed)` was precisely the *"cool SaaS palette fighting a warm paper object"* that note called out.

| kind | material | signature |
|---|---|---|
| transit | きっぷ magnetic ticket | **untouched** — ADR-0031 keeps it as the exemplar |
| stamp | ink-on-washi | vermilion square seal, fibre rulings |
| goods | kraft swing tag | clipped shoulders, punched hole through an eyelet |
| receipt | thermal roll | narrow measure, monospace, barcode, torn hem |
| live | admission stock | vertical tear-off stub, perforation, edge notches |
| souvenir | postcard back | centre divider, stamp box with postmark rings |

## Two reconciliations worth reviewing

**ADR-0031 lists five materials against six kinds.** Its list predates the kind registry, so it names a `ticket` kind that does not exist while `live` and `souvenir` have none assigned. `live` takes the admission stock the ADR describes ("the reference's Jeju/UNESCO look; perforated stub"). `souvenir` gets the **postcard** — my call: its `name`/`origin`/`note` fields map exactly onto a postcard's place and message, and it stays structurally distinct from the goods tag.

**The cut-outs are real.** Perforations, notches and the torn hem are `clip-path`/`mask-image`, not drawn lines, so the silhouettes genuinely break — that is the direct answer to "stubs don't feel like things". Faces with a cut silhouette drop the card's rounded/overflow/box-shadow via `:has()` and take a `drop-shadow` filter instead, so the shadow follows the real edge. `.stub-card`'s markup is untouched and still carries the shared-element morph from #62.

## The bar I held it to

**Desaturate all six and they must still be distinguishable** — that is ADR-0031's "form and material, not a coloured pill" made testable. They are; hue does no identifying work. `live` and `souvenir` are the closest pair (both two-column cards) and would want widening apart if stubs are ever rendered as small map thumbnails.

## Scope

**v1 only.** `.goods-face`/`.stamp-face` remain in `index.css` because **v2 still consumes them** — deleting that gradient would change v2, so retiring it belongs with v2's own pass.

## Test plan

- [x] `make web-check` (svelte-check + eslint + prettier) — clean
- [x] Stepped through **all six** in a real browser against the compiled artifact, confirming each silhouette and that every face is warm paper (verified via computed style, e.g. `.admission-face` = `rgb(240,226,196)`, `.postcard-face` = `rgb(243,236,220)`)
- [x] Degradation checked against required-fields-only data for each kind

Two notes on verification:

- The demo workspace carries no `live` or `souvenir` memento, so **those two materials are not exercised by the deployed demo**. I verified them by injecting fixtures into the *compiled* artifact only — no example data was changed. Worth deciding separately whether the demo should show all six.
- The browser pane runs the page with `document.visibilityState === "hidden"`, which pauses `requestAnimationFrame` and freezes Svelte transitions mid-flight at ~50% opacity. That is a harness artifact, not a regression — I had to force the settled state to screenshot accurately, and flag it here because it makes stubs *look* dark under automated capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)