### PR TITLE
fix: recolour the goods stub to kraft, retiring the last cool-palette holdout

### DIFF
--- a/apps/web-public/src/index.css
+++ b/apps/web-public/src/index.css
@@ -383,8 +383,11 @@ button {
   @apply flex justify-between border-t border-black/20 pt-3 font-semibold;
 }
 
+/* Kraft swing-tag stock: browner and lower-value than the ticket's pale-gold
+   thermal paper, so goods still read as a different material without leaving
+   the one warm amber → orange scale (docs/research/ux-restyle.md). */
 .goods-face {
-  background: linear-gradient(135deg, #fef3c7, #fb7185 48%, #7c3aed);
+  background: linear-gradient(135deg, #e7d3ae, #cba876 52%, #b08a58);
   color: #241203;
 }
 


### PR DESCRIPTION
## What

`ux-restyle.md`'s visual-identity diagnosis was that the warm JR ticket sat beside *"stock-Tailwind kind badges … a cool SaaS palette fighting a warm paper object"*, and [ADR-0031](https://github.com/azusachino/felicia/blob/main/docs/adr/0031-frontend-style-map-first-and-shared-element-open.md) commits to **one warm amber → orange scale**.

`.goods-face` was still pink into violet:

```diff
-background: linear-gradient(135deg, #fef3c7, #fb7185 48%, #7c3aed);
+background: linear-gradient(135deg, #e7d3ae, #cba876 52%, #b08a58);
```

Kraft swing-tag stock — browner and lower-value than the ticket's pale-gold thermal paper, so goods still reads as a *different material* rather than a second ticket, while staying inside the one warm scale. The existing `#241203` ink keeps contrast across the whole ramp.

**This was the last of it.** Grepping web-public for the teardown's palette (`#6366f1`, `#ec4899`, `#06b6d4`, `#7c3aed`, `#fb7185`) now returns nothing — the `kind-*` badges had already been migrated, and the comment at `index.css:82` asserting the stub faces "stay warm in both" themes was the only thing this rule had been quietly contradicting.

## Scope and ordering

The rule is shared, so **today** it covers v1 and v2. #65 moves v1 onto its own per-kind materials (`.tag-face`), after which `.goods-face` is v2's alone — which is the correct long-term home for it either way.

The two changes are **independent and merge in any order**: this one touches two lines inside the existing rule, #65 adds a new section. If this lands first, v1 gets the kraft gradient in the interim, which is strictly better than the violet.

## Test plan

- [x] `make web-check` (svelte-check + eslint + prettier) — clean, in the containerized nix devshell
- [x] Confirmed no cool-palette hex values remain anywhere in `apps/web-public/src/`

Credit: the colour choice and rationale come from the background task session that investigated this rule; this PR carries that work forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)