### PR TITLE
fix: stop the API image build from shipping the whole working tree

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,18 @@
+# Keep the API build context to the Go workspace. Without this, `COPY . .` in
+# deploy/Containerfile pulls in worktrees, node_modules, and build output —
+# ~900MB of context that never reaches the compiled binary.
+.claude/
+.git/
+node_modules/
+**/node_modules/
+dist/
+**/dist/
+site/
+bin/
+.venv/
+**/__pycache__/
+apps/
+web/
+docs/
+experiments/
+examples/


### PR DESCRIPTION
## What

Adds a `.dockerignore`. The repository had none.

## Why

`deploy/Containerfile` ends with `COPY . .`, so without an ignore file the build context was **~941MB** — of which **~874MB was `.claude/worktrees`**, copied into the image alongside `node_modules/` and build output. None of it is read by the Go workspace build that produces `felicia-api`.

Found while bringing the compose stack up locally to walk the user flow; the image builds fine either way, it just carries and transfers the entire working tree to do it.

## Scope

Context restriction only. `deploy/Containerfile` is unchanged, and the resulting binary is identical — the excluded paths never reached it.

## Verification

`docker compose -f deploy/compose.yaml build api` succeeds with this file in place, and the resulting image starts and serves `/api/v1/journeys` and `/healthz` against the compose stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)