### PR TITLE
feat: redesign Felicia reader themes

### DIFF
--- a/apps/felicia-public-site/src/App.svelte
+++ b/apps/felicia-public-site/src/App.svelte
@@ -64,10 +64,16 @@
   }
 </script>
 
-<div class="public-reader-shell">
+<div class="public-reader-shell" class:theme-light={theme === "light"}>
   <nav class="public-design-switcher" aria-label={message(lang, "system.design")}>
     {#each designLanguages as design (design.id)}
-      <button type="button" class:active={active.id === design.id} aria-pressed={active.id === design.id} onclick={() => selectDesign(design.id)}>
+      <button
+        type="button"
+        class:active={active.id === design.id}
+        aria-current={active.id === design.id ? "page" : undefined}
+        aria-pressed={active.id === design.id}
+        onclick={() => selectDesign(design.id)}
+      >
         {message(lang, design.labelKey)}
       </button>
     {/each}
@@ -80,9 +86,20 @@
 
 <style>
   .public-reader-shell {
+    --switcher-bg: rgba(9, 9, 11, 0.82);
+    --switcher-border: rgba(255, 255, 255, 0.18);
+    --switcher-text: #d4d4d8;
     position: relative;
     width: 100%;
     height: 100%;
+    color-scheme: dark;
+  }
+
+  .public-reader-shell.theme-light {
+    --switcher-bg: rgba(255, 255, 255, 0.9);
+    --switcher-border: rgba(28, 25, 23, 0.14);
+    --switcher-text: #57534e;
+    color-scheme: light;
   }
 
   .public-design-switcher {
@@ -94,11 +111,13 @@
     gap: 0.2rem;
     max-width: calc(100vw - 2rem);
     overflow-x: auto;
-    padding: 0.25rem;
-    border: 1px solid color-mix(in srgb, #fff 18%, transparent);
+    min-height: 3.25rem;
+    padding: 0.35rem;
+    border: 1px solid var(--switcher-border);
     border-radius: 999px;
-    background: color-mix(in srgb, #09090b 78%, transparent);
+    background: var(--switcher-bg);
     backdrop-filter: blur(12px);
+    box-shadow: 0 1rem 3rem rgba(0, 0, 0, 0.18);
     transform: translateX(-50%);
   }
 
@@ -106,18 +125,31 @@
     border: 0;
     border-radius: 999px;
     padding: 0.38rem 0.65rem;
-    color: #a1a1aa;
+    color: var(--switcher-text);
     background: transparent;
     font-size: 0.68rem;
     font-weight: 700;
     letter-spacing: 0.04em;
     white-space: nowrap;
+    transition:
+      color 180ms ease,
+      background 180ms ease,
+      transform 180ms ease;
   }
 
   .public-design-switcher button:hover,
   .public-design-switcher button.active {
     color: #18120d;
     background: #fdba74;
+  }
+
+  .public-design-switcher button:active {
+    transform: scale(0.97);
+  }
+
+  .public-design-switcher button:focus-visible {
+    outline-color: #fdba74;
+    outline-offset: -2px;
   }
 
   @media (max-width: 700px) {

--- a/docs/development/reader-ui-ux-contract.md
+++ b/docs/development/reader-ui-ux-contract.md
@@ -1,0 +1,117 @@
+# Reader UI and UX contract
+
+This is the shared contract for Felicia's four public reader designs: Atlas,
+Cabinet, Techo, and Cartography. It keeps the reader coherent while allowing
+each design to tell the same journey in its own visual language.
+
+## Design read
+
+Reading this as a redesign of a personal, map-first travel journal for one
+reader, with a tactile editorial atlas language, leaning toward tinted charcoal,
+warm paper, and restrained cinematic motion.
+
+The working dials are:
+
+- Design variance: 7. The four designs should feel authored, not cloned, but
+  share enough structure that the reader never loses orientation.
+- Motion intensity: 6. Movement explains route, selection, and opening a
+  memento. It never runs for decoration alone.
+- Visual density: 4. The map and the memento carry the page; controls stay
+  quiet and sparse.
+
+## What every design must preserve
+
+- The map is the index. A reader can see the active journey and reach the
+  journey/memento index from the first screen.
+- A memento is a physical paper object. Kind is expressed through material,
+  silhouette, and typography rather than a colored badge.
+- Opening a memento is one continuous action. The selected object grows into
+  its detail surface where the layout allows it; a panel reveal is the fallback
+  on narrow screens.
+- Hash navigation remains stable: `/`, `#cabinet`, `#techo`, and
+  `#cartography` remain shareable entry points.
+- Authored copy, locale behavior, and the `{ journey, visit, memento }` reader
+  contract do not change as part of visual work.
+
+## Shared interaction grammar
+
+Every design exposes the same semantic controls, even when their placement and
+visual treatment differ:
+
+| Intent                                 | Required behavior                                                                              |
+| -------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| Choose a journey                       | Updates the active route and keeps the selected journey visible.                               |
+| Inspect a memento                      | Opens its story and gallery, updates map/index selection, and exposes a labelled close action. |
+| Change language                        | Preserves the current design and selected content.                                             |
+| Change light/dark mode                 | Updates the shell and map together, with readable controls in both modes.                      |
+| Change design                          | Uses the existing hash links and exposes the current design to assistive technology.           |
+| Recover from loading/error/empty state | Uses a shaped status surface and an actionable retry or explanation.                           |
+
+Keyboard focus is visible, click targets are at least 44px on touch surfaces,
+and every map marker has a real button name. `Escape` closes an open detail
+surface where the design owns the document focus.
+
+## Visual system
+
+The shell uses one neutral family and one accent family. Dark mode is tinted
+charcoal rather than pure black; light mode is a cool stone derived from the
+same hue. Warm amber/orange is reserved for routes, selected states, and paper
+materials. Red is reserved for actual error or destructive state.
+
+The shape scale is intentionally narrow:
+
+- 2px for map markers and paper edges;
+- 8px for controls and quiet content surfaces;
+- 16px only for the main detail surface when elevation communicates hierarchy;
+- full rounding only for circular markers and icon controls.
+
+Typography uses the existing project fonts and adds hierarchy through measure,
+weight, tracking, and ragged-right reading text. Do not add a new font or UI
+library for this pass.
+
+## Motion contract
+
+Motion is stateful and interruptible. The reader uses the existing Svelte
+transitions and CSS rather than introducing a second animation runtime.
+
+- **Text reveal:** a short stagger for first-entry headings and empty states.
+- **Panel reveal:** translate, opacity, and a small blur for detail surfaces.
+- **Card resize:** ease the index/detail state rather than snapping widths.
+- **Shared-element open:** preserve the current marker/stub ghost behavior where
+  it exists; do not fake a morph with unrelated simultaneous fades.
+- **Route emphasis:** use D3 geometry, interpolation, and easing for route
+  progress or active-segment emphasis. Do not animate layout properties when a
+  transform or opacity is sufficient.
+
+All motion has a `prefers-reduced-motion: reduce` path that removes travel and
+stagger while retaining the state change. Map camera movement must use zero
+duration for reduced motion.
+
+Three.js is not a shared reader dependency. The ThreeUI reference informs
+scene composition, control density, and visual depth; a real Three.js renderer
+belongs to the incubating Tabi scene described by ADR-0036 and should be added
+only when that theme has an approved scene contract.
+
+## Theme roles
+
+- **Atlas:** default map-and-story reader. It owns the clearest route,
+  journey-overview, and memento-open path.
+- **Cabinet:** collection browse. It emphasizes discovery across journeys while
+  retaining the same detail and control semantics.
+- **Techo:** notebook interpretation. It may be warmer and more editorial, but
+  its map remains an actionable index rather than a decorative spread.
+- **Cartography:** full map atlas. It owns the richest per-kind paper materials
+  and route geography, not a separate interaction model.
+
+## Verification bar
+
+Before a reader slice is complete:
+
+1. `make web-check` passes from a clean dependency install.
+2. Each hash loads with the production catalog and no console errors.
+3. A keyboard-only pass can switch design, language, mode, journey, and
+   memento, then close detail.
+4. Narrow viewport behavior keeps the map/index affordance reachable and does
+   not trap detail content off-screen.
+5. Reduced-motion mode keeps all content and state changes usable without
+   animation.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -89,6 +89,7 @@ Deliverables:
 - Keep a dark MapLibre route map, journey index, visit/memento markers, and responsive mobile layout.
 - Render the first memento templates from structured data rather than per-item markup.
 - Implement the signature open interaction into an essay and photo gallery.
+- Align Atlas, Cabinet, Techo, and Cartography behind the shared reader UI/UX contract: map/index access, paper memento semantics, accessible controls, and reduced-motion behavior.
 - Remove prototype/scaffolding chrome from the public reader.
 - Verify Japanese, English, Chinese system UI, keyboard navigation, reduced motion, and readable essay typography.
 

--- a/packages/felicia-components/src/PhotoLightbox.svelte
+++ b/packages/felicia-components/src/PhotoLightbox.svelte
@@ -9,7 +9,18 @@
   export let imageClass = ""
 
   let open = false
+  let triggerButton: HTMLButtonElement
   let closeButton: HTMLButtonElement
+
+  function portal(node: HTMLElement) {
+    document.body.appendChild(node)
+
+    return {
+      destroy() {
+        node.remove()
+      },
+    }
+  }
 
   async function show() {
     open = true
@@ -19,23 +30,28 @@
 
   function close() {
     open = false
+    triggerButton?.focus()
   }
 
   function handleKeydown(event: KeyboardEvent) {
     if (open && event.key === "Escape") close()
   }
+
+  function handleBackdropClick(event: MouseEvent) {
+    if (event.target === event.currentTarget) close()
+  }
 </script>
 
-<svelte:window on:keydown={handleKeydown} />
+<svelte:window onkeydown={handleKeydown} />
 
-<button type="button" class="photo-trigger" aria-label={openLabel} on:click={show}>
+<button bind:this={triggerButton} type="button" class="photo-trigger" aria-label={openLabel} onclick={show}>
   <img {src} {alt} class={imageClass} />
 </button>
 
 {#if open}
-  <div class="photo-lightbox" role="dialog" aria-modal="true" aria-label={alt}>
+  <div use:portal class="photo-lightbox" role="dialog" aria-modal="true" aria-label={alt} onclick={handleBackdropClick}>
     <div class="lightbox-frame">
-      <button bind:this={closeButton} type="button" class="lightbox-close" aria-label={closeLabel} on:click={close}>×</button>
+      <button bind:this={closeButton} type="button" class="lightbox-close" aria-label={closeLabel} onclick={close}>×</button>
       <img class="lightbox-image" {src} {alt} />
       {#if caption}
         <p>{caption}</p>
@@ -67,6 +83,7 @@
     inset: 0;
     display: grid;
     place-items: center;
+    overflow: auto;
     padding: 1.5rem;
     background: rgb(0 0 0 / 82%);
   }
@@ -94,8 +111,8 @@
     z-index: 1;
     top: 0.4rem;
     right: 0.4rem;
-    width: 2rem;
-    height: 2rem;
+    width: 2.75rem;
+    height: 2.75rem;
     border: 1px solid rgb(255 255 255 / 35%);
     border-radius: 999px;
     color: #fff;

--- a/packages/felicia-components/src/PhotoLightbox.svelte
+++ b/packages/felicia-components/src/PhotoLightbox.svelte
@@ -36,10 +36,6 @@
   function handleKeydown(event: KeyboardEvent) {
     if (open && event.key === "Escape") close()
   }
-
-  function handleBackdropClick(event: MouseEvent) {
-    if (event.target === event.currentTarget) close()
-  }
 </script>
 
 <svelte:window onkeydown={handleKeydown} />
@@ -49,7 +45,7 @@
 </button>
 
 {#if open}
-  <div use:portal class="photo-lightbox" role="dialog" aria-modal="true" aria-label={alt} onclick={handleBackdropClick}>
+  <div use:portal class="photo-lightbox" role="dialog" aria-modal="true" aria-label={alt} tabindex="-1">
     <div class="lightbox-frame">
       <button bind:this={closeButton} type="button" class="lightbox-close" aria-label={closeLabel} onclick={close}>×</button>
       <img class="lightbox-image" {src} {alt} />

--- a/packages/felicia-reader/src/public.css
+++ b/packages/felicia-reader/src/public.css
@@ -19,7 +19,7 @@
   color: #f8fafc;
   background: #08090d;
   font-family:
-    Inter,
+    Outfit,
     ui-sans-serif,
     system-ui,
     -apple-system,
@@ -71,6 +71,11 @@ button {
   --ctrl-bg: rgba(15, 23, 42, 0.82);
   --ctrl-invert: 1;
   --stub-shade: rgba(0, 0, 0, 0.5);
+  --surface-raised: rgba(18, 20, 26, 0.92);
+  --accent-soft: rgba(253, 186, 116, 0.14);
+  --accent-strong: #fb923c;
+  --radius-control: 0.5rem;
+  --radius-surface: 1rem;
 }
 
 .app-shell.theme-light {
@@ -88,6 +93,26 @@ button {
   --ctrl-bg: rgba(255, 255, 255, 0.92);
   --ctrl-invert: 0;
   --stub-shade: rgba(60, 40, 20, 0.3);
+  --surface-raised: rgba(255, 255, 255, 0.94);
+  --accent-soft: rgba(194, 65, 12, 0.1);
+  --accent-strong: #c2410c;
+}
+
+html {
+  color-scheme: dark;
+  text-rendering: optimizeLegibility;
+}
+
+button,
+a,
+input,
+select {
+  -webkit-tap-highlight-color: transparent;
+}
+
+:focus-visible {
+  outline: 2px solid var(--accent-strong, #fb923c);
+  outline-offset: 3px;
 }
 
 /* Visually hidden but screen-reader-audible — used for live-region
@@ -137,7 +162,7 @@ button {
 }
 
 .lang-switch button {
-  @apply rounded px-2.5 py-1 text-xs font-semibold;
+  @apply min-h-11 min-w-11 rounded px-2.5 py-1 text-xs font-semibold;
   color: var(--muted);
   background: transparent;
   border: 0;
@@ -148,7 +173,7 @@ button {
 }
 
 .theme-toggle {
-  @apply flex h-8 w-8 items-center justify-center rounded-md text-sm;
+  @apply flex h-11 w-11 items-center justify-center rounded-md text-sm;
   color: var(--text);
   background: transparent;
   border: 1px solid var(--border);
@@ -178,7 +203,7 @@ button {
 }
 
 .all-btn {
-  @apply rounded-md px-2.5 py-1 text-xs font-semibold;
+  @apply min-h-11 rounded-md px-3 text-xs font-semibold;
   color: var(--muted);
   background: transparent;
   border: 1px solid var(--border);
@@ -309,7 +334,7 @@ button {
 /* Sticky within .detail-panel's own scroll (there's no separate inner
    scroll wrapper here, unlike Atlas) so it stays reachable while scrolled. */
 .detail-close {
-  @apply sticky top-0 z-10 flex h-8 w-8 shrink-0 items-center justify-center self-end rounded-full text-base leading-none;
+  @apply sticky top-0 z-10 flex h-11 w-11 shrink-0 items-center justify-center self-end rounded-full text-base leading-none;
   color: var(--text);
   background: var(--ctrl-bg);
   border: 1px solid var(--border);
@@ -896,5 +921,16 @@ button {
   .detail-panel {
     border-left: 0;
     border-top: 1px solid var(--border);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
   }
 }

--- a/packages/felicia-reader/src/theme-ui/atlas/Atlas.svelte
+++ b/packages/felicia-reader/src/theme-ui/atlas/Atlas.svelte
@@ -12,6 +12,7 @@
   let activeJourneyId = $state<string | null>(null)
   let activeMementoId = $state<string | null>(null)
   let selectedMementoId = $state<string | null>(null)
+  let indexOpen = $state(true)
 
   const orderedJourneys = $derived(
     [...journeys]
@@ -37,8 +38,11 @@
       newest: "Newest",
       oldest: "Oldest",
       journeys: "旅",
+      mementos: "件",
       photos: "photos",
       photosHeading: "写真",
+      indexOpen: "目録",
+      indexClose: "目録を閉じる",
       loading: "読み込み中…",
       retry: "再試行",
       close: "閉じる",
@@ -50,8 +54,11 @@
       newest: "Newest",
       oldest: "Oldest",
       journeys: "journeys",
+      mementos: "mementos",
       photos: "photos",
       photosHeading: "Photos",
+      indexOpen: "Index",
+      indexClose: "Hide index",
       loading: "Loading…",
       retry: "Retry",
       close: "Close",
@@ -63,8 +70,11 @@
       newest: "Newest",
       oldest: "Oldest",
       journeys: "次旅程",
+      mementos: "件纪念物",
       photos: "photos",
       photosHeading: "照片",
+      indexOpen: "目录",
+      indexClose: "关闭目录",
       loading: "加载中…",
       retry: "重试",
       close: "关闭",
@@ -127,6 +137,22 @@
     selectedMementoId = memento.id
   }
 
+  function selectMementoById(mementoId: string) {
+    for (const journey of journeys) {
+      const memento = journey.mementos.find((item) => item.id === mementoId)
+      if (memento) {
+        selectMemento(memento, journey.id)
+        return
+      }
+    }
+  }
+
+  function jumpToJourney(journeyId: string) {
+    activeJourneyId = journeyId
+    const target = document.querySelector<HTMLElement>(`[data-journey-id="${journeyId}"]`)
+    target?.scrollIntoView({ behavior: window.matchMedia("(prefers-reduced-motion: reduce)").matches ? "auto" : "smooth", block: "start" })
+  }
+
   function closeMemento() {
     selectedMementoId = null
   }
@@ -143,9 +169,46 @@
       <button type="button" onclick={loadData}>{label.retry}</button>
     </div>
   {:else if orderedJourneys.length}
-    <div class="map-surface" aria-hidden="true">
-      <AtlasMap {journeys} {activeJourneyId} {activeMementoId} {lang} {theme} onSelect={(id) => (selectedMementoId = id)} />
+    <div class="map-surface" aria-label="Journey map">
+      <AtlasMap {journeys} {activeJourneyId} {activeMementoId} {lang} {theme} onSelect={selectMementoById} />
     </div>
+
+    <button class="index-toggle" type="button" aria-expanded={indexOpen} onclick={() => (indexOpen = !indexOpen)}>
+      <span aria-hidden="true">{indexOpen ? "−" : "+"}</span>
+      {indexOpen ? label.indexClose : label.indexOpen}
+    </button>
+
+    {#if indexOpen}
+      <aside class="atlas-index" aria-label={label.journeys}>
+        <div class="atlas-index-head">
+          <div>
+            <p class="index-kicker">FELICIA / ATLAS</p>
+            <h2>{label.journeys}</h2>
+          </div>
+          <span class="index-total">{orderedJourneys.length}</span>
+        </div>
+        <div class="atlas-index-list">
+          {#each orderedJourneys as entry (entry.journey.id)}
+            <button class:active={entry.journey.id === activeJourneyId} class="atlas-journey" type="button" onclick={() => jumpToJourney(entry.journey.id)}>
+              <span class="atlas-journey-title">{t(entry.journey.title)}</span>
+              <span class="atlas-journey-meta">{t(entry.journey.place)} · {t(entry.journey.dates)}</span>
+              <span class="atlas-journey-count">{entry.mementos.length} {label.mementos}</span>
+            </button>
+          {/each}
+        </div>
+        {#if activeJourney}
+          <div class="atlas-index-mementos">
+            <p class="index-kicker">{t(activeJourney.title)}</p>
+            {#each activeJourney.mementos.slice(0, 4) as memento, index (memento.id)}
+              <button class:active={memento.id === activeMementoId} type="button" onclick={() => selectMemento(memento, activeJourney.id)}>
+                <span>{String(index + 1).padStart(2, "0")}</span>
+                <strong>{t(memento.title)}</strong>
+              </button>
+            {/each}
+          </div>
+        {/if}
+      </aside>
+    {/if}
 
     <header class="hero">
       <p class="brand">F E L I C I A / ATLAS</p>
@@ -198,19 +261,21 @@
     --ink: #f5f5f5;
     --muted: #a8a8a8;
     --orange: var(--accent, #d46728);
+    --waypoints-bg: #121212;
     min-height: 100%;
     height: 100%;
     overflow-y: auto;
     overscroll-behavior-y: contain;
     background: #121212;
     color: var(--ink);
-    font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+    font-family: Outfit, ui-sans-serif, system-ui, sans-serif;
   }
 
   .waypoints.light {
     --ink: #2d2925;
     --muted: #706a65;
     --orange: var(--accent, #b45f26);
+    --waypoints-bg: #e7e0d5;
     background: #e7e0d5;
   }
 
@@ -218,7 +283,7 @@
     position: fixed;
     z-index: 0;
     inset: 0;
-    pointer-events: none;
+    pointer-events: auto;
   }
 
   .map-surface :global(.maplibregl-map) {
@@ -230,6 +295,155 @@
   .journey-stream {
     position: relative;
     z-index: 1;
+  }
+
+  .index-toggle {
+    position: fixed;
+    z-index: 5;
+    bottom: 1.25rem;
+    left: 1.25rem;
+    display: flex;
+    min-height: 2.75rem;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.65rem 0.9rem;
+    border: 1px solid color-mix(in srgb, var(--ink) 30%, transparent);
+    border-radius: 999px;
+    color: var(--ink);
+    background: color-mix(in srgb, var(--waypoints-bg) 82%, transparent);
+    box-shadow: 0 0.75rem 2rem #0005;
+    backdrop-filter: blur(12px);
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .index-toggle span {
+    display: grid;
+    width: 1.25rem;
+    height: 1.25rem;
+    place-items: center;
+    border: 1px solid currentColor;
+    border-radius: 50%;
+    font-size: 1rem;
+    line-height: 1;
+  }
+
+  .atlas-index {
+    position: fixed;
+    z-index: 4;
+    top: 5.5rem;
+    left: 1.25rem;
+    display: flex;
+    width: min(21rem, calc(100vw - 2.5rem));
+    max-height: min(70vh, 36rem);
+    flex-direction: column;
+    gap: 1rem;
+    overflow-y: auto;
+    padding: 1.15rem;
+    border: 1px solid color-mix(in srgb, var(--ink) 20%, transparent);
+    border-radius: 1rem;
+    color: var(--ink);
+    background: color-mix(in srgb, var(--waypoints-bg) 88%, transparent);
+    box-shadow: 0 1.5rem 4rem #0007;
+    backdrop-filter: blur(18px) saturate(120%);
+  }
+
+  .atlas-index-head {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+
+  .atlas-index h2 {
+    margin: 0.15rem 0 0;
+    font-size: 1.4rem;
+    letter-spacing: -0.04em;
+  }
+
+  .index-kicker {
+    margin: 0;
+    color: var(--orange);
+    font-size: 0.62rem;
+    font-weight: 700;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+  }
+
+  .index-total {
+    display: grid;
+    min-width: 2rem;
+    height: 2rem;
+    place-items: center;
+    border: 1px solid color-mix(in srgb, var(--ink) 24%, transparent);
+    border-radius: 50%;
+    color: var(--orange);
+    font:
+      700 0.75rem/1 ui-monospace,
+      monospace;
+  }
+
+  .atlas-index-list,
+  .atlas-index-mementos {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+
+  .atlas-journey,
+  .atlas-index-mementos button {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.2rem;
+    width: 100%;
+    padding: 0.7rem;
+    border: 1px solid transparent;
+    border-radius: 0.6rem;
+    color: var(--ink);
+    background: transparent;
+    text-align: left;
+  }
+
+  .atlas-journey:hover,
+  .atlas-journey.active,
+  .atlas-index-mementos button:hover,
+  .atlas-index-mementos button.active {
+    border-color: color-mix(in srgb, var(--orange) 65%, transparent);
+    background: color-mix(in srgb, var(--orange) 18%, transparent);
+  }
+
+  .atlas-journey-title,
+  .atlas-index-mementos strong {
+    font-size: 0.88rem;
+    font-weight: 700;
+  }
+
+  .atlas-journey-meta,
+  .atlas-journey-count {
+    color: var(--muted);
+    font-size: 0.7rem;
+  }
+
+  .atlas-index-mementos {
+    border-top: 1px solid color-mix(in srgb, var(--ink) 16%, transparent);
+    padding-top: 0.9rem;
+  }
+
+  .atlas-index-mementos button {
+    display: grid;
+    grid-template-columns: 2rem minmax(0, 1fr);
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .atlas-index-mementos button > span {
+    color: var(--orange);
+    font:
+      700 0.68rem/1 ui-monospace,
+      monospace;
   }
 
   .hero {
@@ -367,6 +581,21 @@
   }
 
   @media (max-width: 640px) {
+    .atlas-index {
+      top: auto;
+      right: 0.75rem;
+      bottom: 4.75rem;
+      left: 0.75rem;
+      width: auto;
+      max-height: min(52vh, 27rem);
+    }
+
+    .index-toggle {
+      right: 1rem;
+      bottom: 1rem;
+      left: auto;
+    }
+
     .hero {
       min-height: 100svh;
       padding-top: 8rem;

--- a/packages/felicia-reader/src/theme-ui/atlas/AtlasDetail.svelte
+++ b/packages/felicia-reader/src/theme-ui/atlas/AtlasDetail.svelte
@@ -180,12 +180,10 @@
   @keyframes open-panel {
     from {
       opacity: 0;
-      transform: translateX(1.5rem);
     }
 
     to {
       opacity: 1;
-      transform: translateX(0);
     }
   }
 

--- a/packages/felicia-reader/src/theme-ui/atlas/AtlasMap.svelte
+++ b/packages/felicia-reader/src/theme-ui/atlas/AtlasMap.svelte
@@ -2,6 +2,7 @@
   import maplibregl, { type StyleSpecification } from "maplibre-gl"
   import "maplibre-gl/dist/maplibre-gl.css"
   import { onMount } from "svelte"
+  import { geoDistance } from "d3-geo"
   import type { Coordinates, Journey, Memento, Theme } from "@felicia/model"
 
   let {
@@ -24,6 +25,7 @@
   let map: maplibregl.Map | undefined
   let loaded = $state(false)
   let resizeObserver: ResizeObserver | undefined
+  let prefersReducedMotion = $state(false)
   // eslint-disable-next-line svelte/prefer-svelte-reactivity -- imperative MapLibre marker cache
   const markers = new Map<string, maplibregl.Marker>()
 
@@ -86,7 +88,13 @@
     if (!map || !journey) return
     const bounds = boundsOf(coordinatesFor(journey))
     if (!bounds) return
-    map.fitBounds(bounds, { padding: 80, maxZoom: 9, duration: 700 })
+    const distance = journeyDistance(journey)
+    map.fitBounds(bounds, { padding: 80, maxZoom: 9, duration: prefersReducedMotion ? 0 : Math.min(900, 360 + distance * 180) })
+  }
+
+  function journeyDistance(journey: Journey) {
+    const coordinates = journey.routeSegments?.length ? journey.routeSegments.flat() : journey.route
+    return coordinates.slice(1).reduce((total, coordinate, index) => total + geoDistance(coordinates[index], coordinate), 0)
   }
 
   function markerElement(memento: Memento, index: number) {
@@ -146,6 +154,10 @@
 
   onMount(() => {
     if (!container) return
+    const motionQuery = window.matchMedia("(prefers-reduced-motion: reduce)")
+    prefersReducedMotion = motionQuery.matches
+    const onMotionChange = (event: MediaQueryListEvent) => (prefersReducedMotion = event.matches)
+    motionQuery.addEventListener("change", onMotionChange)
     map = new maplibregl.Map({
       container,
       style: mapStyle,
@@ -190,6 +202,7 @@
 
     return () => {
       resizeObserver?.disconnect()
+      motionQuery.removeEventListener("change", onMotionChange)
       resizeObserver = undefined
       markers.forEach((marker) => marker.remove())
       markers.clear()

--- a/packages/felicia-reader/src/theme-ui/cabinet/Cabinet.svelte
+++ b/packages/felicia-reader/src/theme-ui/cabinet/Cabinet.svelte
@@ -67,9 +67,9 @@
       </div>
       <div class="cabinet-controls">
         <div class="lang-switch" role="group" aria-label="Language">
-          <button class:active={lang === "ja"} on:click={() => (lang = "ja")}>日本語</button>
-          <button class:active={lang === "en"} on:click={() => (lang = "en")}>EN</button>
-          <button class:active={lang === "zh"} on:click={() => (lang = "zh")}>中文</button>
+          <button class:active={lang === "ja"} aria-pressed={lang === "ja"} on:click={() => (lang = "ja")}>日本語</button>
+          <button class:active={lang === "en"} aria-pressed={lang === "en"} on:click={() => (lang = "en")}>EN</button>
+          <button class:active={lang === "zh"} aria-pressed={lang === "zh"} on:click={() => (lang = "zh")}>中文</button>
         </div>
         <button class="theme-toggle" on:click={toggleTheme} aria-label={theme === "dark" ? "Switch to light theme" : "Switch to dark theme"}>
           {theme === "dark" ? "☀" : "☾"}
@@ -232,6 +232,12 @@
     max-width: 68rem;
     margin: 0 auto;
     align-items: start;
+  }
+
+  .cabinet-shell :global(button:focus-visible),
+  .cabinet-shell :global(a:focus-visible) {
+    outline: 2px solid var(--accent-ink);
+    outline-offset: 3px;
   }
 
   .cabinet-stub-col {

--- a/packages/felicia-reader/src/theme-ui/cartography/Cartography.svelte
+++ b/packages/felicia-reader/src/theme-ui/cartography/Cartography.svelte
@@ -387,9 +387,9 @@
     <aside class="index-rail" aria-label="Journey index">
       <div class="rail-toolbar">
         <div class="lang-switch" role="group" aria-label="Language">
-          <button class:active={lang === "ja"} on:click={() => (lang = "ja")}>日本語</button>
-          <button class:active={lang === "en"} on:click={() => (lang = "en")}>EN</button>
-          <button class:active={lang === "zh"} on:click={() => (lang = "zh")}>中文</button>
+          <button class:active={lang === "ja"} aria-pressed={lang === "ja"} on:click={() => (lang = "ja")}>日本語</button>
+          <button class:active={lang === "en"} aria-pressed={lang === "en"} on:click={() => (lang = "en")}>EN</button>
+          <button class:active={lang === "zh"} aria-pressed={lang === "zh"} on:click={() => (lang = "zh")}>中文</button>
         </div>
         <button class="theme-toggle" on:click={toggleTheme} aria-label={theme === "dark" ? "Switch to light theme" : "Switch to dark theme"}>
           {theme === "dark" ? "☀" : "☾"}

--- a/packages/felicia-reader/src/theme-ui/techo/Techo.svelte
+++ b/packages/felicia-reader/src/theme-ui/techo/Techo.svelte
@@ -373,7 +373,7 @@
 
         <nav class="year-tabs" aria-label="Years">
           {#each years as year (year)}
-            <button type="button" class="year-tab cursor-pointer border border-solid focus:outline-none" class:active={year === activeYear} onclick={() => selectYear(year)}>
+            <button type="button" class="year-tab cursor-pointer border border-solid" class:active={year === activeYear} aria-pressed={year === activeYear} onclick={() => selectYear(year)}>
               {year}
             </button>
           {/each}
@@ -420,7 +420,7 @@
             </div>
             <button
               type="button"
-              class="flex h-7 w-7 items-center justify-center rounded-full border border-black/10 bg-paper-2 hover:bg-paper-3 text-base text-ink-soft cursor-pointer transition focus:outline-none"
+              class="flex h-11 w-11 items-center justify-center rounded-full border border-black/10 bg-paper-2 hover:bg-paper-3 text-base text-ink-soft cursor-pointer transition"
               onclick={backToLanding}
               aria-label={t(backLabel)}
             >
@@ -431,7 +431,7 @@
           <div class="flex items-center justify-between border-b border-dashed border-black/15 pb-3">
             <button
               type="button"
-              class="flex items-center gap-1 font-mono text-xs text-ink-soft disabled:opacity-30 disabled:cursor-not-allowed hover-accent transition cursor-pointer bg-transparent border-none p-0 focus:outline-none"
+              class="flex min-h-11 items-center gap-1 font-mono text-xs text-ink-soft disabled:opacity-30 disabled:cursor-not-allowed hover-accent transition cursor-pointer bg-transparent border-none p-0"
               disabled={selectedMementoIndex === 0}
               onclick={goToPrevMemento}
             >
@@ -442,7 +442,7 @@
             </span>
             <button
               type="button"
-              class="flex items-center gap-1 font-mono text-xs text-ink-soft disabled:opacity-30 disabled:cursor-not-allowed hover-accent transition cursor-pointer bg-transparent border-none p-0 focus:outline-none"
+              class="flex min-h-11 items-center gap-1 font-mono text-xs text-ink-soft disabled:opacity-30 disabled:cursor-not-allowed hover-accent transition cursor-pointer bg-transparent border-none p-0"
               disabled={selectedMementoIndex === selectedJourney.mementos.length - 1}
               onclick={goToNextMemento}
             >
@@ -534,6 +534,12 @@
   .techo-shell.is-detail {
     padding: 0;
     display: block;
+  }
+
+  .techo-shell :global(button:focus-visible),
+  .techo-shell :global(a:focus-visible) {
+    outline: 2px solid var(--terracotta);
+    outline-offset: 3px;
   }
 
   .detail-back {


### PR DESCRIPTION
## Summary
- Establish a shared map-first UI/UX contract across Atlas, Cabinet, Techo, and Cartography.
- Upgrade Atlas with an accessible journey index, interactive markers, responsive detail flow, and D3-aware camera motion.
- Fix Atlas photo detail: portal the lightbox to the document body so it is truly viewport-scoped, with focus restoration and Escape handling.
- Record the R2 reader milestone and keep Three.js reserved for the Tabi scene contract.

## Verification
- make validate
- Agent-browser SOP verification across all four hashes
- Atlas lightbox verified with a real image, full-viewport dialog, close button, Escape, and no console errors