### PR TITLE
fix: respect public site base path for branding assets

### DIFF
--- a/apps/felicia-public-site/index.html
+++ b/apps/felicia-public-site/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>felicia — A map for the moments</title>
     <meta name="description" content="A map-first travel journal for collecting places, photos, and the stories between them." />
-    <link rel="icon" href="/felicia-mark.svg" />
+    <link rel="icon" href="%BASE_URL%felicia-mark.svg" />
 
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/apps/felicia-public-site/src/App.svelte
+++ b/apps/felicia-public-site/src/App.svelte
@@ -31,6 +31,7 @@
   const configured = $derived(designLanguageFromId(settings?.design))
   const active = $derived(routeHash ? designLanguageFromHash(routeHash) : configured)
   const Active = $derived(active.component)
+  const markUrl = `${import.meta.env.BASE_URL}felicia-mark.svg`
 
   // lang/theme are shared across the mounted design so switching keeps your
   // reading state. lang keeps its existing localStorage override precedence
@@ -66,7 +67,7 @@
 
 <div class="public-reader-shell" class:theme-light={theme === "light"} class:design-cabinet={active.id === "cabinet"} class:design-cartography={active.id === "cartography"}>
   <a class="public-brand" href="/" aria-label="Felicia home">
-    <img src="/felicia-mark.svg" alt="" aria-hidden="true" />
+    <img src={markUrl} alt="" aria-hidden="true" />
     <span>felicia</span>
   </a>
 


### PR DESCRIPTION
## Summary

- use Vite’s deployment base URL for the public-site top-left mark
- use the same base-aware URL for the favicon

The previous absolute `/felicia-mark.svg` image path escaped the `/felicia/` GitHub Pages prefix and failed to load.

## Verification

- `BASE_PATH=/felicia/ make web-build`
- live `agent-browser` check at `/felicia/` confirms the mark loads with `naturalWidth: 150`
- `make validate`