### PR TITLE
fix: Atlas theme interface audit findings

### DIFF
--- a/packages/felicia-components/src/PhotoLightbox.svelte
+++ b/packages/felicia-components/src/PhotoLightbox.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-  import { tick } from "svelte"
-
   export let src: string
   export let alt: string
   export let caption = ""
@@ -8,53 +6,38 @@
   export let closeLabel = "Close"
   export let imageClass = ""
 
-  let open = false
   let triggerButton: HTMLButtonElement
-  let closeButton: HTMLButtonElement
+  let dialogEl: HTMLDialogElement
 
-  function portal(node: HTMLElement) {
-    document.body.appendChild(node)
-
-    return {
-      destroy() {
-        node.remove()
-      },
-    }
-  }
-
-  async function show() {
-    open = true
-    await tick()
-    closeButton?.focus()
+  function show() {
+    dialogEl?.showModal()
   }
 
   function close() {
-    open = false
+    dialogEl?.close()
+  }
+
+  // Fires on Escape and on our own close() call alike -- native <dialog>
+  // already supplies the focus trap and Escape handling; this only needs to
+  // return focus to whatever opened it.
+  function onDialogClose() {
     triggerButton?.focus()
   }
-
-  function handleKeydown(event: KeyboardEvent) {
-    if (open && event.key === "Escape") close()
-  }
 </script>
-
-<svelte:window onkeydown={handleKeydown} />
 
 <button bind:this={triggerButton} type="button" class="photo-trigger" aria-label={openLabel} onclick={show}>
   <img {src} {alt} class={imageClass} />
 </button>
 
-{#if open}
-  <div use:portal class="photo-lightbox" role="dialog" aria-modal="true" aria-label={alt} tabindex="-1">
-    <div class="lightbox-frame">
-      <button bind:this={closeButton} type="button" class="lightbox-close" aria-label={closeLabel} onclick={close}>×</button>
-      <img class="lightbox-image" {src} {alt} />
-      {#if caption}
-        <p>{caption}</p>
-      {/if}
-    </div>
+<dialog bind:this={dialogEl} class="photo-lightbox" aria-label={alt} onclose={onDialogClose}>
+  <div class="lightbox-frame">
+    <button type="button" class="lightbox-close" aria-label={closeLabel} onclick={close}>×</button>
+    <img class="lightbox-image" {src} {alt} />
+    {#if caption}
+      <p>{caption}</p>
+    {/if}
   </div>
-{/if}
+</dialog>
 
 <style>
   .photo-trigger {
@@ -78,9 +61,18 @@
     z-index: 100;
     inset: 0;
     display: grid;
-    place-items: center;
     overflow: auto;
+    width: 100%;
+    max-width: 100%;
+    height: 100%;
+    max-height: 100%;
+    place-items: center;
     padding: 1.5rem;
+    border: 0;
+    background: transparent;
+  }
+
+  .photo-lightbox::backdrop {
     background: rgb(0 0 0 / 82%);
   }
 

--- a/packages/felicia-reader/src/theme-ui/atlas/Atlas.svelte
+++ b/packages/felicia-reader/src/theme-ui/atlas/Atlas.svelte
@@ -35,18 +35,22 @@
     ja: {
       title: "旅の地図帳",
       subtitle: "旅の記憶を、チケットのかたちで",
-      newest: "Newest",
-      oldest: "Oldest",
+      newest: "新しい順",
+      oldest: "古い順",
       journeys: "旅",
       mementos: "件",
-      photos: "photos",
+      photos: "枚",
       photosHeading: "写真",
-      indexOpen: "目録",
+      indexOpen: "目録を開く",
       indexClose: "目録を閉じる",
       loading: "読み込み中…",
       retry: "再試行",
       close: "閉じる",
-      story: "Story",
+      story: "物語",
+      journeyMap: "旅の地図",
+      links: "リンク",
+      sortJourneys: "旅の並べ替え",
+      more: (n: number) => `ほか${n}件`,
     },
     en: {
       title: "Felicia's Waypoints",
@@ -57,28 +61,36 @@
       mementos: "mementos",
       photos: "photos",
       photosHeading: "Photos",
-      indexOpen: "Index",
+      indexOpen: "Show index",
       indexClose: "Hide index",
       loading: "Loading…",
       retry: "Retry",
       close: "Close",
       story: "Story",
+      journeyMap: "Journey map",
+      links: "Links",
+      sortJourneys: "Sort journeys",
+      more: (n: number) => `+${n} more`,
     },
     zh: {
       title: "旅行图册",
       subtitle: "以纪念物记录旅途",
-      newest: "Newest",
-      oldest: "Oldest",
+      newest: "最新",
+      oldest: "最早",
       journeys: "次旅程",
       mementos: "件纪念物",
-      photos: "photos",
+      photos: "张照片",
       photosHeading: "照片",
-      indexOpen: "目录",
+      indexOpen: "打开目录",
       indexClose: "关闭目录",
       loading: "加载中…",
       retry: "重试",
       close: "关闭",
       story: "故事",
+      journeyMap: "旅程地图",
+      links: "链接",
+      sortJourneys: "旅程排序",
+      more: (n: number) => `还有${n}件`,
     },
   } as const
 
@@ -135,6 +147,12 @@
     activeJourneyId = journeyId
     activeMementoId = memento.id
     selectedMementoId = memento.id
+    // The index and detail panels overlap below 640px -- the detail panel
+    // takes over the role the index was playing, so close it rather than
+    // stack both fixed-position panels on a narrow viewport.
+    if (typeof window !== "undefined" && window.matchMedia("(max-width: 640px)").matches) {
+      indexOpen = false
+    }
   }
 
   function selectMementoById(mementoId: string) {
@@ -160,6 +178,8 @@
   $effect(() => loadData())
 </script>
 
+<svelte:window onkeydown={(event) => event.key === "Escape" && closeMemento()} />
+
 <main class="waypoints" class:light={theme === "light"}>
   {#if isLoading}
     <div class="status" role="status">{label.loading}</div>
@@ -169,7 +189,7 @@
       <button type="button" onclick={loadData}>{label.retry}</button>
     </div>
   {:else if orderedJourneys.length}
-    <div class="map-surface" aria-label="Journey map">
+    <div class="map-surface" aria-label={label.journeyMap}>
       <AtlasMap {journeys} {activeJourneyId} {activeMementoId} {lang} {theme} onSelect={selectMementoById} />
     </div>
 
@@ -183,7 +203,7 @@
         <div class="atlas-index-head">
           <div>
             <p class="index-kicker">FELICIA / ATLAS</p>
-            <h2>{label.journeys}</h2>
+            <h2 lang={lang}>{label.journeys}</h2>
           </div>
           <span class="index-total">{orderedJourneys.length}</span>
         </div>
@@ -205,6 +225,9 @@
                 <strong>{t(memento.title)}</strong>
               </button>
             {/each}
+            {#if activeJourney.mementos.length > 4}
+              <p class="index-more">{label.more(activeJourney.mementos.length - 4)}</p>
+            {/if}
           </div>
         {/if}
       </aside>
@@ -212,15 +235,15 @@
 
     <header class="hero">
       <p class="brand">F E L I C I A / ATLAS</p>
-      <h1>{label.title}</h1>
+      <h1 lang={lang}>{label.title}</h1>
       <p>{label.subtitle}</p>
-      <nav class="social" aria-label="Links">
+      <nav class="social" aria-label={label.links}>
         <a href="https://github.com" aria-label="GitHub">◉</a>
         <a href="https://x.com" aria-label="X">𝕏</a>
         <a href="https://telegram.org" aria-label="Telegram">➤</a>
         <a href="mailto:hello@example.com" aria-label="Email">✉</a>
       </nav>
-      <div class="sort" role="group" aria-label="Sort journeys">
+      <div class="sort" role="group" aria-label={label.sortJourneys}>
         <button type="button" class:active={newestFirst} aria-pressed={newestFirst} onclick={() => (newestFirst = true)}>{label.newest}</button>
         <button type="button" class:active={!newestFirst} aria-pressed={!newestFirst} onclick={() => (newestFirst = false)}>{label.oldest}</button>
       </div>
@@ -371,6 +394,14 @@
     letter-spacing: -0.04em;
   }
 
+  /* Negative tracking optically tightens Latin type; CJK glyphs already fill
+     a full-width em with no natural inter-character gap, so the same value
+     crowds them instead. */
+  .atlas-index h2:lang(ja),
+  .atlas-index h2:lang(zh) {
+    letter-spacing: normal;
+  }
+
   .index-kicker {
     margin: 0;
     color: var(--orange);
@@ -440,6 +471,12 @@
     padding-top: 0.9rem;
   }
 
+  .index-more {
+    margin: 0.2rem 0 0;
+    color: var(--muted);
+    font-size: 0.72rem;
+  }
+
   .atlas-index-mementos button {
     display: grid;
     grid-template-columns: 2rem minmax(0, 1fr);
@@ -477,6 +514,11 @@
     font-weight: 800;
     letter-spacing: -0.06em;
     text-shadow: 0 5px 18px #000;
+  }
+
+  .hero h1:lang(ja),
+  .hero h1:lang(zh) {
+    letter-spacing: normal;
   }
 
   .hero > p:not(.brand),

--- a/packages/felicia-reader/src/theme-ui/atlas/AtlasDetail.svelte
+++ b/packages/felicia-reader/src/theme-ui/atlas/AtlasDetail.svelte
@@ -76,12 +76,14 @@
   }
 
   .detail-close {
+    display: grid;
     position: absolute;
     z-index: 1;
     top: 0.7rem;
     right: 0.7rem;
-    width: 2rem;
-    height: 2rem;
+    width: 2.75rem;
+    height: 2.75rem;
+    place-items: center;
     border: 1px solid #a99a87;
     border-radius: 50%;
     color: #594b3d;

--- a/packages/felicia-reader/src/theme-ui/atlas/AtlasMap.svelte
+++ b/packages/felicia-reader/src/theme-ui/atlas/AtlasMap.svelte
@@ -248,7 +248,14 @@
       700 0.75rem/1 ui-sans-serif,
       system-ui,
       sans-serif;
-    cursor: default;
+  }
+
+  /* Keep the visible marker at 2rem (map density) but grow the actual hit
+     area to the project's 44px touch-target minimum. */
+  :global(.atlas-marker)::after {
+    content: "";
+    position: absolute;
+    inset: calc((2rem - 2.75rem) / 2);
   }
 
   :global(.atlas-marker.is-dimmed) {

--- a/packages/felicia-reader/src/theme-ui/atlas/AtlasStub.svelte
+++ b/packages/felicia-reader/src/theme-ui/atlas/AtlasStub.svelte
@@ -132,7 +132,7 @@
 
   .tag-kind,
   .card-kind {
-    color: #71695e;
+    color: #3a2f22;
     font-size: 0.65rem;
     letter-spacing: 0.15em;
     text-transform: uppercase;


### PR DESCRIPTION
## Summary
- Fixes 10 of 11 findings from the interface audit run with `better-interface` against the Atlas reader theme: 2 HIGH, 6 MEDIUM, 2 LOW fixed; 1 LOW (sub-12px caption sizes) recorded as a deliberate editorial choice rather than a defect.
- HIGH: `.tag-kind`/`.card-kind` stub labels darkened from `#71695e` to `#3a2f22`, fixing a WCAG AA contrast failure on goods/souvenir backgrounds (2.15:1/3.64:1 -> 5.19:1/8.79:1 as rendered). Mobile index/detail panel overlap fixed — the index panel now closes when a memento opens on <=640px viewports.
- MEDIUM: ja/zh string localization (was leaking hardcoded English); `PhotoLightbox` swapped from a manual portal/focus-trap dialog to native `<dialog>`/`showModal()` (drops the custom focus-management code, shared by every reader theme); Escape now closes the open memento detail panel per the reader's own UX contract; `.detail-close`/`.atlas-marker` hit areas raised to the reader's 44px minimum; CJK letter-spacing fixed; truncated memento list now shows a "+N more" indicator.
- LOW: fixed a marker cursor mismatch and an inconsistent disclosure-button label.

## Test plan
- [x] `make web-private-check` passes (svelte-check + eslint + prettier)
- [x] `make web-private-build` passes
- [x] Both HIGH findings re-verified visually via Playwright against mock journey data — contrast and mobile-overlap fixes confirmed rendered
- [x] Reviewed locally via `make browser-mock` + the public-site dev server against the deterministic fixture before opening this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)