### PR TITLE
fix: Cabinet, Techo and Cartography interface audit findings

### DIFF
--- a/packages/felicia-reader/src/public.css
+++ b/packages/felicia-reader/src/public.css
@@ -177,13 +177,13 @@ select {
 }
 
 .lang-switch {
-  @apply flex rounded-md p-0.5;
+  @apply flex rounded-lg p-0.5;
   border: 1px solid var(--border);
   background: var(--card);
 }
 
 .lang-switch button {
-  @apply min-h-11 min-w-11 rounded px-2.5 py-1 text-xs font-semibold;
+  @apply min-h-11 min-w-11 rounded-lg px-2.5 py-1 text-xs font-semibold;
   color: var(--muted);
   background: transparent;
   border: 0;
@@ -195,7 +195,7 @@ select {
 }
 
 .theme-toggle {
-  @apply flex h-11 w-11 items-center justify-center rounded-md text-sm;
+  @apply flex h-11 w-11 items-center justify-center rounded-lg text-sm;
   color: var(--text);
   background: transparent;
   border: 1px solid var(--border);
@@ -225,7 +225,7 @@ select {
 }
 
 .all-btn {
-  @apply min-h-11 rounded-md px-3 text-xs font-semibold;
+  @apply min-h-11 rounded-lg px-3 text-xs font-semibold;
   color: var(--muted);
   background: transparent;
   border: 1px solid var(--border);
@@ -293,7 +293,7 @@ select {
 }
 
 .timeline-glyph {
-  @apply flex h-9 w-9 shrink-0 items-center justify-center rounded-md text-sm font-black;
+  @apply flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-sm font-black;
   background: var(--chip-bg);
   border: 2px solid var(--chip-border);
   color: var(--text);
@@ -448,7 +448,10 @@ select {
   color: #241203;
 }
 
-.goods-face span,
+.goods-face span {
+  @apply text-xs font-bold uppercase tracking-[0.2em] opacity-90;
+}
+
 .stamp-face span {
   @apply text-xs font-bold uppercase tracking-[0.2em] opacity-80;
 }
@@ -458,7 +461,10 @@ select {
   @apply mt-10 block text-3xl font-black leading-tight;
 }
 
-.goods-face small,
+.goods-face small {
+  @apply mt-5 block text-sm font-semibold opacity-90;
+}
+
 .stamp-face small {
   @apply mt-5 block text-sm font-semibold opacity-80;
 }
@@ -539,7 +545,7 @@ select {
 
 .washi-date {
   @apply mt-5 block text-xs font-semibold tracking-[0.14em];
-  color: rgba(36, 26, 16, 0.55);
+  color: rgba(36, 26, 16, 0.68);
 }
 
 /* goods — kraft swing tag --------------------------------------------------- */
@@ -569,7 +575,7 @@ select {
 
 .tag-kind {
   @apply m-0 text-[0.68rem] font-bold uppercase tracking-[0.22em];
-  color: rgba(53, 32, 12, 0.68);
+  color: rgba(53, 32, 12, 0.9);
 }
 
 .tag-name {
@@ -579,13 +585,13 @@ select {
 
 .tag-source {
   @apply m-0 mt-2 text-sm font-semibold;
-  color: rgba(53, 32, 12, 0.75);
+  color: rgba(53, 32, 12, 0.9);
 }
 
 .tag-foot {
   @apply mt-auto flex items-baseline justify-between gap-3 pt-4 text-xs font-semibold uppercase tracking-[0.16em];
   border-top: 1px solid rgba(66, 40, 14, 0.35);
-  color: rgba(53, 32, 12, 0.72);
+  color: rgba(53, 32, 12, 0.9);
 }
 
 .tag-foot b {
@@ -780,7 +786,7 @@ select {
 
 .postcard-dateline {
   @apply m-0 text-[0.7rem] font-semibold uppercase tracking-[0.18em];
-  color: rgba(47, 36, 21, 0.6);
+  color: rgba(47, 36, 21, 0.68);
 }
 
 .postcard-message {
@@ -864,6 +870,11 @@ select {
 
 .gallery img {
   @apply block aspect-[4/3] w-full object-cover;
+  /* Depth outline that follows the theme automatically: --text is light in
+     dark mode and dark in light mode, so this never needs a separate
+     .theme-light override. */
+  outline: 1px solid color-mix(in srgb, var(--text) 10%, transparent);
+  outline-offset: -1px;
 }
 
 .gallery figcaption {
@@ -874,7 +885,15 @@ select {
 /* Map markers (read on both dark + light tiles) --------------------------- */
 
 .map-marker {
-  @apply flex h-10 w-10 items-center justify-center rounded-md border-2 border-zinc-400 bg-zinc-950/90 text-sm font-black text-zinc-200 shadow-xl transition;
+  @apply relative flex h-10 w-10 items-center justify-center rounded-[2px] border-2 border-zinc-400 bg-zinc-950/90 text-sm font-black text-zinc-200 shadow-xl transition;
+}
+
+/* Keep the visible 40px marker but grow the actual hit area to the reader's
+   44px touch-target minimum. */
+.map-marker::after {
+  content: "";
+  position: absolute;
+  inset: calc((2.5rem - 2.75rem) / 2);
 }
 
 .map-marker:hover,
@@ -913,6 +932,14 @@ select {
 
 .techo-mark:hover {
   transform: scale(1.1);
+}
+
+/* Keep the visible 36px circle but grow the actual hit area to the reader's
+   44px touch-target minimum. */
+.techo-mark::after {
+  content: "";
+  position: absolute;
+  inset: calc((2.25rem - 2.75rem) / 2);
 }
 
 .techo-mark.is-active {

--- a/packages/felicia-reader/src/theme-ui/cabinet/Cabinet.svelte
+++ b/packages/felicia-reader/src/theme-ui/cabinet/Cabinet.svelte
@@ -19,6 +19,15 @@
     map: { ja: "← 地図", en: "← Map", zh: "← 地图" },
     onMap: { ja: "地図で見る →", en: "See on the map →", zh: "在地图上查看 →" },
     memories: { ja: "記憶", en: "Memories", zh: "回忆" },
+    loading: { ja: "読み込み中…", en: "Loading…", zh: "加载中…" },
+    retry: { ja: "再試行", en: "Retry", zh: "重试" },
+    noMementos: { ja: "記憶がありません", en: "No mementos", zh: "暂无回忆" },
+    mementoDetail: { ja: "記憶の詳細", en: "Memento detail", zh: "回忆详情" },
+    mementoShelf: { ja: "記憶の棚", en: "Memento shelf", zh: "回忆架" },
+    themeToLight: { ja: "ライトテーマに切り替え", en: "Switch to light theme", zh: "切换到浅色主题" },
+    themeToDark: { ja: "ダークテーマに切り替え", en: "Switch to dark theme", zh: "切换到深色主题" },
+    pauseShelf: { ja: "棚のスクロールを一時停止", en: "Pause shelf scrolling", zh: "暂停货架滚动" },
+    resumeShelf: { ja: "棚のスクロールを再開", en: "Resume shelf scrolling", zh: "继续货架滚动" },
   }
 
   let allMementos: MementoCard[] = []
@@ -26,11 +35,15 @@
   let selected: MementoCard | undefined
   let isLoading = true
   let error: string | null = null
+  let prefersReducedMotion = false
+  let shelfPaused = false
 
   $: t = (value: L | MessageKey) => (typeof value === "string" ? message(lang, value) : value[lang])
   $: memento = selected?.memento as Memento | undefined
 
-  onMount(() => {
+  function load() {
+    isLoading = true
+    error = null
     loadJourneys()
       .then((data) => {
         allMementos = data.flatMap((journey) => journey.mementos.map((item) => ({ memento: item, journey })))
@@ -43,6 +56,15 @@
       .finally(() => {
         isLoading = false
       })
+  }
+
+  onMount(() => {
+    const motionQuery = window.matchMedia("(prefers-reduced-motion: reduce)")
+    prefersReducedMotion = motionQuery.matches
+    const onMotionChange = (event: MediaQueryListEvent) => (prefersReducedMotion = event.matches)
+    motionQuery.addEventListener("change", onMotionChange)
+    load()
+    return () => motionQuery.removeEventListener("change", onMotionChange)
   })
 
   function select(card: MementoCard) {
@@ -52,13 +74,25 @@
   function toggleTheme() {
     theme = theme === "dark" ? "light" : "dark"
   }
+
+  function toggleShelfPaused() {
+    shelfPaused = !shelfPaused
+  }
 </script>
 
 <main class="app-shell cabinet-shell" class:theme-light={theme === "light"}>
   {#if isLoading}
-    <div class="cabinet-status">Loading…</div>
+    <div class="cabinet-status">{t(label.loading)}</div>
   {:else if error}
-    <div class="cabinet-status">{error}</div>
+    <div class="cabinet-status cabinet-status--recover" role="alert">
+      <p>{error}</p>
+      <div class="cabinet-status-actions">
+        <button class="all-btn" on:click={load}>{t(label.retry)}</button>
+        {#if toMap}
+          <button class="all-btn" on:click={toMap}>{t(label.map)}</button>
+        {/if}
+      </div>
+    </div>
   {:else if selected && memento}
     <header class="cabinet-top">
       <div class="cabinet-brand">
@@ -66,12 +100,12 @@
         <h1>{t(title)}</h1>
       </div>
       <div class="cabinet-controls">
-        <div class="lang-switch" role="group" aria-label="Language">
+        <div class="lang-switch" role="group" aria-label={t("system.language")}>
           <button class:active={lang === "ja"} aria-pressed={lang === "ja"} on:click={() => (lang = "ja")}>日本語</button>
           <button class:active={lang === "en"} aria-pressed={lang === "en"} on:click={() => (lang = "en")}>EN</button>
           <button class:active={lang === "zh"} aria-pressed={lang === "zh"} on:click={() => (lang = "zh")}>中文</button>
         </div>
-        <button class="theme-toggle" on:click={toggleTheme} aria-label={theme === "dark" ? "Switch to light theme" : "Switch to dark theme"}>
+        <button class="theme-toggle" on:click={toggleTheme} aria-label={theme === "dark" ? t(label.themeToLight) : t(label.themeToDark)}>
           {theme === "dark" ? "☀" : "☾"}
         </button>
         {#if toMap}
@@ -81,10 +115,10 @@
     </header>
 
     <!-- The memento detail "page": the centre of Cabinet. -->
-    <section class="cabinet-stage" aria-label="Memento detail">
+    <section class="cabinet-stage" aria-label={t(label.mementoDetail)}>
       {#key memento.id}
-        <div class="cabinet-detail" in:fade={{ duration: 200 }}>
-          <div class="cabinet-stub-col" in:fly={{ y: 14, duration: 320, delay: 40 }}>
+        <div class="cabinet-detail" in:fade={{ duration: prefersReducedMotion ? 0 : 200 }}>
+          <div class="cabinet-stub-col" in:fly={{ y: 14, duration: prefersReducedMotion ? 0 : 320, delay: prefersReducedMotion ? 0 : 40 }}>
             <div class="stub-card {memento.kind}">
               {#if memento.kind === "transit" || memento.kind === "ticket"}
                 <TicketStub {memento} {lang} />
@@ -151,15 +185,22 @@
       {/key}
     </section>
 
-    <!-- The preview carousel: the index. Auto-scrolls; pauses on hover. -->
-    <footer class="cabinet-carousel" aria-label="Memento shelf">
-      <p class="eyebrow cabinet-carousel-head">{t(label.memories)}</p>
-      <div class="cabinet-shelf">
+    <!-- The preview carousel: the index. Auto-scrolls; pauses on hover, focus, or the pause button. -->
+    <footer class="cabinet-carousel" aria-label={t(label.mementoShelf)}>
+      <div class="cabinet-carousel-head">
+        <p class="eyebrow">{t(label.memories)}</p>
+        <button class="cabinet-shelf-pause" on:click={toggleShelfPaused} aria-pressed={shelfPaused}>
+          {shelfPaused ? "▶" : "⏸"}
+          <span class="sr-only">{shelfPaused ? t(label.resumeShelf) : t(label.pauseShelf)}</span>
+        </button>
+      </div>
+      <div class="cabinet-shelf" class:paused={shelfPaused}>
         <div class="cabinet-track">
           {#each shelf as card, i (i)}
             <button
               class="cabinet-preview cabinet-preview--{card.memento.kind}"
               class:active={card.memento.id === memento.id}
+              aria-current={card.memento.id === memento.id ? "true" : undefined}
               aria-hidden={i >= allMementos.length}
               tabindex={i >= allMementos.length ? -1 : 0}
               on:click={() => select(card)}
@@ -174,7 +215,14 @@
       </div>
     </footer>
   {:else}
-    <div class="cabinet-status">No mementos</div>
+    <div class="cabinet-status cabinet-status--recover">
+      <p>{t(label.noMementos)}</p>
+      {#if toMap}
+        <div class="cabinet-status-actions">
+          <button class="all-btn" on:click={toMap}>{t(label.map)}</button>
+        </div>
+      {/if}
+    </div>
   {/if}
 </main>
 
@@ -195,13 +243,33 @@
     color: var(--muted);
   }
 
+  .cabinet-status--recover {
+    gap: 1rem;
+    text-align: center;
+    justify-items: center;
+  }
+
+  .cabinet-status--recover p {
+    margin: 0;
+  }
+
+  .cabinet-status-actions {
+    display: flex;
+    gap: 0.5rem;
+  }
+
   .cabinet-top {
     display: flex;
+    flex-wrap: wrap;
     align-items: flex-start;
     justify-content: space-between;
     gap: 1rem;
     padding: 1.25rem 1.75rem;
     border-bottom: 1px solid var(--border);
+  }
+
+  .cabinet-brand {
+    min-width: 0;
   }
 
   .cabinet-brand h1 {
@@ -264,7 +332,7 @@
   }
 
   .cabinet-facts dt {
-    font-size: 0.7rem;
+    font-size: 0.75rem;
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.16em;
@@ -286,6 +354,7 @@
 
   .cabinet-onmap {
     align-self: flex-start;
+    min-height: 2.75rem;
     padding: 0.55rem 1rem;
     border-radius: 0.5rem;
     font-size: 0.85rem;
@@ -307,7 +376,28 @@
   }
 
   .cabinet-carousel-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
     margin: 0 0 1rem;
+  }
+
+  .cabinet-shelf-pause {
+    display: flex;
+    height: 2rem;
+    width: 2rem;
+    align-items: center;
+    justify-content: center;
+    border-radius: 999px;
+    color: var(--muted);
+    background: transparent;
+    border: 1px solid var(--border);
+    font-size: 0.7rem;
+  }
+
+  .cabinet-shelf-pause:hover {
+    background: var(--hover);
   }
 
   .cabinet-shelf {
@@ -324,7 +414,8 @@
   }
 
   .cabinet-shelf:hover .cabinet-track,
-  .cabinet-shelf:focus-within .cabinet-track {
+  .cabinet-shelf:focus-within .cabinet-track,
+  .cabinet-shelf.paused .cabinet-track {
     animation-play-state: paused;
   }
 
@@ -374,7 +465,9 @@
   }
 
   .cabinet-preview--stamp {
-    border-left-color: #ef4444;
+    /* Not red -- red is reserved for error/destructive state
+       (reader-ui-ux-contract.md). */
+    border-left-color: #d97706;
   }
 
   .cabinet-preview--goods {
@@ -382,7 +475,7 @@
   }
 
   .cabinet-preview-kind {
-    font-size: 0.66rem;
+    font-size: 0.75rem;
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.18em;

--- a/packages/felicia-reader/src/theme-ui/cartography/Cartography.svelte
+++ b/packages/felicia-reader/src/theme-ui/cartography/Cartography.svelte
@@ -36,6 +36,10 @@
   let detailHeadingEl: HTMLHeadingElement | undefined
   let prefersReducedMotion = false
 
+  const loadingLabel = { ja: "読み込み中…", en: "Loading…", zh: "加载中…" } satisfies L
+  const retryLabel = { ja: "再試行", en: "Retry", zh: "重试" } satisfies L
+  const emptyLabel = { ja: "旅の記録がありません", en: "No journeys", zh: "暂无旅程" } satisfies L
+
   const [sendStub, receiveStub] = crossfade({
     duration: (d: number) => (prefersReducedMotion ? 0 : Math.min(500, 220 + Math.sqrt(d) * 8)),
     easing: cubicOut,
@@ -154,7 +158,7 @@
     map.fitBounds(bounds, {
       padding: fitPadding(),
       maxZoom: 6.5,
-      duration: 800,
+      duration: prefersReducedMotion ? 0 : 800,
     })
   }
 
@@ -162,7 +166,7 @@
     if (!map) return
     const bounds = boundsOf(journey.route)
     if (!bounds) return
-    map.fitBounds(bounds, { padding: fitPadding(), maxZoom: 9, duration: 800 })
+    map.fitBounds(bounds, { padding: fitPadding(), maxZoom: 9, duration: prefersReducedMotion ? 0 : 800 })
   }
 
   function markerElement(memento: Memento, seq: number) {
@@ -271,11 +275,11 @@
       map.fitBounds(bounds, {
         padding: fitPadding(),
         maxZoom: 10.5,
-        duration: 700,
+        duration: prefersReducedMotion ? 0 : 700,
       })
       return
     }
-    map.flyTo({ center: memento.coords, zoom: 9.6, duration: 700, essential: true })
+    map.flyTo({ center: memento.coords, zoom: 9.6, duration: prefersReducedMotion ? 0 : 700, essential: true })
   }
 
   function applyMapTheme(next: Theme) {
@@ -348,7 +352,9 @@
 
   $: applyMapTheme(theme)
 
-  onMount(() => {
+  function load() {
+    isLoading = true
+    error = null
     loadJourneys()
       .then(async (data) => {
         journeys = data
@@ -362,6 +368,10 @@
         error = reason instanceof Error ? reason.message : String(reason)
         isLoading = false
       })
+  }
+
+  onMount(() => {
+    load()
 
     const motionQuery = window.matchMedia("(prefers-reduced-motion: reduce)")
     prefersReducedMotion = motionQuery.matches
@@ -382,9 +392,12 @@
 <main class="app-shell" class:theme-light={theme === "light"}>
   <div class="sr-only" role="status" aria-live="polite">{liveMessage}</div>
   {#if isLoading}
-    <div class="cartography-status">Loading…</div>
+    <div class="cartography-status">{t(loadingLabel)}</div>
   {:else if error}
-    <div class="cartography-status">{error}</div>
+    <div class="cartography-status cartography-status--recover" role="alert">
+      <p>{error}</p>
+      <button class="all-btn" on:click={load}>{t(retryLabel)}</button>
+    </div>
   {:else if selectedJourney && selected}
     <!-- Index rail: journeys (world index) -> selected journey's chronological timeline. -->
     <aside class="index-rail" aria-label="Journey index">
@@ -415,7 +428,12 @@
       <ol class="journey-list" aria-label="Journeys">
         {#each journeys as journey (journey.id)}
           <li>
-            <button class="journey-item" class:active={journey.id === selectedJourneyId} on:click={() => selectJourney(journey)}>
+            <button
+              class="journey-item"
+              class:active={journey.id === selectedJourneyId}
+              aria-current={journey.id === selectedJourneyId ? "true" : undefined}
+              on:click={() => selectJourney(journey)}
+            >
               <span class="journey-item-title">{t(journey.title)}</span>
               <span class="journey-item-meta">{t(journey.dates)} · {t(journey.place)}</span>
               <span class="journey-item-count">{countLabel(journey.mementos.length)}</span>
@@ -425,7 +443,12 @@
               <ol class="timeline" aria-label="Mementos in order">
                 {#each journey.mementos as memento, index (memento.id)}
                   <li>
-                    <button class="timeline-item" class:active={memento.id === selected.id} on:click={() => selectMemento(memento)}>
+                    <button
+                      class="timeline-item"
+                      class:active={memento.id === selected.id}
+                      aria-current={memento.id === selected.id ? "true" : undefined}
+                      on:click={() => selectMemento(memento)}
+                    >
                       <span class="timeline-glyph timeline-glyph--{memento.kind}">{index + 1}</span>
                       <span class="timeline-body">
                         <span class="timeline-date">{t(memento.date)}</span>
@@ -573,7 +596,7 @@
             <div class="gallery">
               {#each selected.photos as photo, index (`${photo.src}:${index}`)}
                 <figure>
-                  <PhotoLightbox src={photo.src} alt={t(selected.title)} caption={t(photo.caption)} openLabel={t(uiText.zoom)} closeLabel={t(uiText.close)} />
+                  <PhotoLightbox src={photo.src} alt={t(photo.caption)} caption={t(photo.caption)} openLabel={t(uiText.zoom)} closeLabel={t(uiText.close)} />
                   <figcaption>{t(photo.caption)}</figcaption>
                 </figure>
               {/each}
@@ -583,7 +606,7 @@
       {/key}
     </aside>
   {:else}
-    <div class="cartography-status">No journeys</div>
+    <div class="cartography-status">{t(emptyLabel)}</div>
   {/if}
 </main>
 
@@ -594,5 +617,15 @@
     min-height: 100%;
     place-items: center;
     color: var(--muted);
+  }
+
+  .cartography-status--recover {
+    gap: 1rem;
+    text-align: center;
+    justify-items: center;
+  }
+
+  .cartography-status--recover p {
+    margin: 0;
   }
 </style>

--- a/packages/felicia-reader/src/theme-ui/techo/Techo.svelte
+++ b/packages/felicia-reader/src/theme-ui/techo/Techo.svelte
@@ -5,6 +5,7 @@
   import { message, type MessageKey } from "@felicia/model"
   import type { Journey } from "@felicia/model"
   import { onMount } from "svelte"
+  import { fade, fly } from "svelte/transition"
   import PhotoLightbox from "@felicia/components/PhotoLightbox.svelte"
 
   // Techo (手帳, paper notebook) front door. View 1 (landing) is the
@@ -22,9 +23,16 @@
   let view = $state<"landing" | "detail">("landing")
   let selectedPlaceKey = $state<string | null>(null)
   let selectedMementoIndex = $state(0)
+  let prefersReducedMotion = $state(false)
 
   function handleKeydown(event: KeyboardEvent) {
-    if (view !== "detail" || !selectedMemento) return
+    if (view !== "detail") return
+    if (event.key === "Escape") {
+      event.preventDefault()
+      backToLanding()
+      return
+    }
+    if (!selectedMemento) return
     if (event.key === "ArrowLeft") {
       event.preventDefault()
       goToPrevMemento()
@@ -91,6 +99,7 @@
   const mapPlaces = $derived(
     placeGroups.map((group) => ({
       key: group.key,
+      label: t(group.label),
       coords: group.coords,
       seq: group.seq,
       count: group.mementos.length,
@@ -136,6 +145,11 @@
   }
 
   onMount(() => {
+    const motionQuery = window.matchMedia("(prefers-reduced-motion: reduce)")
+    prefersReducedMotion = motionQuery.matches
+    const onMotionChange = (event: MediaQueryListEvent) => (prefersReducedMotion = event.matches)
+    motionQuery.addEventListener("change", onMotionChange)
+
     const restoreFromURL = () => {
       const id = window.location.hash.match(/^#techo\/journeys\/([^/]+)$/)?.[1]
       const index = id ? journeys.findIndex((journey) => journey.id === id) : -1
@@ -149,7 +163,10 @@
       }
     }
     window.addEventListener("popstate", restoreFromURL)
-    return () => window.removeEventListener("popstate", restoreFromURL)
+    return () => {
+      window.removeEventListener("popstate", restoreFromURL)
+      motionQuery.removeEventListener("change", onMotionChange)
+    }
   })
 
   function selectPlace(key: string) {
@@ -216,7 +233,7 @@
 
   const journeyCountLabel = $derived.by(() => {
     const n = journeys.length
-    if (lang === "en") return `${n} journeys`
+    if (lang === "en") return `${n} journey${n === 1 ? "" : "s"}`
     if (lang === "zh") return `${n}次旅程`
     return `${n}つの旅`
   })
@@ -257,6 +274,14 @@
   const backLabel = { ja: "手帳に戻る", en: "Back to journal", zh: "返回手帳" } satisfies L
   const prevMemoryLabel = { ja: "前の記憶", en: "Previous memory", zh: "上一段记忆" } satisfies L
   const nextMemoryLabel = { ja: "次の記憶", en: "Next memory", zh: "下一段记忆" } satisfies L
+  const errorTitle = { ja: "読み込みエラー", en: "Loading error", zh: "加载错误" } satisfies L
+  const retryLabel = { ja: "再試行", en: "Retry", zh: "重试" } satisfies L
+  const emptyTitle = { ja: "旅の記録がありません", en: "No journeys recorded", zh: "暂无旅程记录" } satisfies L
+  const emptyText = {
+    ja: "現在、この手帳には記録された旅がありません。",
+    en: "There are no journeys recorded in this journal.",
+    zh: "此手帐中目前没有记录的旅程。",
+  } satisfies L
 </script>
 
 <svelte:window on:keydown={handleKeydown} />
@@ -264,7 +289,7 @@
 <main class="techo-shell" class:theme-light={theme === "light"} class:is-detail={view === "detail"}>
   {#if view === "landing"}
     <!-- View 1: the journal index — sketch map on the left, journey cards on the right. -->
-    <div class="techo-frame">
+    <div class="techo-frame" in:fade={{ duration: prefersReducedMotion ? 0 : 220 }}>
       <div class="techo-spread">
         {#if isLoading}
           <!-- Map page skeleton -->
@@ -305,9 +330,9 @@
           </section>
           <section class="techo-page techo-page--index" aria-label="Journal index error">
             <div class="error-container">
-              <h2 class="error-title">読み込みエラー / Loading Error</h2>
+              <h2 class="error-title">{t(errorTitle)}</h2>
               <p class="error-text">{error}</p>
-              <button type="button" class="retry-button" onclick={loadData}>再試行 / Retry</button>
+              <button type="button" class="retry-button" onclick={loadData}>{t(retryLabel)}</button>
             </div>
           </section>
         {:else if journeys.length === 0}
@@ -316,10 +341,8 @@
           </section>
           <section class="techo-page techo-page--index" aria-label="Journal index empty">
             <div class="empty-container">
-              <h2 class="error-title">旅の記録がありません</h2>
-              <p class="empty-text">
-                現在、この手帳には記録された旅がありません。<br />There are no journeys recorded in this journal.
-              </p>
+              <h2 class="error-title">{t(emptyTitle)}</h2>
+              <p class="empty-text">{t(emptyText)}</p>
             </div>
           </section>
         {:else}
@@ -383,7 +406,11 @@
   {:else}
     <!-- View 2: the journey on a real map; mementos cluster by place, opening a
          place reveals its memories. -->
-    <section class="relative h-full w-full overflow-hidden bg-paper-2" aria-label={t(selectedJourney.title)}>
+    <section
+      class="relative h-full w-full overflow-hidden bg-paper-2"
+      aria-label={t(selectedJourney.title)}
+      in:fade={{ duration: prefersReducedMotion ? 0 : 220 }}
+    >
       <TripMap places={mapPlaces} route={selectedJourney.route} transit={transitPairs} activeKey={selectedPlaceKey} {theme} onSelect={selectPlace} />
 
       <header class="pointer-events-none absolute left-6 top-6 z-10 flex items-start gap-3">
@@ -408,6 +435,7 @@
           class="absolute right-0 top-0 z-10 flex h-full w-[min(30rem,46vw)] flex-col gap-5 overflow-y-auto bg-paper-1/95 px-6 py-6 shadow-2xl backdrop-blur"
           aria-label="Memories at this place"
           aria-keyshortcuts="ArrowLeft ArrowRight"
+          in:fly={{ x: 24, duration: prefersReducedMotion ? 0 : 240 }}
         >
           <div class="flex items-start justify-between">
             <div>
@@ -510,6 +538,12 @@
     --paper-2: #f3ecdb;
     --paper-3: #efe7d5;
     --terracotta: var(--accent, #d9674c);
+    /* Darkened text/label role: --terracotta itself is ~3.3:1 against the
+       paper backgrounds (and against its own reversed near-white text),
+       below the 4.5:1 AA floor for normal text. Decorative/border/route
+       uses keep --terracotta; only text and text-on-terracotta pairings
+       use this. */
+    --terracotta-text: #a8492f;
     --hairline: rgba(90, 66, 30, 0.3);
     --hairline-strong: rgba(90, 66, 30, 0.4);
 
@@ -555,7 +589,7 @@
     border-radius: 0.45rem;
     background: rgba(253, 249, 240, 0.95);
     box-shadow: 0 0.35rem 0.8rem rgba(58, 47, 28, 0.18);
-    color: var(--terracotta);
+    color: var(--terracotta-text);
     cursor: pointer;
     font-family: ui-monospace, "SFMono-Regular", monospace;
     font-size: 0.72rem;
@@ -574,17 +608,19 @@
      custom property above) — used where accent-colored text needs to track
      the author's chosen accent at runtime. */
   .text-accent {
-    color: var(--terracotta);
+    color: var(--terracotta-text);
   }
 
   .hover-accent:hover {
-    color: var(--terracotta);
+    color: var(--terracotta-text);
   }
 
   .techo-frame {
     position: relative;
     width: min(94vw, 76rem);
     max-height: 92vh;
+    /* 0.9rem outer radius = 0.4rem inner page radius + 0.5rem padding below,
+       so the two curves nest concentrically. */
     border-radius: 0.9rem;
     background: var(--paper-3);
     box-shadow:
@@ -612,14 +648,14 @@
 
   .techo-page--map {
     background: var(--paper-2);
-    border-top-left-radius: 0.9rem;
-    border-bottom-left-radius: 0.9rem;
+    border-top-left-radius: 0.4rem;
+    border-bottom-left-radius: 0.4rem;
   }
 
   .techo-page--index {
     background: var(--paper-1);
-    border-top-right-radius: 0.9rem;
-    border-bottom-right-radius: 0.9rem;
+    border-top-right-radius: 0.4rem;
+    border-bottom-right-radius: 0.4rem;
   }
 
   /* --- View 1: OSM index map --- */
@@ -654,7 +690,7 @@
     font-family: ui-monospace, "SFMono-Regular", monospace;
     font-size: 0.95rem;
     letter-spacing: 0.4em;
-    color: var(--terracotta);
+    color: var(--terracotta-text);
   }
 
   .brand-tagline {
@@ -740,7 +776,7 @@
     font-size: 0.62rem;
     letter-spacing: 0.06em;
     color: #fff;
-    background: var(--terracotta);
+    background: var(--terracotta-text);
     border-radius: 0.25rem;
     padding: 0.2rem 0.5rem;
   }
@@ -761,14 +797,11 @@
 
   .card-kinds {
     margin: 0.45rem 0 0;
-    overflow: hidden;
-    color: var(--terracotta);
+    color: var(--terracotta-text);
     font-family: "IBM Plex Mono", monospace;
     font-size: 0.62rem;
     letter-spacing: 0.08em;
-    text-overflow: ellipsis;
     text-transform: uppercase;
-    white-space: nowrap;
   }
 
   .card-divider {
@@ -789,14 +822,14 @@
 
   .card-count {
     font-weight: 700;
-    color: var(--terracotta);
+    color: var(--terracotta-text);
   }
 
   .card-action {
     display: inline-flex;
     align-items: center;
     gap: 0.45rem;
-    color: var(--terracotta);
+    color: var(--terracotta-text);
   }
 
   .year-tabs {
@@ -824,8 +857,8 @@
 
   .year-tab.active {
     color: #fdf6ec;
-    background: var(--terracotta);
-    border-color: var(--terracotta);
+    background: var(--terracotta-text);
+    border-color: var(--terracotta-text);
   }
 
   @media (max-width: 900px) {
@@ -842,7 +875,17 @@
     }
 
     .year-tabs {
-      display: none;
+      position: static;
+      flex-direction: row;
+      overflow-x: auto;
+      flex-wrap: nowrap;
+      margin-top: 0.5rem;
+      padding: 0 0.5rem;
+    }
+
+    .year-tab {
+      writing-mode: horizontal-tb;
+      flex: 0 0 auto;
     }
   }
 
@@ -929,16 +972,17 @@
     border: 1px solid var(--terracotta);
     border-radius: 0.25rem;
     background: transparent;
-    color: var(--terracotta);
+    color: var(--terracotta-text);
     font-family: inherit;
     font-size: 0.85rem;
     font-weight: 700;
     cursor: pointer;
-    transition: all 0.2s ease;
+    transition-property: background-color, color;
+    transition-duration: 150ms;
   }
 
   .retry-button:hover {
-    background: var(--terracotta);
+    background: var(--terracotta-text);
     color: #fdf6ec;
   }
 </style>

--- a/packages/felicia-reader/src/theme-ui/techo/TechoIndexMap.svelte
+++ b/packages/felicia-reader/src/theme-ui/techo/TechoIndexMap.svelte
@@ -21,6 +21,7 @@
   let map: maplibregl.Map | undefined
   let loaded = $state(false)
   let resizeObserver: ResizeObserver | undefined
+  let prefersReducedMotion = false
 
   const style = "https://tiles.openfreemap.org/styles/liberty"
 
@@ -56,7 +57,7 @@
     if (!coords.length) return
     const bounds = new maplibregl.LngLatBounds(coords[0], coords[0])
     coords.forEach((coord) => bounds.extend(coord))
-    map.fitBounds(bounds, { padding: 48, maxZoom: 3.2, duration: 500 })
+    map.fitBounds(bounds, { padding: 48, maxZoom: 3.2, duration: prefersReducedMotion ? 0 : 500 })
   }
 
   function refreshData() {
@@ -67,6 +68,11 @@
   }
 
   onMount(() => {
+    const motionQuery = window.matchMedia("(prefers-reduced-motion: reduce)")
+    prefersReducedMotion = motionQuery.matches
+    const onMotionChange = (event: MediaQueryListEvent) => (prefersReducedMotion = event.matches)
+    motionQuery.addEventListener("change", onMotionChange)
+
     map = new maplibregl.Map({
       container,
       style,
@@ -93,6 +99,14 @@
 
     map.on("load", () => {
       if (!map) return
+      // Read the theme's own runtime-overridable tokens once at setup,
+      // instead of duplicating their default values as literals -- an
+      // author-configured --accent would otherwise silently stop applying
+      // to the map the moment the view switches away from CSS-styled chrome.
+      const styles = getComputedStyle(container)
+      const terracotta = styles.getPropertyValue("--terracotta").trim() || "#d9674c"
+      const ink = styles.getPropertyValue("--ink").trim() || "#3a2f1c"
+
       map.addSource("journeys", { type: "geojson", data: routeData() })
       map.addLayer({
         id: "journey-routes",
@@ -100,7 +114,7 @@
         source: "journeys",
         layout: { "line-cap": "round", "line-join": "round" },
         paint: {
-          "line-color": ["case", ["get", "selected"], "#ff9b72", "#7aa8a6"],
+          "line-color": ["case", ["get", "selected"], terracotta, "#7aa8a6"],
           "line-width": ["case", ["get", "selected"], 4, 2],
           "line-opacity": ["case", ["get", "selected"], 0.95, 0.5],
         },
@@ -111,7 +125,7 @@
         type: "circle",
         source: "places",
         paint: {
-          "circle-color": "#ff9b72",
+          "circle-color": terracotta,
           "circle-radius": 5,
           "circle-stroke-color": "#fff8ed",
           "circle-stroke-width": 2,
@@ -128,7 +142,7 @@
           "text-anchor": "top",
         },
         paint: {
-          "text-color": "#4c3a27",
+          "text-color": ink,
           "text-halo-color": "#fff8ed",
           "text-halo-width": 1.5,
         },
@@ -141,6 +155,7 @@
     return () => {
       resizeObserver?.disconnect()
       resizeObserver = undefined
+      motionQuery.removeEventListener("change", onMotionChange)
       map?.remove()
       map = undefined
     }

--- a/packages/felicia-reader/src/theme-ui/techo/TripMap.svelte
+++ b/packages/felicia-reader/src/theme-ui/techo/TripMap.svelte
@@ -10,6 +10,7 @@
   // mementos. Selecting a place is bubbled up; the parent opens its memories.
   interface Place {
     key: string
+    label: string
     coords: Coordinates
     seq: number
     count: number
@@ -35,6 +36,7 @@
   let map: maplibregl.Map | undefined
   let loaded = $state(false)
   let resizeObserver: ResizeObserver | undefined
+  let prefersReducedMotion = false
   // eslint-disable-next-line svelte/prefer-svelte-reactivity -- imperative maplibre marker cache, not reactive UI state
   const markers = new Map<string, maplibregl.Marker>()
 
@@ -79,14 +81,14 @@
     if (!map) return
     const coords = [...route, ...places.map((place) => place.coords)]
     if (!coords.length) return
-    map.fitBounds(boundsOf(coords), { padding: fitPadding, maxZoom: 9, duration: 700 })
+    map.fitBounds(boundsOf(coords), { padding: fitPadding, maxZoom: 9, duration: prefersReducedMotion ? 0 : 700 })
   }
 
   function markerElement(place: Place) {
     const button = document.createElement("button")
     button.type = "button"
     button.className = "techo-mark"
-    button.setAttribute("aria-label", `Place ${place.seq}`)
+    button.setAttribute("aria-label", `${place.seq}. ${place.label}`)
     button.innerHTML = `<span>${place.seq}</span>${place.count > 1 ? `<i class="techo-mark-count">${place.count}</i>` : ""}`
     button.addEventListener("click", (e) => {
       e.stopPropagation()
@@ -120,6 +122,11 @@
   }
 
   onMount(() => {
+    const motionQuery = window.matchMedia("(prefers-reduced-motion: reduce)")
+    prefersReducedMotion = motionQuery.matches
+    const onMotionChange = (event: MediaQueryListEvent) => (prefersReducedMotion = event.matches)
+    motionQuery.addEventListener("change", onMotionChange)
+
     map = new maplibregl.Map({
       container,
       style: mapStyle,
@@ -141,12 +148,17 @@
 
     map.on("load", () => {
       if (!map) return
+      // Read the theme's own runtime-overridable token once at setup,
+      // instead of duplicating its default value as a literal -- see
+      // TechoIndexMap.svelte for the same recipe.
+      const terracotta = getComputedStyle(container).getPropertyValue("--terracotta").trim() || "#d9674c"
+
       map.addSource("route", { type: "geojson", data: routeGeoJson() })
       map.addLayer({
         id: "route-glow",
         type: "line",
         source: "route",
-        paint: { "line-color": "#ff9b72", "line-width": 8, "line-opacity": 0.18, "line-blur": 4 },
+        paint: { "line-color": terracotta, "line-width": 8, "line-opacity": 0.18, "line-blur": 4 },
       })
       map.addLayer({
         id: "route-line",
@@ -154,7 +166,7 @@
         source: "route",
         layout: { "line-cap": "round", "line-join": "round" },
         paint: {
-          "line-color": "#ff9b72",
+          "line-color": terracotta,
           "line-width": 4,
           "line-opacity": 0.95,
         },
@@ -182,6 +194,7 @@
     return () => {
       resizeObserver?.disconnect()
       resizeObserver = undefined
+      motionQuery.removeEventListener("change", onMotionChange)
       markers.forEach((marker) => marker.remove())
       markers.clear()
       map?.remove()


### PR DESCRIPTION
## Summary

better-interface audits of the three reader themes not covered by #100's Atlas pass surfaced 33 findings (12 HIGH, 18 MEDIUM, 3 LOW) against the shared reader UX contract. Fixes all of them. Closes #32.

- **Shared (`public.css`)**: contrast fixes on Cabinet's goods-face and Cartography's five stub-material labels, 44px hit-area extensions on `.techo-mark`/`.map-marker`, `.map-marker`'s radius brought onto the contract's shape scale, five controls raised to the contract's 8px control radius, a themed gallery-image outline.
- **Cabinet**: dead-end error/empty states now retry + escape to the map; 320px header overflow fixed; memento-switch transitions respect `prefers-reduced-motion`; active carousel card gets `aria-current`; a red kind-accent moved off the error/destructive hue; the auto-scrolling shelf gets a visible pause control; hardcoded strings localized.
- **Techo**: a systemic terracotta-on-text contrast failure fixed via a dedicated `--terracotta-text` role token (also caught and fixed the "Selected" badge, which had the same reversed-pairing failure but wasn't in the original audit finding); both maps respect `prefers-reduced-motion`; kind-summary truncation removed; map markers read the theme's own CSS tokens instead of hardcoded hex and get real place names instead of sequence numbers; panel-reveal transitions added; error/empty copy localized to ja/en/zh; `Escape` returns to landing; the year-quick-jump rail scrolls instead of vanishing below 900px; page corners nest concentrically.
- **Cartography**: every map-camera move respects `prefers-reduced-motion`; the error state gets `role="alert"` + retry + localized copy; selected journey/memento gets `aria-current`; gallery photos get their own caption as alt text instead of sharing the memento's title.

## Test plan
- [x] `make web-private-check` passes (svelte-check + eslint + prettier)
- [x] `make web-private-build` passes
- [x] All three themes visually re-verified via `make browser-mock` + the public-site dev server (no crashes, contrast/motion/truncation fixes render as expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)