### PR TITLE
docs: review Felicia foundations and adopt local rumdl checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   backend:
-    name: Backend (make check)
+    name: Backend (make check-ci)
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -44,8 +44,8 @@ jobs:
       - name: Apply migrations
         run: DATABASE_DSN="$CI_DATABASE_DSN" make migrate
 
-      - name: Check (fmt, vet, lint, race tests)
-        run: FELICIA_TEST_DATABASE_DSN="$CI_DATABASE_DSN" make check
+      - name: Check (vet, lint, race tests)
+        run: FELICIA_TEST_DATABASE_DSN="$CI_DATABASE_DSN" make check-ci
 
       - name: SQLite journey workflow
         run: make test-workflow

--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -1,0 +1,12 @@
+[global]
+# Match the workstation Markdown policy: prose is not hard-wrapped.
+disable = ["MD013"]
+exclude = ["node_modules/**", ".venv/**", ".felicia/**", "site/**", "apps/*/dist/**"]
+
+[per-file-ignores]
+# The agent entry point is an include directive, not a prose document.
+"CLAUDE.md" = ["MD041"]
+# README uses an HTML wrapper for the project banner.
+"README.md" = ["MD033", "MD041"]
+# Archived issue bodies inherit their title from the issue itself.
+"docs/archive/github-issues/*.md" = ["MD041"]

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ GO      ?= $(MISE_RUN) go
 BUN     ?= $(MISE_RUN) bun
 GOOSE   := $(MISE_RUN) goose
 SQLC    := $(MISE_RUN) sqlc
+# Markdown formatting is local-only; rumdl is supplied by Nix on PATH.
+RUMDL   ?= rumdl
 
 DATABASE_DSN ?= postgres://postgres:password@localhost:5432/felicia?sslmode=disable
 PORT ?= 8080
@@ -17,17 +19,23 @@ COMPOSE ?= $(shell \
 	elif command -v docker >/dev/null 2>&1; then echo docker compose; \
 	else echo ''; fi)
 
-.PHONY: help fmt fmt-check vet lint test test-api test-features layout-check test-sqlite test-postgres check build cli-build experiment-intake journey-local validate deps-check tidy db-up db-down migrate seed admin dev dev-sqlite dev-postgres test-workflow test-workflow-postgres test-admin-e2e sqlc mock-up mock-down browser-mock web-install web-check web-build admin-check admin-build web-private-check web-private-build site-build site-verify pages-workflow-validate fork-smoke pages-preview pages-down docs docs-build share share-down
+.PHONY: help fmt fmt-check fmt-docs fmt-docs-check vet lint test test-api test-features layout-check test-sqlite test-postgres check check-ci build cli-build experiment-intake journey-local validate deps-check tidy db-up db-down migrate seed admin dev dev-sqlite dev-postgres test-workflow test-workflow-postgres test-admin-e2e sqlc mock-up mock-down browser-mock web-install web-check web-build admin-check admin-build web-private-check web-private-build site-build site-verify pages-workflow-validate fork-smoke pages-preview pages-down docs docs-build share share-down
 
 help: ## List targets
 	@grep -E '^[a-zA-Z_-]+:.*?## ' $(MAKEFILE_LIST) | \
 		awk 'BEGIN{FS=":.*?## "}{printf "  \033[36m%-13s\033[0m %s\n", $$1, $$2}'
 
-fmt: ## Format Go and frontend code
+fmt: fmt-docs ## Format Go, frontend code and Markdown
 	$(UV_RUN) run python scripts/format.py
 
-fmt-check: ## Check Go and frontend formatting without modifying files
+fmt-check: fmt-docs-check ## Check Go, frontend and Markdown without modifying files
 	$(UV_RUN) run python scripts/format.py --check
+
+fmt-docs: ## Fix Markdown lint with rumdl
+	$(RUMDL) check --config .rumdl.toml --fix .
+
+fmt-docs-check: ## Check Markdown with rumdl
+	$(RUMDL) check --config .rumdl.toml .
 
 vet: ## Run go vet
 	$(UV_RUN) run python scripts/go_tasks.py vet
@@ -38,7 +46,9 @@ lint: ## Lint Go (golangci-lint, from mise)
 test: ## Run Go tests with race detector + coverage
 	$(UV_RUN) run python scripts/go_tasks.py test
 
-check: fmt-check vet lint test test-features ## Pre-commit gate
+check: fmt-check check-ci ## Local pre-commit gate, including formatting
+
+check-ci: vet lint test test-features ## CI checks without local formatting tools
 
 build: ## Build all binaries
 	$(UV_RUN) run python scripts/go_tasks.py build

--- a/docs/archive/device-walkthroughs.md
+++ b/docs/archive/device-walkthroughs.md
@@ -83,7 +83,7 @@ identical:
 
 ## W1 — iPhone solo (the baseline)
 
-**During the trip**
+### During the trip
 
 - **Overland** (iOS) posts significant-location-change points to
   `https://track.<domain>` continuously — battery-cheap, survives multi-day trips,
@@ -93,7 +93,7 @@ identical:
 - Ticket stubs: photograph **in the moment when you can** (best EXIF), or batch them
   at the hotel — precedence rules absorb either.
 
-**After the trip**
+### After the trip
 
 ```bash
 # in Immich: album "Jeju 2026", ⭐ the ticket shots

--- a/docs/lessons/learnings.md
+++ b/docs/lessons/learnings.md
@@ -1,3 +1,5 @@
+# Learnings
+
 > Project-local fallback lessons captured when asobi was unavailable. Migrate into asobi when possible.
 
 ## 2026-07-12 — stable-journey-identifiers

--- a/docs/lessons/pitfalls.md
+++ b/docs/lessons/pitfalls.md
@@ -1,3 +1,5 @@
+# Pitfalls
+
 > Project-local fallback lessons captured when asobi was unavailable. Migrate into asobi when possible.
 
 ## 2026-07-12 — public-api-slug-identifiers

--- a/docs/research/backend-stack.md
+++ b/docs/research/backend-stack.md
@@ -2,7 +2,7 @@
 
 > 2026-07-08. A re-audit of the backend against the **memento** model (not the frozen
 > ticket-era [`archive/design.md`](../archive/design.md) / [`archive/spec-gaps.md`](../archive/spec-gaps.md)),
-> the v2 demo shape ([`web/src/data.ts`](../../web/src/data.ts)), and the
+> the v2 demo shape ([`web/src/data.ts`](../../packages/felicia-model/src/data.ts)), and the
 > presentation-agnostic-contract direction. Two halves: **(1)** popular-OSS library
 > selections for the Go backend, and **(2)** rewritten recommended decisions + todos.
 > Research-stage **leanings**, not locks — they graduate to a spec when ratified.
@@ -58,7 +58,7 @@ seams); **heavy geo stays in PostGIS SQL**, Go only does I/O + light geometry.
 > **manual/authored** — the hand-authored transit creator and back-fillable goods — so no
 > ticket to OCR. When it lands it's one source _behind_ the memento-creation seam; nothing in
 > the model changes.
-
+>
 > **Why not Viper?** It's popular and capable, but for our tiny config it's the wrong shape:
 > a large transitive dep tree, a **global singleton** (`viper.Get` from anywhere — hidden
 > coupling, harder to test the pure core), and **case-insensitive key folding** that has
@@ -163,7 +163,7 @@ migration.
 `felicia:decision:memento-template-registry`. A memento **kind is a template declared as
 data** — one entry per kind describing everything the three surfaces need:
 
-```
+```text
 template
   kind         "transit"
   anchor       point | edge          # edge => LineString geom (from→to); point => single coord
@@ -204,7 +204,7 @@ triplet is real triplicated work.
 Replaces the ticket-era `archive/todo.md` M0 "spec freeze." Flow stays research → spec →
 TDD → build; we are finishing **research**.
 
-**R — ratify (finish research)**
+### R — ratify (finish research)
 
 - [x] Ratify D1–D9 (or amend) and the §1 stack picks. _(D9 declarative registry ratified
       2026-07-09; D1–D8 still standing.)_
@@ -231,7 +231,7 @@ source_ref)`.
       union/compose (D2), Dawarich track+visits ingest and visit-snap (place-as-derived-visit).
       (OCR/vision pre-fill deferred — §1 note.)
 
-**T — TDD (first failing tests, memento order)**
+### T — TDD (first failing tests, memento order)
 
 - [ ] **Template registry + `kind_data` validation (D9).** `internal/domain`: load a template,
       validate a `kind_data` blob against it — required-missing, unknown-field, per-`type`

--- a/docs/research/data-model.md
+++ b/docs/research/data-model.md
@@ -4,7 +4,7 @@
 > zero. Derives from the decisions in [`backend-stack.md`](backend-stack.md) (D1–D8), the plan revision in [`backend-plan-revision.md`](backend-plan-revision.md), and
 > supersedes the ticket-era ER in [`archive/design.md`](../archive/design.md) §4.
 > It defines the DDL schema strictly for **PostgreSQL 18 + PostGIS**.
-
+>
 > **Status note (2026-07-18).** The storage framing below predates
 > [ADR-0017](../adr/0017-sqlite-first-storage.md): SQLite is now the default
 > local provider and PostgreSQL/PostGIS is optional (provider matrix in
@@ -26,7 +26,6 @@
    and translations add a **language axis**; the importer never clobbers authored work.
 5. **Uniform memento** — one `mementos` table, `kind`-tagged, kind-specifics in `kind_data`
    jsonb. New kinds = new enum value, not new tables.
-
 6. **Canonical observation seam** — source adapters map provider DTOs into
    `SourceIdentity`, `Observation`, `Route`, `Visit`, `MediaAsset`, and
    `MementoCandidate` values before the write side sees them. Provenance records

--- a/docs/research/notion-prototype.md
+++ b/docs/research/notion-prototype.md
@@ -31,7 +31,7 @@ Treat Notion as a **throwaway sandbox with a known exit**, never a creeping sour
 
 Three related databases. If it feels right here, the schema is probably right.
 
-**Trips**
+### Trips
 
 | Property              | Notion type | Notes                               |
 | --------------------- | ----------- | ----------------------------------- |
@@ -43,7 +43,7 @@ Three related databases. If it feels right here, the schema is probably right.
 | gpx                   | files       | **out-of-band** — Notion has no geo |
 | map-link              | url         | placeholder for the route           |
 
-**Mementos**
+### Mementos
 
 | Property    | Notion type      | Notes                                               |
 | ----------- | ---------------- | --------------------------------------------------- |

--- a/docs/research/saas-dataflow.md
+++ b/docs/research/saas-dataflow.md
@@ -6,12 +6,12 @@
 > route and memento input.** Research-stage sketch — a candidate, not a spec. Sits
 > downstream of [`product-vs-personal.md`](product-vs-personal.md) and the
 > [direction](../direction.md).
-
+>
 > **Updated 2026-06-14:** the "ticket" here generalizes to **memento** (`kind`-tagged) —
 > see [`mementos-not-tickets.md`](mementos-not-tickets.md). The flow below is unchanged in
 > shape; the stub-creation step (3) just accepts more sources (Wallet `.pkpass`, email,
 > goods-photo + vision-LLM) behind the _same seam_, and `TICKET` below is now `MEMENTO`.
-
+>
 > **Updated 2026-06-23:** the active MVP UI stack is **Svelte + TypeScript + Tailwind**.
 > **Updated 2026-07-01:** the map renderer is **MapLibre GL** for token-free OSS local demos.
 > There is no desktop plan yet.

--- a/docs/research/third-source-spike.md
+++ b/docs/research/third-source-spike.md
@@ -5,7 +5,7 @@ Date: 2026-07-13
 Task 7 uses a local YAML document as a realistic third source. It represents
 both a synchronized external-style record (`source_system` plus stable
 `external_id`) and Felicia-owned manual input. The adapter is intentionally
-thin: [`internal/manualyaml`](../../internal/manualyaml) parses the document
+thin: [`internal/manualyaml`](../../apps/felicia-providers/manualyaml) parses the document
 into `domain.Observation` and `domain.MementoCandidate`; it does not write the
 database or invent template behavior.
 

--- a/docs/reviews/2026-09-10-clean-rebuild-and-feasible-options.md
+++ b/docs/reviews/2026-09-10-clean-rebuild-and-feasible-options.md
@@ -1,0 +1,147 @@
+# Felicia from zero: mature product and feasible delivery options
+
+Proposal, 2026-09-10 JST. Companion to [the source-backed foundations review](2026-09-10-foundations-and-product-review.md), reviewed against `344ae46`. This document designs an alternative; it does not claim implementation or migration has been performed.
+
+## Recommendation
+
+If starting from zero, build **a local travel-journal studio that produces a deliberate, versioned public site**. Its center is the author's collection and writing; the map and collectible mementos are the reader experience. Reliable preservation, effortless intake and understandable publication are product features, not backend chores.
+
+For the existing Felicia, the most feasible choice is to replace the unsafe storage/import/publication boundaries inside the current repository, then reorganize the authoring experience around them. A fresh implementation is feasible, but it must earn its migration cost. Keep the original system available until a full journal has been imported, edited, published, withdrawn and restored successfully in the replacement.
+
+The goal is a complete, mature personal product. Early milestones below are delivery order, not permission to ship a reduced substitute. This proposal assumes single-author local operation remains the intended product; collaboration and hosted multi-user operation would change the architecture and should be a separate product decision.
+
+## What the finished product feels like
+
+1. **Connect or bring your trip.** Choose a date interval and timezone; connect GPS/photo sources or select local files. See what was found, what is missing and what needs interpretation. A trip can start without GPS or without photos.
+2. **Review one inbox.** Routes, suggested stops and photos arrive together. Accept, merge or dismiss suggestions. Repeated intake updates the evidence without moving things the author deliberately arranged.
+3. **Compose memories.** Group photos, choose a memento kind, write an essay, adjust place/time and order. Save drafts without completing every publication field. Recover local work after navigation, a failed save or a conflict.
+4. **Preview a publication.** Choose which journeys and memories are public, what location detail is acceptable, the site design and identity. Review changes since the previous build, including removals. Preview the exact build to be deployed.
+5. **Publish and return later.** A release has a stable identity and a clear outcome. Late photos and corrections enter the same workflow. A failed build retains the prior site. Withdrawal removes content from the next deployed artifact; backups restore the private journal, not merely its public rendering.
+
+Automation belongs in collection, deduplication, candidate generation, derivative creation and build validation. It must not silently decide what becomes public or overwrite an authored memory. Do not require daily records or impose Iroha-style completeness on a curated trip.
+
+## Architecture if there were no existing code
+
+Use one Go application with a CLI and a local authoring HTTP interface, one SQLite database, a private immutable media directory, and a static publication compiler. Use Svelte for the authoring app and reusable reader compositions. Internal packages separate responsibilities; separate services and one module per concept are unnecessary.
+
+The normal authoring authority is **SQLite plus original blobs**, with recoverable browser drafts for uncommitted edits. Imported packages are interchange inputs; exported recovery archives are backups. Neither silently overrides newer GUI edits. The static site is a sanitized projection, never the backup or primary database.
+
+| Boundary    | Owns                                                                            | Does not own                                |
+| ----------- | ------------------------------------------------------------------------------- | ------------------------------------------- |
+| Collection  | Source credentials, cursors, file receipts, retryable acquisition               | Authored essays or publication decisions    |
+| Intake      | Normalized evidence, deduplication, candidate proposals and review decisions    | Direct replacement of curated memories      |
+| Journal     | Journeys, visits/anchors, mementos, writing, ordering and revisions             | Provider-specific payload formats           |
+| Media       | Immutable originals, verified digests, attachment metadata and derivatives      | Destructive resets of authoring storage     |
+| Publication | Public projection, privacy rules, complete build manifests and release identity | Editing the private journal                 |
+| Application | Commands, API, authoring screens and reader hosts                               | A second implementation of the domain rules |
+
+Use the same application commands from the CLI and GUI. Keep one primary local database engine for a fresh product. PostgreSQL is not intrinsically needed to author locally and publish static files. For a port of existing Felicia, however, inventory PostgreSQL users/data first: either migrate and explicitly retire support or preserve it with the same conformance tests. This is a support decision, not an incidental cleanup.
+
+Avoid introducing a workflow engine, event sourcing for every field, a universal plugin system, microservices, remote object storage or a native mobile application without a demonstrated need. Retain adapter seams for actual sources. The existing Go modules can remain during an in-place rebuild; module consolidation is not a prerequisite for correctness.
+
+## Concrete storage model
+
+These are logical responsibilities, not a requirement to introduce every table at once or mirror the old schema mechanically.
+
+| Record                 | Identity and invariants                                                                                                        |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| Journal                | Stable journal ID, site identity, timezone defaults and settings revision                                                      |
+| Journey                | Stable ID, title/date interval, revision; imports cannot replace authored values                                               |
+| Source instance        | Provider/account or local collection identity; separate from an individual import                                              |
+| Import run and receipt | Source instance, input digest, acquisition interval, outcome and diagnostics; retry is distinguishable from new evidence       |
+| Observation            | Stable source-scoped identity, normalized value and provenance; newer interpretation does not acquire authorship               |
+| Stop proposal/review   | Stable derivation identity, evidence, decision and revision; re-planning retains accepted/ignored choices                      |
+| Memento                | Journey owner, kind, content, anchor, lifecycle and revision; meaningful incomplete drafts are allowed                         |
+| Authored overrides     | Explicit overridden fields, including intentional empty values; source refresh never clears them                               |
+| Blob                   | Verified content digest, size/type and immutable storage key; package filenames are metadata                                   |
+| Attachment             | Memento owner, blob reference, caption, order and revision; curation is independent of byte identity                           |
+| Build/release          | Input snapshot identity, privacy policy version, artifact digest, outcome and manifest; deployment acknowledgement is separate |
+
+Keep core ownership fields relational. Kind-specific details may remain validated JSON with versioned schemas; the renderer never gets to invent storage fields. Validate date/time semantics explicitly, preserve source timestamps and timezone uncertainty, and allow manual location correction without changing the original evidence.
+
+Enforce foreign keys, source-scoped uniqueness and revision predicates in the database. A read/merge/full-row-write sequence is not a sufficient authorship guard. Candidate plus evidence changes share a transaction. A photo's sequence/caption changes belong to a revision-aware curation command, not a generic import upsert.
+
+Use a small append-only command/import audit for diagnosis and recovery where valuable; do not require rebuilding all current state from an event log. Version database migrations and recovery formats independently from the public JSON contract.
+
+## Three workflows that must be correct by construction
+
+### Acquisition and import
+
+Acquire into a private staging area, validate the complete input, hash the original bytes, install immutable blobs, then transact references and normalized evidence. A failed transaction can leave unreferenced immutable files for conservative cleanup; it must not leave published references to missing bytes. Retry by receipt/source identity.
+
+Show an import result that distinguishes acquired, interpreted, applied, skipped and conflicted. Partial runs remain visible. Re-import can add source evidence and suggestions but cannot apply a manual author patch. An explicit restore/replace command is a separate, previewed operation with a recovery checkpoint.
+
+Connected-source refresh can be scheduled while the local application is running, with persisted checkpoints and retries. “Automatic” must not imply background operation while the computer is asleep or the app is stopped. Start with bounded catch-up on opening a journey and optional periodic refresh; introduce a daemon only if unattended collection is an actual requirement.
+
+### Authoring
+
+Save through revision-checked commands that return the committed revision. Keep the submitted draft until the save outcome is known. On conflict, preserve both versions and show a comparison or field-level choice; a reload must not discard the only copy of the author's work. Browser draft recovery is local and must respect the private-data boundary.
+
+Distinguish publication eligibility from editing state. Editing an eligible memory creates changes for a future build; it must not silently alter a remotely served static release. Keep manual photo order, captions, exclusions and anchor corrections independent of source refresh.
+
+### Publication and recovery
+
+Capture a consistent journal snapshot and its blob references. Produce all JSON, sanitized media and matching reader assets in a new owned build directory. Verify references, public-field allowlists, coordinate policy, draft exclusion, base paths and manifest hashes. Then promote the complete release; a failed build never changes the active one.
+
+For local serving, switch a release pointer atomically under a single build/promotion lock. For static hosts, use their complete-artifact deployment capability and record the acknowledged release; do not claim universal atomic deployment on arbitrary file-copy hosting. Serialize promotion and do not let an older build supersede a newer selected release by finishing late.
+
+Show “changes since build,” “built,” and “deployed” separately. Content edits, settings changes and removals affect the input digest. A network/status error means unknown, not clean. Unpublishing requires a new release and confirmed deployment; locally changing a flag does not retract previously deployed bytes.
+
+A recovery archive includes a consistent database snapshot, referenced original blobs, configuration needed to interpret it, version metadata and checksums. Restore into an empty location and validate before switching. Keep credentials out of portable publication artifacts; document how an author reconnects sources after recovery.
+
+## Complete feature port, not a minimal replacement
+
+| Capability           | Rebuild requirement                                                                                                                                                       |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Journey collection   | Multiple trips, stable IDs, dates/timezones, local GPX/photos and supported Dawarich/Immich inputs                                                                        |
+| Intake               | Routes, derived stops, evidence/confidence, review/merge/ignore, late arrivals and safe repeated import                                                                   |
+| Writing and curation | Existing memento kinds and kind data, essays, attachments/captions/order, anchors, drafts, validation and conflict recovery                                               |
+| Reader               | Private reader and public reader hosts; Atlas, Cabinet, Techo, Cartography; map routes/places, memento detail, galleries, deep links, supported system locales and themes |
+| Site                 | Site identity/settings, inclusion decisions, privacy precision/exclusion, exact-artifact preview, static build and base-path deployment                                   |
+| Interchange          | Existing workspace/package import with declared compatibility, export/recovery and identity mapping                                                                       |
+| Operations           | CLI/GUI parity for supported workflows, actionable failures, retry/catch-up, backup/restore and failed-build recovery                                                     |
+| Existing deployments | Inventory provider/database/API consumers; preserve or explicitly migrate them before retiring the old path                                                               |
+
+The inventory must include real data distributions and unsupported media behavior. Preserve originals even when the current public renderer cannot display them; explain that boundary rather than silently dropping attachments. Current AI enrichment and remote object storage deferrals do not automatically become rebuild requirements.
+
+## Feasible options for the existing repository
+
+| Option                            | Concrete scope                                                                                                                             | Benefit                                                                     | Cost/risk                                                  | Assessment                                                              |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------- | ---------------------------------------------------------- | ----------------------------------------------------------------------- |
+| A. Repair existing boundaries     | Fix the ten review findings, add recovery/build identity, then connect the existing admin flow                                             | Fastest route to trustworthy daily use; preserves current ports and readers | Existing split workflows remain until explicitly unified   | Best when current authoring broadly fits the user                       |
+| B. Replace the core in place      | Establish safe blob/import/publication commands; move existing callers onto them; redesign the authoring flow around one journal authority | Coherent product without rebuilding reader assets or every integration      | Requires careful data conversion and temporary adapters    | Recommended balance for a substantial rework                            |
+| C. Fresh successor with full port | New local studio implementing the architecture above; import the old journal and port all agreed capabilities before cutover               | Cleanest implementation boundaries                                          | Largest duplicate effort, parity burden and migration risk | Feasible if concrete structural blockers make B harder than replacement |
+
+These options have different scopes, not different quality bars. A can still deliver a mature product. B is not a permanent dual-system design. C must not be called complete when only one reader or a clean demo dataset works.
+
+Before choosing C, compare one representative vertical slice: import two trips with colliding media names, author and revise memories, re-import, build, withdraw and restore. Identify which current abstractions prevent that slice from being implemented cleanly. The existing review finds broken boundaries, but does not establish that the current codebase is fundamentally incapable of enforcing them.
+
+## Recommended implementation sequence for option B
+
+| Phase | Deliverable                                                                    | Exit evidence                                                                                               |
+| ----- | ------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------- |
+| 0     | Repair the destructive preview path; capture current capability/data inventory | Preview cannot delete originals; retained inputs and author state are enumerated                            |
+| 1     | Recovery archive and verified immutable blob mapping                           | Restore a representative multi-trip journal; colliding filenames retain correct bytes                       |
+| 2     | Atomic source intake and revision-aware author commands                        | Late input, retry, concurrency and old-package tests preserve all authored values and review decisions      |
+| 3     | Consistent snapshot compiler and complete release promotion                    | Failed/concurrent builds retain a coherent active release; withdrawn files are absent from the new artifact |
+| 4     | One inbox/editor/publication flow using those commands                         | No routine terminal step between available evidence and local public preview; conflicts retain drafts       |
+| 5     | Port complete reader/deployment/interchange behavior                           | All capability rows pass; old data and consumers have an explicit disposition                               |
+| 6     | Rehearsed cutover and real authoring acceptance                                | Author uses a new trip plus a revision to an old trip, deploys, withdraws, and restores without lost work   |
+
+Keep the source-backed review's specific regression cases as the acceptance ledger. Split phases into focused changes when implementation starts. Do not schedule a fixed completion date before measuring archive/restore and one full slice; those establish the real effort better than estimates from file count.
+
+## Migration and cutover
+
+Inventory database state, originals, authored workspaces, decisions, site settings and external consumers before designing conversion. Stop writers for a consistent export. Preserve old IDs where possible; record explicit mappings otherwise. Verify media byte hashes and authored fields, not just row counts or whether the homepage renders.
+
+Run the replacement against a restored copy, with no permanent dual writes. Compare private-state preservation and intended public output separately; privacy fixes may intentionally change public output. At cutover, take a final checkpoint, import/convert, validate and only then reopen authoring. Keep the previous application/data available for rollback. After new edits begin, rollback must carry those edits and blobs back or preserve them in a recoverable archive; restoring an old database alone is data loss.
+
+The first two foundation repairs should not wait for a final decision about a successor. Preserve the current originals and archive the journal before experimentation.
+
+## Decision to carry forward
+
+Adopt option B if the intention is to spend meaningful effort improving Felicia itself. Keep option C as an implementation alternative with the same feature and recovery gates. Retain option A if the authoring workflow proves satisfactory after targeted fixes.
+
+The product needs fewer contradictory write/build paths and clearer ownership of the author's work. Starting from zero is useful for defining that destination; it is not itself evidence that throwing away working readers, parsers and tests is the most feasible route there.
+
+This is a design proposal based on the prior local source review, not a new competitor survey or a tested replacement. Existing review verification limits still apply.

--- a/docs/reviews/2026-09-10-foundations-and-product-review.md
+++ b/docs/reviews/2026-09-10-foundations-and-product-review.md
@@ -1,0 +1,157 @@
+# Felicia: foundations and product review
+
+Reviewed on 2026-09-10 JST against `344ae46` and the current working tree. Recommendation, not implementation approval.
+
+## Decision
+
+Felicia needs a focused foundational rework and a more coherent authoring-to-publication workflow. It does not currently justify starting from zero, changing the stack, replacing the journey/memento model, or rebuilding its four reader designs.
+
+The product idea is sound, but several implementation paths contradict its strongest promises: preserve authorship, retain originals, and publish only a deliberate safe artifact. These are release-blocking concerns for a mature journal, even though its happy-path MVP is complete. More visual polish or automated imports should follow their repair.
+
+Felicia differs materially from Iroha. External GPS and photos are inputs, but essays, curation, captions, chosen locations and original media are valuable author-owned state. They cannot be assumed reconstructible from providers or a sanitized public site. A destructive rebuild of derived data must never imply permission to discard them.
+
+## Scope and evidence
+
+Read the current project instructions, direction, selected user journey, Make workflows, admin screens, publication/compiler, package ingestion, and SQLite/PostgreSQL write paths. Two independent source reviews covered ingestion/persistence and publication/media. Existing graph checkpoints were stale and were not treated as completion evidence.
+
+The checkout began on `main` with 68 pre-existing modified documentation files, including `AGENTS.md`. Those changes are preserved. This review adds one new document. No private journal, credentials, deployed instance, external providers, or sibling checkout was accessed. No production command, publication or database migration was executed.
+
+One destructive-build defect was reproduced against temporary paths with external commands mocked. Other findings below are source-backed reachable paths, not claims of observed production incidents. The UI review is of implemented interaction/state handling, not a rendered visual or accessibility certification. Historic bugs already described as fixed in the README are not automatically counted as current defects.
+
+## Product contract to retain
+
+The useful user story is: return from a trip, collect evidence, select the places and memories worth keeping, write and arrange them, preview the exact public result, publish, and revisit or revise it later without losing prior work.
+
+Keep these foundations:
+
+- Journey → memento → essay/photos, with derived visits as useful location anchors.
+- SQLite local authoring and a static public artifact as the primary supported workflow.
+- Shared publication contracts for live/static readers, and the Atlas, Cabinet, Techo and Cartography compositions.
+- Provider adapters, pure intake planning, stable candidate identities and explicit review decisions.
+- Authored-field masks, manual-edit revisions, transactional package metadata, image sanitization and published-state filtering. These mechanisms need consistent enforcement, not replacement with a universal data platform.
+
+Do not equate automation with auto-publication. Importing evidence can become automatic; deciding what expresses a memory and what is safe to share remains an author action.
+
+## Findings that change the implementation plan
+
+### F1 — P0: the Pages preview workflow can delete authoring originals
+
+`scripts/felicia.py:18` uses `.felicia/media`; lines 29–38 recursively delete the selected media directory whenever `PAGES_DB` is unset, including an explicit `PAGES_MEDIA_ROOT`. The server defaults to the same media root (`apps/felicia-server/config/config.go:25`), as does CLI import (`apps/felicia-cli/cmd/felicia/main.go:246`). `make pages-preview` reaches this script at `Makefile:179`. The separate `make site-build` path does not execute this particular deletion.
+
+Reproduction: imported the actual Python module, redirected all roots to a temporary directory, placed a sentinel original in the selected media root, cleared environment overrides, and mocked `run()` to stop at the first build command. The sentinel was deleted before that command. No real data was touched.
+
+Replace the shared default with an explicitly disposable publication workspace. Reset only a directory whose ownership the build can prove; reject overlap with the authoring database, originals and authored workspaces. A failing preview build must leave all originals intact. This is the first repair, before another local Pages preview.
+
+### F2 — P1: package member names become shared media identity
+
+`apps/felicia-runtime/importer/package.go:335–341` carries a package photo path into `ObjectKey`; `apps/felicia-cli/cmd/felicia/main.go:284–297` writes that path beneath the shared media root with `os.WriteFile`. Two different packages containing `media/ticket.jpg` can therefore replace one another's bytes despite having different photo identities.
+
+Public image sanitization does not prevent a collision in the private source store. Store immutable originals by verified content identity, with package-member-to-blob mappings. Verify two packages with the same member name and different bytes preserve both images and their references.
+
+### F3 — P1: database import commits before its media is durable
+
+CLI `main.go:280` applies the package transaction; lines 284–297 subsequently copy files. `apps/felicia-runtime/importer/package.go:69–77` confirms the SQL transaction completes inside that call. Disk failure or interruption can leave committed references to absent or incomplete originals.
+
+Stage and validate immutable files before publishing database references. A failed transaction may leave recoverable unreferenced blobs; it must not leave committed references to missing bytes. Define retry behavior and conservative orphan cleanup, and inject failures at each boundary. A general distributed transaction system is unnecessary.
+
+### F4 — P1: package re-import bypasses authorship protection
+
+`apps/felicia-runtime/importer/package.go:44–46` promises authored fields are not supplied, but lines 105–107 invoke `ApplyManualMementoPatch` with package-authored fields and state, without an expected revision. Lines 111–114 upsert photos; PostgreSQL `queries/query.sql:201–208` replaces caption, sequence and association.
+
+An old authored package can overwrite a newer essay or photo arrangement. The ordinary source-import path and intentional archive restoration need different contracts. Default re-import should preserve later authored state; conflicting authored package values should produce a reviewable conflict. Explicit restore/replace should be a separate operation with a preview and backup. Test import → edit essay/caption/order → re-import, including lifecycle state changes.
+
+### F5 — P1: journey ingest protection is a read/merge/write race
+
+SQLite `store.go:398–409` and PostgreSQL `repository.go:266–277` read a journey, merge fields in memory, then call the ordinary full-row upsert. SQLite `store.go:430` replaces the authored values and mask. There is no revision predicate or row lock in these ingest methods; route sync can call them outside package transactions.
+
+Interleaving: ingest reads → author changes title and marks it authored → ingest writes the stale copy while updating the route. The title and protection mask can be lost. Make field ownership checks and updates atomic against current database state, or use revisions/locking with a bounded retry. Test that exact interleaving on each supported provider. Single-user does not mean single-request.
+
+### F6 — P1: PostgreSQL stop refresh can return failure after partial mutation
+
+`apps/felicia-providers/postgres/stop_candidate.go:85–113` updates the candidate, deletes evidence, then validates/inserts replacement evidence without an internal transaction. `apps/felicia-runtime/intake/service.go:82–89` calls candidate upserts directly. SQLite's equivalent is transactional (`sqlite/stop_candidate.go:98–105,140–154`).
+
+Validate the complete replacement first and transact candidate plus evidence together, including when called inside an existing transaction. Use one conformance case that injects invalid evidence and insert failure; both providers must retain the complete prior state. This is a current behavioral mismatch; historic table-name drift alone is not evidence of current schema drift.
+
+### F7 — P1: journey index coordinates bypass the privacy boundary
+
+`apps/felicia-publication/projection.go:62–68` emits raw point coordinates or the first line coordinate into `representative_dots`. The shared journey index projection is used by the compiler and live API. Detail geometry rounding does not cover this path.
+
+Route all public coordinates through the same precision policy and test high-precision inputs in both index and detail JSON. Audit coordinate-bearing `kind_data` as a follow-up; this review does not claim it is a demonstrated second leak. Rounding itself is a precision policy, not a substitute for author-controlled omission of a sensitive place.
+
+### F8 — P1: publication lacks a complete-artifact commit boundary
+
+`apps/felicia-publication/fileio.go:85–110` atomically replaces individual files. That does not make a complete build atomic. A later compiler failure leaves mixed output. Server `api/server.go:1271–1282` only finalizes after compilation succeeds.
+
+At `fileio.go:157–170`, an unreadable or malformed previous manifest becomes an empty inventory. Finalization then skips stale-file removal and replaces the manifest, forgetting older files. An unpublished image can remain directly reachable even if it disappears from the index. The malformed-manifest test currently accepts this behavior.
+
+Build a complete artifact in a new owned directory from a consistent input snapshot, verify it, then switch the served release. Serialize builds targeting the same publication and keep the prior valid release on failure. Treat malformed ownership metadata as an error for reused output, not successful cleanup. Test unpublication, corrupt manifests, concurrent builds and failure midway through media processing. Preserve the public SPA alongside its matching data release.
+
+### F9 — P1/P2: “pending build” ignores content changes and confuses built with deployed
+
+`apps/felicia-server/api/buildstatus.go:17–23,59–89` compares only published memento ID membership. Editing an already-published essay, caption, journey title or site settings can leave zero pending items. No artifact also returns zero. `JourneyDetail.svelte:216–224` converts status-read errors into an empty pending set.
+
+Track the revision or content digest of the complete publication input against the last successful local build. Distinguish “never built,” “changes since build,” “build failed/unknown,” and “built.” Track a deployed release separately only when a deployment workflow can provide evidence; a local output directory is not proof of what a remote site serves. Verify an essay-only edit marks the site dirty and a status error does not look clean.
+
+### F10 — P2: conflict recovery discards the draft the author needs to reapply
+
+`apps/felicia-admin/src/views/MementoEditor.svelte:246–247` handles “Reload and reapply” by calling `loadAll()`. Lines 175–179 hydrate the form from the server, replacing its local contents. The label at line 396 suggests a recovery action, but the unsaved draft is not retained or merged.
+
+Preserve the attempted draft on conflict and show what changed before retrying. Add explicit unsaved-navigation handling or local draft recovery for essays and captions. This is a source-level interaction finding; no browser reproduction was performed. Test two editor sessions and intentional navigation during a save.
+
+## Data-model recommendation
+
+Retain the current domain tables. A memento with kind-specific data is a sensible model; no finding requires an all-purpose fact/event schema or a rewrite of every repository interface.
+
+Strengthen the boundaries that the model currently expresses only partially:
+
+1. Immutable original blobs, independent of filenames and package membership.
+2. Source observations/import membership distinct from authored overlays and explicit restore commands.
+3. Revision-aware aggregate writes for journeys and curated photos as well as mementos.
+4. Candidate/evidence changes committed together, with provider conformance tests.
+5. A publication input revision/digest and immutable build identity, separate from publication eligibility and deployment acknowledgement.
+
+Choose one authoring authority for the normal workflow: the local database plus retained originals and author drafts. JSON workspaces/packages are import/export interchange or explicitly selected alternative authoring workflows; they must not silently compete with later GUI edits. A public artifact is deliberately lossy and cannot serve as the recovery archive.
+
+Keep SQLite as the primary release path. Do not expand PostgreSQL-specific features while correctness parity is incomplete. If PostgreSQL remains supported, every relevant invariant must pass on both; otherwise explicitly narrow its support status before release. Do not remove it merely to reduce the review's task list.
+
+## Workflow and UX recommendation
+
+The four reader designs are already a product asset. The larger UX return is in the authoring loop:
+
+- One trip inbox combines route/photo intake outcomes and candidate review. Show missing evidence and partial import failures without inventing memories.
+- Curate first, then write. Preserve selections and essays across refreshes, re-imports and conflicts. Allow incomplete drafts without forcing final metadata prematurely.
+- Separate “include in next publication” from “build preview” and “deploy.” Show the exact changes included in a build, including edits and removals.
+- Preview the exact artifact intended for deployment. Surface privacy exclusions, missing media and unresolved conflicts before build promotion.
+- Make backup/export and restore part of the supported author workflow, including originals, essays, revisions and curation. Rehearse restoring into a fresh local installation.
+
+The current admin includes internal milestone language and implementation instructions in user-facing copy (`SiteDeploy.svelte:190–199,219–220`). Replace these after the underlying workflow is truthful; better copy alone will not solve preservation or stale build state.
+
+Do not copy Iroha's daily coverage model into Felicia. A journey is deliberately curated and may have sparse memories or no route. Automatic collection should reduce repeated effort, but daily rows and periodic imports are not Felicia's core success criterion.
+
+## Concrete repair sequence
+
+| Order | Work                                                                                    | Acceptance before proceeding                                                                                                              |
+| ----- | --------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| 1     | Protect private roots and isolate disposable publication workspaces (F1)                | Temporary sentinel originals survive default/overridden preview paths and forced build failure.                                           |
+| 2     | Inventory retained data and establish a recovery archive                                | Fresh-machine restore reproduces essays, captions, ordering, original bytes and identity links. No destructive repair before this gate.   |
+| 3     | Make original-media identity and import publication safe (F2–F3)                        | Same filenames across two trips do not collide; interrupted/retried imports preserve references and bytes.                                |
+| 4     | Separate re-import from restore; enforce atomic authorship and evidence updates (F4–F6) | Re-import after editing and concurrent edit/import preserve authorship; provider failure tests leave no partial state.                    |
+| 5     | Close every public coordinate projection and stage whole artifacts (F7–F8)              | High-precision data passes the policy; failed builds retain the previous release; unpublication removes direct access in the new release. |
+| 6     | Add accurate build identity/status and conflict draft recovery (F9–F10)                 | Essay-only edits mark changes; status failure is unknown; conflicts retain local work; built/deployed are distinct.                       |
+| 7     | Connect intake, curation, preview and deployment around those contracts                 | Complete two-trip workflow with revisits, late photos, corrected route, withdrawal, failure/retry and restore; verify all four readers.   |
+
+This is a finite repair program within the existing repo. Several findings can share a carefully scoped change, but media migration, authored-state migration and artifact promotion should remain separately reviewable. Estimate effort after the retained-data and current test baseline are known; this review does not invent a delivery date.
+
+## Verification and limits
+
+The temporary Python reproduction for F1 passed: the current code removed the sentinel before its first external build command. This validates the defect, not a fix. No product code was changed.
+
+`make check` stopped in formatting: two pre-existing dirty documents (`docs/adr/0010-media-pipeline.md` and `docs/research/tabi-design-reset.md`) fail Prettier. They were not modified by this review. Frontend dependencies are missing; `scripts/format.py:62–65` reports this but returns success for the frontend formatting step, so a green aggregate formatting result would not certify those files. The new review document is checked separately with the repository Markdown formatting options. `make test` was attempted separately and stopped during CLI test setup because downloading `modernc.org/sqlite@v1.23.1` failed certificate validation. No Go test pass is claimed. No real provider/device trial, rendered UI walkthrough, database migration, restore rehearsal or deployment was run. The source findings must become focused regression cases in the repair work; existing unit test counts alone do not prove these boundary guarantees.
+
+The recommendation is to repair foundations first, then complete the authoring UX using the existing product. A clean rebuild would still need all the same preservation and publication decisions, while adding migration risk for the most valuable data Felicia owns.
+
+### Follow-up: local Markdown tooling
+
+The PR also replaces the Markdown Prettier path with Nix-provided rumdl. `make fmt-docs` fixes Markdown and `make fmt-docs-check` checks it. Local `make check` includes formatting; CI runs `make check-ci` (vet, lint, tests and feature contracts), which does not require rumdl. No rumdl installation was added to mise or CI.
+
+After fixing the remaining Markdown findings, rumdl passes all 128 files. Local `make check` now passes its formatting stage but is blocked in Go vet by the SQLite dependency download certificate error. The frontend formatter reports missing dependencies and skips its portion, as noted above. These are not full repository passes.

--- a/scripts/format.py
+++ b/scripts/format.py
@@ -21,17 +21,6 @@ def go_files() -> list[Path]:
     )
 
 
-def markdown_files() -> list[Path]:
-    return sorted(
-        path
-        for path in ROOT.rglob("*.md")
-        if ".git" not in path.parts
-        and "node_modules" not in path.parts
-        and "site" not in path.parts
-        and ".venv" not in path.parts
-    )
-
-
 def run(command: list[str], *, cwd: Path = ROOT) -> subprocess.CompletedProcess[str]:
     return subprocess.run(command, cwd=cwd, check=False, text=True, capture_output=True)
 
@@ -76,41 +65,11 @@ def format_web(check: bool) -> bool:
     return success
 
 
-def format_markdown(check: bool) -> bool:
-    mode = "--check" if check else "--write"
-    files = [str(path) for path in markdown_files()]
-    if not files:
-        return True
-    # Markdown is repository documentation, not a frontend dependency. Keep this
-    # path usable before `make web-install` and avoid loading the Svelte plugin.
-    result = run(
-        [
-            "bun",
-            "run",
-            "--cwd",
-            "apps/felicia-public-site",
-            "prettier",
-            "--no-config",
-            "--parser",
-            "markdown",
-            "--prose-wrap",
-            "preserve",
-            "--print-width",
-            "200",
-            mode,
-            *files,
-        ]
-    )
-    print(result.stdout, end="")
-    print(result.stderr, end="")
-    return result.returncode == 0
-
-
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--check", action="store_true")
     args = parser.parse_args()
-    success = format_go(args.check) and format_web(args.check) and format_markdown(args.check)
+    success = format_go(args.check) and format_web(args.check)
     return 0 if success else 1
 
 


### PR DESCRIPTION
Felicia's authoring and publication paths contain preservation and consistency gaps despite a complete happy-path MVP. This change documents those findings and compares feasible routes to a mature journal, while completing the requested local Markdown lint migration.

Read `docs/reviews/2026-09-10-foundations-and-product-review.md` for ten prioritized findings, a safely reproduced preview-media deletion defect, and seven ordered repair steps. The companion `2026-09-10-clean-rebuild-and-feasible-options.md` defines a complete clean-start architecture, feature-port requirements, and migration/recovery gates. It recommends replacing unsafe boundaries in place while retaining useful readers and integrations. Product repairs are proposed, not implemented.

Markdown formatting now uses Nix-provided rumdl through `make fmt-docs` and `make fmt-docs-check`. Local `make check` includes formatting; CI uses `make check-ci` for vet, lint, tests and feature contracts without requiring rumdl. The obsolete Markdown Prettier helper is removed. Remaining Markdown headings, blockquotes and stale links are corrected, with narrow exceptions for intentional README/agent/archive layouts.

Validation:
- Rumdl passes all 128 Markdown files; staged whitespace checks pass.
- Make dry-run verification confirms the local/CI split and retained CI checks; Python syntax validation passes.
- `make check` and `make validate` reach Go vet but fail downloading the SQLite dependency because of certificate validation. Frontend dependencies are also unavailable; the existing formatter reports and skips that portion.
- The user explicitly approved proceeding with the documented gate blocker. No verification bypass or TLS disabling was used.

No private data, migrations, deployment, or product implementation changes are included. Other pre-existing working-tree edits remain outside this commit.
