### PR TITLE
fix: stop rumdl autofixes from rewriting document content

### DIFF
--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -1,6 +1,12 @@
 [global]
-# Match the workstation Markdown policy: prose is not hard-wrapped.
-disable = ["MD013"]
+# MD013: match the workstation Markdown policy — prose is not hard-wrapped.
+# MD025: ADRs and contracts carry a frontmatter `title:` *and* an H1 heading, which
+# MD025 counts as two top-level headings. Its autofix demotes every H1 to H2 and
+# cascades the whole outline, so the rule is disabled rather than obeyed.
+# MD018: a prose line may legitimately begin with `#` — an issue reference like
+# `#68`, or an anchor like `#decision`. The autofix reads it as a heading and
+# splits the sentence into one. The reference stays; the rule goes.
+disable = ["MD013", "MD025", "MD018"]
 exclude = ["node_modules/**", ".venv/**", ".felicia/**", "site/**", "apps/*/dist/**"]
 
 [per-file-ignores]
@@ -10,3 +16,7 @@ exclude = ["node_modules/**", ".venv/**", ".felicia/**", "site/**", "apps/*/dist
 "README.md" = ["MD033", "MD041"]
 # Archived issue bodies inherit their title from the issue itself.
 "docs/archive/github-issues/*.md" = ["MD041"]
+# The indented body of a mkdocs-material `!!! note` admonition is not an
+# indented code block; MD046's autofix turns it into a fenced one and the
+# callout stops rendering.
+"docs/publish.md" = ["MD046"]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ where you author _essays / photo curation / animation_. The importer is **field-
 
 ### Current layout
 
-```
+```text
 apps/{felicia-core,felicia-runtime,felicia-providers,felicia-publication,
 felicia-server,felicia-cli,felicia-admin,felicia-web,felicia-public-site}/
 packages/{felicia-model,felicia-runtime,felicia-components,felicia-renderers,
@@ -189,7 +189,7 @@ One classification standard for the open ledger. Three competing title schemes
   a workaround · `prio:P3` correctness/polish, nobody blocked.
 - **Work order:** milestone ascending, then priority ascending. Query it, don't guess:
 
-  ```
+  ```text
   gh issue list --state open --milestone "R4 — Ingestion and route enrichment" --label prio:P0
   ```
 

--- a/docs/adr/0007-backend-stack.md
+++ b/docs/adr/0007-backend-stack.md
@@ -28,7 +28,7 @@ The libraries and tools selected:
 5. **Object Storage (minio-go v7):** A lightweight, S3-compatible client that allows pointing at Cloudflare R2, MinIO, or Backblaze B2 via simple configuration.
 6. **Migrations (goose):** Simple, SQL-based database migrations.
 
-### PostgreSQL 18 Exploitation:
+### PostgreSQL 18 Exploitation
 
 We explicitly target PostgreSQL 18 to leverage its modern features:
 

--- a/docs/adr/0010-media-pipeline.md
+++ b/docs/adr/0010-media-pipeline.md
@@ -34,7 +34,7 @@ Two planes, one seam.
      image must not leak them),
    - content-addresses by `content_hash` (Immich `checksum`) → `object_key =
 photos/{hash}/{variant}.webp`; upload is idempotent (skip if present), so re-import is free
-     and de-duped,
+   and de-duped,
    - records `memento_photos{ object_key, content_hash, … }` (columns already exist).
 
 3. **Object store = S3-compatible R2** (MinIO/B2 swappable by config; `internal/objectstore`),

--- a/docs/archive/importer-spec.md
+++ b/docs/archive/importer-spec.md
@@ -31,7 +31,7 @@ zero rewrites.
 
 ## 2. CLI surface
 
-```
+```text
 waypoints <command> [flags]
 
   import   Ingest a trip into Postgres + object storage (idempotent).
@@ -42,7 +42,7 @@ waypoints <command> [flags]
 
 ### `import`
 
-```
+```text
 waypoints import [SOURCE] [flags]
 
 SOURCE (one of):
@@ -59,7 +59,7 @@ flags:
 
 ### `sync`
 
-```
+```text
 waypoints sync --immich-album "Jeju 2026" [--track f.gpx] [--out content/trips/<slug>.yaml]
 ```
 
@@ -68,7 +68,7 @@ review. Never touches the DB. Re-running merges into an existing draft (keeps yo
 
 ### `export`
 
-```
+```text
 waypoints export [--journey <slug>] [--out content/trips/]
 ```
 

--- a/docs/archive/user-journey-status-log.md
+++ b/docs/archive/user-journey-status-log.md
@@ -25,9 +25,7 @@ longer the two most recent. Kept for history; not maintained going forward.
   saves title/accent, reloads to confirm persistence, builds, and checks
   both the live `/api/v1/site` response and the compiled `site.json` on
   disk.
-
 - **2026-07-22 (issue audit & milestone reconciliation)** — Conducted a full audit of open GitHub issues against implementation status. Verified completion and closed 21 issues across M0 (content & acceptance lock), M1 (canonical storage & public API projections), M2 (declarative templates & projections), M3 (admin authoring GUI MVP), M4 (ingestion connectors & intake planner), and epic FELICIA-PAGES-01 (#40–#50). Added 3 new enhancement issues on GitHub: #57 (automatic journey date bounds derivation), #58 (offline timezone resolution via `tzf`), and #59 (optional local AI agent ticket artwork generator for missing media in admin GUI). Updated roadmap and delivery trackers accordingly.
-
 - **2026-07-19 (memento lifecycle + staged rebuild)** — Formalized the
   memento lifecycle as a binding contract
   ([docs/contracts/memento-lifecycle.md](../contracts/memento-lifecycle.md))

--- a/docs/research/authoring-publish-flow.md
+++ b/docs/research/authoring-publish-flow.md
@@ -10,7 +10,7 @@
 
 ## The flow
 
-```
+```text
 1. INGEST    GPX / Dawarich track  +  Immich photos
                 track  → the amber route line
                 photos ⨝ track on timestamp → CANDIDATE anchors (auto-proposed)

--- a/docs/research/backend-plan-revision.md
+++ b/docs/research/backend-plan-revision.md
@@ -57,6 +57,7 @@ By using **PostgreSQL 18** as our database foundation, we leverage modern, stabl
 1. **SQL/JSON Standard Functions:**
    - Instead of relying on PG-specific legacy JSON operators (`#>`, `->>`), queries on `mementos.kind_data` utilize standard SQL/JSON functions (`JSON_VALUE`, `JSON_QUERY`, `JSON_EXISTS`). This aligns our schema queries with standard SQL and improves query planner optimization.
    - Example query for transit mementos:
+
      ```sql
      SELECT id, JSON_VALUE(kind_data, '$.operator' RETURNING text) AS operator
      FROM mementos
@@ -65,6 +66,7 @@ By using **PostgreSQL 18** as our database foundation, we leverage modern, stabl
 
 2. **Advanced MERGE for Field-Scoped Upserts:**
    - PostgreSQL 18's enhanced `MERGE` statement executes complex conditional upserts (our multi-axis "no-clobber" rule) in a single database transaction:
+
      ```sql
      MERGE INTO mementos AS target
      USING (VALUES ($1, $2, $3, $4, $5)) AS source(journey_id, source_ref, kind, geom, occurred_at)
@@ -75,6 +77,7 @@ By using **PostgreSQL 18** as our database foundation, we leverage modern, stabl
          INSERT (journey_id, source_ref, kind, geom, occurred_at)
          VALUES (source.journey_id, source.source_ref, source.kind, source.geom, source.occurred_at);
      ```
+
    - This guarantees atomic updates and eliminates check-then-write roundtrips in Go application logic.
 
 3. **Sequential UUIDv7 Keys:**
@@ -111,6 +114,7 @@ graph TD
 The v3 Techo landing page renders a map with representative place dots per journey and a card index. To avoid N+1 queries:
 
 - `GET /api/v1/journeys` returns a collection of journeys, where each item includes:
+
   ```json
   {
     "slug": "2026-japan-spring",
@@ -122,6 +126,7 @@ The v3 Techo landing page renders a map with representative place dots per journ
     ]
   }
   ```
+
 - **Selection Heuristic:** The database derives these representative dots at query time by selecting up to 3 mementos per journey, ordered by:
   1. The chronological order (`occurred_at ASC`).
   2. Prioritizing distinct places over adjacent points.
@@ -140,7 +145,7 @@ If a user requests the English (`en`) interface:
 
 The **A+E model** coordinates automated ingestion (**A**) with manual authoring (**E**).
 
-```
+```text
 [Immich API] ──> Fetch Photo ──> Resize & Strip EXIF ──> Hash Derivative ──> Deduplicate R2
                                                                          └─> Seed Memento (DB)
 ```
@@ -189,7 +194,7 @@ If a kind template definition (e.g. `transit.yaml`) changes over time:
 
 To support a single-user publishing model (similar to `yihong0618/running_page`), `felicia` operates as a compiler that reads from our primary **PostgreSQL 18 + PostGIS** database to generate a zero-cost, 100% static public website.
 
-```
+```text
 +------------------+                   +--------------------+                   +----------------------+
 | Local Authoring  |                   |   Primary PG18     |                   |   Static Site Build  |
 | (Go localhost    | ==[Writes to]==>  |   Database         | ==[Compiles to]==> | (Static JSONs +      |

--- a/docs/research/mementos-not-tickets.md
+++ b/docs/research/mementos-not-tickets.md
@@ -27,7 +27,7 @@ stub isn't a compromise. It's the design.
 > **Ticket → Memento:** a _collectible that anchors a memory_, tagged with a `kind`. The
 > `kind` selects the rendered stub **form**. Everything else is unchanged.
 
-```
+```text
 Journey → Memento → { essay, photo gallery, open-animation }
           kind: ticket | goods | receipt | souvenir | stamp | …
 ```

--- a/docs/research/notion-to-stack.md
+++ b/docs/research/notion-to-stack.md
@@ -37,7 +37,7 @@ Notion is the _source_, our importer is the _sink_ — and it's the **same Memen
 seam** as every other source ([mementos-not-tickets](mementos-not-tickets.md)). So a
 `notion` source is just one more interface impl behind that seam:
 
-```
+```text
 Notion API ──▶ notionSource (impl) ──▶ Memento-creation seam ──▶ core ──▶ Postgres + R2
    (pages,        maps page→draft        image + structured        (same as OCR /
     relations,    + re-fetches files     draft + route             Wallet / goods-photo)

--- a/docs/research/reader-admin-surfaces.md
+++ b/docs/research/reader-admin-surfaces.md
@@ -29,7 +29,7 @@ where it goes — the admin app.
 
 `authoring-publish-flow.md` defines the motions; the admin app is where they live:
 
-```
+```text
 INGEST   → candidates auto-proposed (Immich × Dawarich on timestamp)
 CURATE   → confirm / merge / reject   ← "Review Queue" belongs here
 AUTHOR   → pick kind, attach photos, write the essay; Transit Creator lives here

--- a/docs/research/source-connectors.md
+++ b/docs/research/source-connectors.md
@@ -24,7 +24,7 @@ Dawarich's trick isn't "be generic." It accepts OwnTracks / Overland / GPSLogger
 translates each into **one** internal point shape; everything downstream is generic over that
 shape, not over the sources. Copy exactly this — normalize at the edge, keep the core narrow:
 
-```
+```text
 internal/domain (pure, no I/O) — the normalized shapes everything joins on
   TrackPoint  { At; Lat; Lon }
   PhotoAsset  { ID; At; Lat?; Lon?; Kind }   // Lat/Lon nil → fill from track by timestamp
@@ -32,7 +32,7 @@ internal/domain (pure, no I/O) — the normalized shapes everything joins on
 
 Two small **typed roles** at the seam — not N generic sources:
 
-```
+```text
 TrackSource  { Track(from, to) -> []TrackPoint }     // Dawarich impls this
 PhotoSource  { Assets(Query)   -> []PhotoAsset  }     // Immich impls this
 ```
@@ -49,7 +49,7 @@ data model has grown the full pipeline **`points → tracks → visits @ places 
 (`felicia:decision:place-as-derived-visit`, data-model §Places). So the `TrackSource` role yields
 more than points:
 
-```
+```text
 TrackSource {
   Track(from, to)  -> []TrackPoint    // the polyline → journeys.gps_route
   Visits(from, to) -> []Visit         // stays: {coord, label, arrive, depart} → derived places
@@ -105,7 +105,7 @@ dialect.
 "Some kind of query to assemble a memento" sounds clean, but the assembly _is_ the product,
 and none of it is expressible as a generic OpenAPI field mapping:
 
-```
+```text
 pull track  ─┐
 pull assets ─┴─▶ timestamp-join ─▶ cluster (time+space) ─▶ pick stub
                                                           └▶ vision-LLM pre-fill kind/vendor/price

--- a/docs/research/tabi-design-reset.md
+++ b/docs/research/tabi-design-reset.md
@@ -103,7 +103,6 @@ agent decide them alone again.
    Babylon.js both work embedded as a library inside someone else's render loop; between those
    two, "batteries-included" cuts both ways for a from-zero learner — more built-in tooling to
    lean on, but also more to learn before the first triangle renders. Not decided here.
-
 2. **Palette.** Not locked. Whatever the map/cat/chrome share, it needs to be stated once and
    checked everywhere, not picked per-component.
 3. **Character design.** Proportions, pose count (continuous rig vs. discrete sprite frames

--- a/docs/research/transit-tickets.md
+++ b/docs/research/transit-tickets.md
@@ -21,7 +21,7 @@ land through the _same_ Memento-creation seam.
 
 Every memento so far is **point**-anchored — one `coords`. A transit ticket is **edge**-anchored:
 
-```
+```text
 point memento:   • (one place)            ticket | stamp | goods
 transit memento: •──────▶• (from → to)    kind: transit
 ```
@@ -39,7 +39,7 @@ trip, the JR + Metro legs draw most of the map on their own.
 
 A `transit` kind (or `ticket` with a `transit` sub-shape — decide at spec time) carries:
 
-```
+```text
 Transit memento
   operator   JR East | Tokyo Metro | …      (MVP: these two)
   line       Tōkaidō Shinkansen | Ginza Line | …   (optional)
@@ -69,7 +69,7 @@ small and offline:
 
 A small authoring surface (admin app; for the MVP a single form is fine):
 
-```
+```text
 operator ▾   line ▾(optional)
 from [⌕ station autocomplete]  →  to [⌕ station autocomplete]
 date [____]   fare [¥____]

--- a/docs/roadmap/user-journey.md
+++ b/docs/roadmap/user-journey.md
@@ -11,7 +11,7 @@ Per [ADR-0025](../adr/0025-static-and-self-hosted-modes.md), the primary
 release workflow is server-mode authoring compiled into a static artifact.
 The selected shape:
 
-```
+```text
 Dawarich / Immich or local GPX + photos          (data stays on the author's machine)
   → felicia local server (SQLite): import + intake planning
   → felicia-admin GUI: review stop candidates → edit mementos → write essays → publish

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -70,10 +70,12 @@ for configuration precedence and the PostgreSQL test-database safety rules.
 
 - **Linux Dev Runtime (Podman Compose):**
   The database (PostgreSQL 18 + PostGIS) runs inside a container using **Podman** and `podman-compose`. The Go application itself runs **locally** on the host.
+
   ```bash
   # Spin up the database container
   podman-compose -f ops/compose.yaml up -d
   ```
+
 - **macOS Dev Runtime:**
   Leverage the native, lightweight **Bianpai** app ([github.com/bianpai/bianpai](https://github.com/bianpai/bianpai)) to run PostgreSQL 18 + PostGIS natively on the host.
 - **Migrations:**


### PR DESCRIPTION
Follow-up to #102, which adopted rumdl into `make check` but merged without the content corrections that make it pass. `main` currently fails its own mandated gate:

```
$ git checkout main && make fmt-docs-check
Issues: Found 86 issues in 66/128 files
make: *** [fmt-docs-check] Error 1
```

AGENTS.md requires `make check` before every commit and forbids `--no-verify`, so today that gate is unpassable for any change by anyone. CI stayed green because #102 deliberately routed CI to `make check-ci`, which excludes rumdl — so CI structurally cannot see this.

## Why the corrections were not simply committable

Running `rumdl --fix` produces 66 changed files, and three of its autofixes rewrite content rather than formatting it. Committing that output as-is would have been worse than omitting it:

- **MD025 (52 files)** counts an ADR's frontmatter `title:` and its H1 as two top-level headings. The autofix demoted the H1 of all 40 ADRs plus the contracts, experiments, release and epic documents, cascading every outline down a level. The frontmatter-plus-H1 pairing is the convention these documents share, so the rule is disabled.
- **MD046** rewrote the indented body of the `!!! note` admonition in `docs/publish.md` as a fenced code block, which stops the callout rendering. That file ignores the rule.
- **MD018** read the prose reference `#68.` at the start of a line in ADR-0032 as a heading and split a sentence into one. A line may legitimately begin with `#` — an issue reference, or an anchor — so the reference stays and the rule goes.

The remaining 32 findings are genuine and applied: fenced-code languages, blank lines around fences and list items, one continuation indent, and a trailing colon in a heading.

## Validation

- `make fmt-docs-check` — 128 files, no issues.
- `make check` — exit 0, complete: fmt-check, vet, lint, `go test -race` with coverage across all modules, and 50 Python feature tests. The SQLite dependency download that blocked Go vet in #102 now succeeds, so this is a full gate pass rather than a partial one.
- All 40 ADRs verified to retain their H1; the `publish.md` callout and the `#68` reference verified byte-identical to before the autofix.