### PR TITLE
docs: accept ADR-0028 and ADR-0030

### DIFF
--- a/docs/adr/0028-cli-compiler-and-shared-publication-boundary.md
+++ b/docs/adr/0028-cli-compiler-and-shared-publication-boundary.md
@@ -1,7 +1,7 @@
 ---
 id: "0028"
 title: "CLI Compiler and Shared Publication Boundary"
-status: "proposed"
+status: "accepted"
 date: "2026-07-17"
 decisions:
   - "Use the existing canonical domain model as the source of truth for both server and CLI workflows."
@@ -133,11 +133,25 @@ private source payloads.
 - GPX parsing, local media copying, checksum validation, and arbitrary `kind_data`
   preservation become testable without a running server.
 
-## Open decisions
+## Resolved decisions
 
-- Whether `publication` is a new Go module or a package first moved into
-  `runtime`.
-- Whether package YAML is decoded directly into import DTOs or first normalized
-  into a versioned intermediate representation.
-- Whether static compilation writes media directly to `dist/media/` or delegates
-  to a blob-store adapter that exposes public derivatives.
+The three questions this ADR left open were settled by the implementation and
+by the layout ADRs that followed it:
+
+- `publication` is its own Go module (`apps/felicia-publication/go.mod`), not a
+  package inside `runtime`. ADR-0034 records the resulting ownership map.
+- Package YAML is normalized into a versioned intermediate representation
+  before import. `journeypackage` rejects any manifest whose `schema_version`
+  is not `CurrentSchemaVersion`, and `importer.DecodePackage` produces a
+  `PackageDocument` that the applier consumes; import DTOs are not decoded
+  straight from YAML.
+- Static compilation delegates to the `ArtifactWriter` port
+  (`compiler.go` `output.WriteMedia`) rather than writing a hardcoded
+  `dist/media/` path or routing through a blob-store adapter.
+
+`apps/felicia-server/cmd/build` remains a PostgreSQL-only composition root. It
+uses the shared `publication.StaticCompiler`, so it satisfies this ADR's
+requirement that the provider-specific compiler be retired behind the shared
+boundary, and choosing a provider per composition root is what this ADR
+permits. Whether that root survives at all is ADR-0032's question, not this
+one's.

--- a/docs/adr/0030-intake-planning-contract.md
+++ b/docs/adr/0030-intake-planning-contract.md
@@ -1,7 +1,7 @@
 ---
 id: "0030"
 title: "Intake Planning Contract and Candidate Review Boundary"
-status: "proposed"
+status: "accepted"
 date: "2026-07-18"
 decisions:
   - "felicia:decision:intake-candidate-boundary"


### PR DESCRIPTION
Both ADRs describe boundaries the implementation has since built, so `status: proposed` recorded a decision that had already been made. **Neither acceptance commits new work** — this is bookkeeping, verified against the tree.

## ADR-0028 — CLI compiler and shared publication boundary

All four decisions hold today:

| Decision | Evidence |
| --- | --- |
| Canonical domain model shared by server and CLI | `apps/felicia-core/domain` consumed by both |
| Provider-neutral import/publication/storage seams | `publication.ReadModel` / `MediaSource` / `ArtifactWriter`, `importer.PackageStore` |
| `felicia-cli` as its own composition root in `go.work` | `apps/felicia-cli/` |
| Projection/compiler boundary out of server | `apps/felicia-publication/` |

Its three open questions are answered in the tree, so they are recorded as resolved rather than left open in an accepted document:

- `publication` became its own Go module (`apps/felicia-publication/go.mod`), not a package inside `runtime`; ADR-0034 records the resulting ownership map.
- Package YAML normalizes through a versioned intermediate representation — `journeypackage` rejects any manifest whose `schema_version` is not `CurrentSchemaVersion`, and `importer.DecodePackage` produces a `PackageDocument`.
- Static compilation delegates to the `ArtifactWriter` port (`compiler.go` `output.WriteMedia`), not a hardcoded `dist/media/` path.

`apps/felicia-server/cmd/build` remains a PostgreSQL-only composition root. It uses the shared `publication.StaticCompiler`, so it satisfies this ADR's requirement that the provider-specific compiler be retired behind the shared boundary, and choosing a provider per composition root is what this ADR permits. Whether that root survives is ADR-0032's question, not this one's.

## ADR-0030 — intake planning contract

Present and working: the four intake layers, `derivation_version` inside candidate identity, evidence references with source identity/kind/locator, the `proposed`/`kept`/`ignored`/`merged` review states, the split `RouteSource`/`VisitSource`/`PhotoSource` capabilities with `TrackSource` retained as the compatibility composite, and the pure planner.

**One clause is not met.** The ADR requires that when connected and local sources both exist, the runtime "record the conflict and apply an explicit source precedence policy". Only the precedence half exists — `apps/felicia-runtime/intake/planner.go:101-103`, "Supplied visits take precedence" — with nothing surfacing that evidence disagreed. Tracked as #111; a gap against an accepted ADR is a defect to file, not a reason to leave the ADR unaccepted.

## Validation

`make check` exits 0 — fmt-check including rumdl, vet, lint, `go test -race` with coverage across every module, and 50 Python feature tests. Documentation-only change: no Go, frontend, schema or deployment surface touched.