### PR TITLE
docs: accept ADR-0032, SQLite as the only v1 persistence contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,8 @@ journey and its per-stage status live in
 ## Tech Stack & Architecture
 
 - **Backend:** Go 1.27 — API, runtime, provider, and core modules in one `go.work` workspace.
-- **DB:** SQLite is the local-first provider; PostgreSQL remains supported for deployments that need it.
+- **DB:** SQLite is the only v1 persistence contract ([ADR-0032](docs/adr/0032-sqlite-first-v1-postgres-follow-up.md)).
+  The PostgreSQL/PostGIS provider stays in the tree as frozen, explicitly non-v1 work, deferred to v1.1/v1.2.
 - **Object storage:** S3-compatible interface; **R2** backend (MinIO/B2 swappable by config).
 - **Frontend:** Vite + MapLibre GL SPAs — public site, private reader, and admin authoring app (bun workspace).
 - **Locales:** static system UI catalogs support Japanese, English, and Chinese. Authored content
@@ -115,13 +116,17 @@ stops being possible.
    unused — with nothing in the logs to say so. Configuring a DSN for a provider
    you did not select must be a startup error, never a silent default.
 
-2. **A dual-provider schema change ships a parity check.**
+2. **A v1 schema change lands in SQLite only; touching both providers ships a parity check.**
    [ADR-0017](docs/adr/0017-sqlite-first-storage.md) required conformance tests
    "to prevent SQLite and PostgreSQL behavior from drifting", and
    `apps/felicia-providers/contract` delivers that — for _behavior_. Schema shape is
    unguarded, and the two DDLs have already diverged (`tb_journal` in
-   `apps/felicia-server/migrations/`, `tb_journals` in `apps/felicia-providers/sqlite/schema.sql`). Any change
-   touching both providers asserts shape parity in a test, not in review.
+   `apps/felicia-server/migrations/`, `tb_journals` in `apps/felicia-providers/sqlite/schema.sql`).
+   Under [ADR-0032](docs/adr/0032-sqlite-first-v1-postgres-follow-up.md) that drift
+   is now a frozen deferred-provider snapshot, not an active obligation: v1 schema
+   changes are not duplicated into PostgreSQL, and doing so by reflex re-opens the
+   parity surface the deferral closed. A change that does touch both — v1.1 re-entry
+   work — asserts shape parity in a test, not in review.
 
 3. **Every user-facing surface has exactly one documented `make` target.**
    The admin GUI — the primary authoring surface — had no launcher, so the

--- a/docs/adr/0017-sqlite-first-storage.md
+++ b/docs/adr/0017-sqlite-first-storage.md
@@ -4,7 +4,7 @@ title: "SQLite-First Storage with Optional PostgreSQL"
 status: "accepted"
 date: "2026-07-14"
 decisions: []
-related: []
+related: ["0032"]
 supersedes: []
 ---
 

--- a/docs/adr/0032-sqlite-first-v1-postgres-follow-up.md
+++ b/docs/adr/0032-sqlite-first-v1-postgres-follow-up.md
@@ -1,7 +1,7 @@
 ---
 id: "0032"
 title: "SQLite-First v1, PostgreSQL Follow-up"
-status: "proposed"
+status: "accepted"
 date: "2026-08-10"
 decisions:
   - "SQLite is the only supported and acceptance-tested persistence provider for v1.0."
@@ -48,7 +48,7 @@ The v1 product does not need PostgreSQL to complete its local authoring,
 publication, or Pages workflow. Carrying both schema surfaces as equal v1
 commitments adds maintenance without advancing the v1 acceptance outcome.
 
-## Proposed decision
+## Decision
 
 1. **SQLite is the v1 persistence contract.** The supported v1 API, admin GUI,
    CLI static compiler, workflow tests, and acceptance journey use SQLite.
@@ -157,6 +157,14 @@ keep two active v1 commitments.
 
 ## Status
 
-Proposed pending the decision and follow-up issue breakdown in GitHub issue
-#68. Once accepted, update the roadmap and database-development instructions
-to reflect SQLite-only v1 support.
+Accepted. The scope decision binds from acceptance; the repository work that
+makes it truthful is tracked separately, so this document is the contract and
+not a record of completed work. Until that work lands, two things in the tree
+still contradict it: `apps/felicia-server/cmd/build` is a PostgreSQL-only
+composition root, and CI provisions a PostGIS service for the v1 lane. Both
+need an explicit disposition under item 5 and item 6 above.
+
+The deferral also reclassifies existing PostgreSQL-only defects. A provider gap
+that SQLite does not share — such as the non-transactional stop-candidate
+refresh in `apps/felicia-providers/postgres/stop_candidate.go` — is
+deferred-provider work under item 4, not a v1 parity blocker.

--- a/docs/reviews/2026-09-10-clean-rebuild-and-feasible-options.md
+++ b/docs/reviews/2026-09-10-clean-rebuild-and-feasible-options.md
@@ -35,7 +35,9 @@ The normal authoring authority is **SQLite plus original blobs**, with recoverab
 | Publication | Public projection, privacy rules, complete build manifests and release identity | Editing the private journal                 |
 | Application | Commands, API, authoring screens and reader hosts                               | A second implementation of the domain rules |
 
-Use the same application commands from the CLI and GUI. Keep one primary local database engine for a fresh product. PostgreSQL is not intrinsically needed to author locally and publish static files. For a port of existing Felicia, however, inventory PostgreSQL users/data first: either migrate and explicitly retire support or preserve it with the same conformance tests. This is a support decision, not an incidental cleanup.
+Use the same application commands from the CLI and GUI. Keep one primary local database engine for a fresh product. PostgreSQL is not intrinsically needed to author locally and publish static files.
+
+For existing Felicia this is no longer an open question: [ADR-0032](../adr/0032-sqlite-first-v1-postgres-follow-up.md) is accepted, SQLite is the only v1 persistence contract, and PostgreSQL/PostGIS is a frozen non-v1 snapshot deferred to v1.1/v1.2. No inventory is required to decide it. What remains is enforcement, tracked separately, and the reclassification that follows: a provider gap SQLite does not share is deferred-provider work, not a v1 parity blocker, so no phase below carries a dual-provider test burden.
 
 Avoid introducing a workflow engine, event sourcing for every field, a universal plugin system, microservices, remote object storage or a native mobile application without a demonstrated need. Retain adapter seams for actual sources. The existing Go modules can remain during an in-place rebuild; module consolidation is not a prerequisite for correctness.
 
@@ -53,9 +55,31 @@ These are logical responsibilities, not a requirement to introduce every table a
 | Stop proposal/review   | Stable derivation identity, evidence, decision and revision; re-planning retains accepted/ignored choices                      |
 | Memento                | Journey owner, kind, content, anchor, lifecycle and revision; meaningful incomplete drafts are allowed                         |
 | Authored overrides     | Explicit overridden fields, including intentional empty values; source refresh never clears them                               |
-| Blob                   | Verified content digest, size/type and immutable storage key; package filenames are metadata                                   |
+| Blob                   | Verified content digest, size/type and immutable storage key; package filenames are metadata ([ADR-0026](../adr/0026-local-first-media-and-blob-storage.md) already specifies this) |
 | Attachment             | Memento owner, blob reference, caption, order and revision; curation is independent of byte identity                           |
 | Build/release          | Input snapshot identity, privacy policy version, artifact digest, outcome and manifest; deployment acknowledgement is separate |
+
+### Delta against the current schema
+
+The table above reads as a fresh design, which understates how much of it exists. Measured against `apps/felicia-providers/sqlite/schema.sql`, nine of the eleven records are already present and the work is mostly at column level:
+
+| Record                 | Today                                                         | Delta                                                                                           |
+| ---------------------- | ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| Journal                | `tb_journals`, `tb_site_settings`                             | no settings revision                                                                            |
+| Journey                | `tb_journeys` with `authored_fields`                          | **no `revision` column** — this is the ingest race itself                                       |
+| Source instance        | a `source_system` string only                                 | new record, or an explicit decision that the string suffices                                     |
+| Import run and receipt | `tb_import_runs` (ADR-0014)                                   | add input digest and acquisition interval; retry is not currently distinguishable                |
+| Observation            | `tb_source_observations` (ADR-0010)                           | identity is **run-scoped** — `UNIQUE (run_id, source_system, source_external_id)` — not source-scoped |
+| Stop proposal/review   | `tb_stop_candidates`, `tb_stop_candidate_evidence`             | has `revision` and `derivation_version`; PostgreSQL lacks the shared transaction                 |
+| Memento                | `tb_mementos`                                                 | already revision-aware                                                                          |
+| Authored overrides     | `authored_fields` masks (ADR-0033)                            | enforcement, not schema                                                                          |
+| Blob                   | `content_hash` on `tb_memento_photos`                         | **new record**; the hash is recorded but `object_key` is the package path                        |
+| Attachment             | `tb_memento_photos`                                           | no `revision`, so curation has the same race as the journey                                      |
+| Build/release          | —                                                             | **new record**                                                                                   |
+
+So the storage delta is two new records, roughly four columns, three `revision` columns, and one uniqueness change. `revision` exists today on exactly `tb_mementos` and `tb_stop_candidates`.
+
+Two consequences follow. The blob record is not a decision to be made — [ADR-0026](../adr/0026-local-first-media-and-blob-storage.md) is accepted and already specifies `originals/<sha256>/<filename>` with the content hash as the stable contract, so this is a defect against an existing contract rather than new design, and phase 1 inherits a specified target. And build/release identity is the one genuinely new decision in this document, so it is the one that warrants its own ADR.
 
 Keep core ownership fields relational. Kind-specific details may remain validated JSON with versioned schemas; the renderer never gets to invent storage fields. Validate date/time semantics explicitly, preserve source timestamps and timezone uncertainty, and allow manual location correction without changing the original evidence.
 
@@ -114,7 +138,9 @@ The inventory must include real data distributions and unsupported media behavio
 
 These options have different scopes, not different quality bars. A can still deliver a mature product. B is not a permanent dual-system design. C must not be called complete when only one reader or a clean demo dataset works.
 
-Before choosing C, compare one representative vertical slice: import two trips with colliding media names, author and revise memories, re-import, build, withdraw and restore. Identify which current abstractions prevent that slice from being implemented cleanly. The existing review finds broken boundaries, but does not establish that the current codebase is fundamentally incapable of enforcing them.
+The three-way framing overstates the choice, now that the storage delta above is measured. A and B share nearly all of their work: two new records, a few columns, and the enforcement to go with them. What actually separates them is whether the authoring flow is then redesigned around one journal authority, which is a decision that can be taken after the repairs rather than before them. So the real sequence is: do the boundary repairs, which nothing here disputes, and decide on the authoring redesign separately once daily use is trustworthy.
+
+Before choosing C, compare one representative vertical slice: import two trips with colliding media names, author and revise memories, re-import, build, withdraw and restore. Identify which current abstractions prevent that slice from being implemented cleanly. The existing review finds broken boundaries, but does not establish that the current codebase is fundamentally incapable of enforcing them — and the delta above is evidence in the other direction, since nine of eleven records and both revision-aware write paths already exist.
 
 ## Recommended implementation sequence for option B
 
@@ -123,12 +149,26 @@ Before choosing C, compare one representative vertical slice: import two trips w
 | 0     | Repair the destructive preview path; capture current capability/data inventory | Preview cannot delete originals; retained inputs and author state are enumerated                            |
 | 1     | Recovery archive and verified immutable blob mapping                           | Restore a representative multi-trip journal; colliding filenames retain correct bytes                       |
 | 2     | Atomic source intake and revision-aware author commands                        | Late input, retry, concurrency and old-package tests preserve all authored values and review decisions      |
-| 3     | Consistent snapshot compiler and complete release promotion                    | Failed/concurrent builds retain a coherent active release; withdrawn files are absent from the new artifact |
-| 4     | One inbox/editor/publication flow using those commands                         | No routine terminal step between available evidence and local public preview; conflicts retain drafts       |
-| 5     | Port complete reader/deployment/interchange behavior                           | All capability rows pass; old data and consumers have an explicit disposition                               |
+| 3     | Consistent snapshot compiler and complete release promotion                    | Failed/concurrent builds retain a coherent active release; withdrawn files are absent from the new artifact; high-precision input sits on the public grid in **index and detail** JSON alike |
+| 4     | One inbox/editor/publication flow using those commands                         | No routine terminal step between available evidence and local public preview; conflicts retain drafts; an essay-only edit marks the site as changed and a status error reads as unknown |
+| 5     | Verify reader behavior unchanged; port deployment and interchange              | All capability rows pass; old data and consumers have an explicit disposition                               |
 | 6     | Rehearsed cutover and real authoring acceptance                                | Author uses a new trip plus a revision to an old trip, deploys, withdraws, and restores without lost work   |
 
+Phase 5 says *verify* rather than *port* because option B does not rebuild the readers. Under option C that row becomes a port, and it is the largest single line item in the option.
+
 Keep the source-backed review's specific regression cases as the acceptance ledger. Split phases into focused changes when implementation starts. Do not schedule a fixed completion date before measuring archive/restore and one full slice; those establish the real effort better than estimates from file count.
+
+### These phases are mostly an existing backlog
+
+The phases are an ordering and a set of gates, not a new inventory of work. Most of the work already exists in the issue ledger, and saying so keeps the plan from being read as a second, competing plan:
+
+- phase 0 is the P0 preview defect, plus the inventory;
+- phase 1's recovery archive is the standing backup/restore issue, and its blob mapping is the ADR-0026 violation;
+- phase 2 and phase 3 correspond to the filed import, authorship and publication defects;
+- phase 4's inbox and editor work is already filed across the intake and admin-GUI gaps;
+- phase 6 is the standing end-to-end release rehearsal.
+
+The plan's own contribution is the order, the gates, and the rule that no destructive repair happens before the archive exists.
 
 ## Migration and cutover
 

--- a/docs/reviews/2026-09-10-clean-rebuild-and-feasible-options.md
+++ b/docs/reviews/2026-09-10-clean-rebuild-and-feasible-options.md
@@ -24,7 +24,7 @@ Automation belongs in collection, deduplication, candidate generation, derivativ
 
 Use one Go application with a CLI and a local authoring HTTP interface, one SQLite database, a private immutable media directory, and a static publication compiler. Use Svelte for the authoring app and reusable reader compositions. Internal packages separate responsibilities; separate services and one module per concept are unnecessary.
 
-The normal authoring authority is **SQLite plus original blobs**, with recoverable browser drafts for uncommitted edits. Imported packages are interchange inputs; exported recovery archives are backups. Neither silently overrides newer GUI edits. The static site is a sanitized projection, never the backup or primary database.
+The normal authoring authority is **SQLite plus original blobs**, with recoverable browser drafts for uncommitted edits. Imported packages are interchange inputs and never silently override newer GUI edits. Backup is a copy of that directory, taken by whatever already backs up the machine. The static site is a sanitized projection, never the backup or primary database.
 
 | Boundary    | Owns                                                                            | Does not own                                |
 | ----------- | ------------------------------------------------------------------------------- | ------------------------------------------- |
@@ -111,7 +111,9 @@ For local serving, switch a release pointer atomically under a single build/prom
 
 Show “changes since build,” “built,” and “deployed” separately. Content edits, settings changes and removals affect the input digest. A network/status error means unknown, not clean. Unpublishing requires a new release and confirmed deployment; locally changing a flag does not retract previously deployed bytes.
 
-A recovery archive includes a consistent database snapshot, referenced original blobs, configuration needed to interpret it, version metadata and checksums. Restore into an empty location and validate before switching. Keep credentials out of portable publication artifacts; document how an author reconnects sources after recovery.
+Recovery does not need a feature. For a single owner on one machine the journal is one SQLite file and a media directory under `.felicia/`, so a disk-level backup already covers it and recovery is copying the directory back. The precaution a migration genuinely needs is one manual copy taken before it, with the application stopped -- a live WAL-mode database is the only thing a file copy cannot snapshot consistently, and stopping the app removes that. An `archive`/`restore` subsystem duplicating `cp -a` was proposed, examined and declined; what would change that is a second user, a hosted deployment, or a machine whose disk is not otherwise backed up.
+
+If a portable export is ever wanted, it is a different requirement -- portability, not recovery -- and it reuses the existing package format rather than inventing an archive one. Keep credentials out of portable artifacts either way.
 
 ## Complete feature port, not a minimal replacement
 
@@ -147,7 +149,7 @@ Before choosing C, compare one representative vertical slice: import two trips w
 | Phase | Deliverable                                                                    | Exit evidence                                                                                               |
 | ----- | ------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------- |
 | 0     | Repair the destructive preview path; capture current capability/data inventory | Preview cannot delete originals; retained inputs and author state are enumerated                            |
-| 1     | Recovery archive and verified immutable blob mapping                           | Restore a representative multi-trip journal; colliding filenames retain correct bytes                       |
+| 1     | Verified immutable blob mapping, behind one manual pre-migration copy          | Colliding filenames retain correct bytes; the copy is taken with the app stopped before any migration runs  |
 | 2     | Atomic source intake and revision-aware author commands                        | Late input, retry, concurrency and old-package tests preserve all authored values and review decisions      |
 | 3     | Consistent snapshot compiler and complete release promotion                    | Failed/concurrent builds retain a coherent active release; withdrawn files are absent from the new artifact; high-precision input sits on the public grid in **index and detail** JSON alike |
 | 4     | One inbox/editor/publication flow using those commands                         | No routine terminal step between available evidence and local public preview; conflicts retain drafts; an essay-only edit marks the site as changed and a status error reads as unknown |
@@ -156,27 +158,27 @@ Before choosing C, compare one representative vertical slice: import two trips w
 
 Phase 5 says *verify* rather than *port* because option B does not rebuild the readers. Under option C that row becomes a port, and it is the largest single line item in the option.
 
-Keep the source-backed review's specific regression cases as the acceptance ledger. Split phases into focused changes when implementation starts. Do not schedule a fixed completion date before measuring archive/restore and one full slice; those establish the real effort better than estimates from file count.
+Keep the source-backed review's specific regression cases as the acceptance ledger. Split phases into focused changes when implementation starts. Do not schedule a fixed completion date before one full slice is measured; that establishes the real effort better than estimates from file count.
 
 ### These phases are mostly an existing backlog
 
 The phases are an ordering and a set of gates, not a new inventory of work. Most of the work already exists in the issue ledger, and saying so keeps the plan from being read as a second, competing plan:
 
 - phase 0 is the P0 preview defect, plus the inventory;
-- phase 1's recovery archive is the standing backup/restore issue, and its blob mapping is the ADR-0026 violation;
+- phase 1 is the ADR-0026 blob-identity violation; its safety precaution is a manual copy, not a feature;
 - phase 2 and phase 3 correspond to the filed import, authorship and publication defects;
 - phase 4's inbox and editor work is already filed across the intake and admin-GUI gaps;
 - phase 6 is the standing end-to-end release rehearsal.
 
-The plan's own contribution is the order, the gates, and the rule that no destructive repair happens before the archive exists.
+The plan's own contribution is the order, the gates, and the rule that no destructive repair runs before a copy of the journal is taken.
 
 ## Migration and cutover
 
 Inventory database state, originals, authored workspaces, decisions, site settings and external consumers before designing conversion. Stop writers for a consistent export. Preserve old IDs where possible; record explicit mappings otherwise. Verify media byte hashes and authored fields, not just row counts or whether the homepage renders.
 
-Run the replacement against a restored copy, with no permanent dual writes. Compare private-state preservation and intended public output separately; privacy fixes may intentionally change public output. At cutover, take a final checkpoint, import/convert, validate and only then reopen authoring. Keep the previous application/data available for rollback. After new edits begin, rollback must carry those edits and blobs back or preserve them in a recoverable archive; restoring an old database alone is data loss.
+Run the replacement against a restored copy, with no permanent dual writes. Compare private-state preservation and intended public output separately; privacy fixes may intentionally change public output. At cutover, take a final checkpoint, import/convert, validate and only then reopen authoring. Keep the previous application/data available for rollback. After new edits begin, rollback must carry those edits and blobs back or set them aside somewhere recoverable; restoring an old database alone is data loss.
 
-The first two foundation repairs should not wait for a final decision about a successor. Preserve the current originals and archive the journal before experimentation.
+The first two foundation repairs should not wait for a final decision about a successor. Copy the journal and its originals aside before experimenting on them.
 
 ## Decision to carry forward
 


### PR DESCRIPTION
Closes the last `proposed` ADR. Unlike #114 this is a real scope decision, not bookkeeping: it binds v1 to one persistence provider and reclassifies existing work.

`docs/roadmap.md` has stated this outcome since before the ADR was drafted — "SQLite-first local storage; PostgreSQL/PostGIS is deferred to v1.1/v1.2, not a v1 compatibility promise" — so `status: proposed` was the last place the two disagreed. #68, the joint call the ADR waited on, is closed against it.

## What acceptance binds

PostgreSQL/PostGIS stays in the tree as frozen, explicitly non-v1 work. New v1 schema changes are not duplicated into it, and the existing `tb_journal` / `tb_journals` divergence becomes a deferred-provider snapshot rather than an active obligation.

**The repository does not yet reflect the decision, and the ADR now says so** rather than implying the work is done. Two things still contradict it: `apps/felicia-server/cmd/build` is a PostgreSQL-only composition root, and CI provisions a PostGIS service for the v1 lane. Both need a disposition under the ADR's items 5 and 6, tracked in #112.

## Two contract statements corrected

Both followed from the old status and are wrong under an accepted ADR-0032:

- The `AGENTS.md` stack summary claimed PostgreSQL "remains supported for deployments that need it".
- Development-flow rule 2 required a parity check on **every** dual-provider schema change. Under item 4 that is backwards: a v1 schema change belongs in SQLite alone, and duplicating it by reflex re-opens the parity surface the deferral closed. The rule still binds for v1.1 re-entry work that genuinely touches both providers.

## Reclassification

A provider gap SQLite does not share is now deferred-provider work rather than a v1 parity blocker — for example the non-transactional stop-candidate refresh in `apps/felicia-providers/postgres/stop_candidate.go:85-115`, where the SQLite equivalent is transactional. This is a priority change, not a dismissal.

## Second commit: grounding the rebuild proposal

`docs/reviews/2026-09-10-clean-rebuild-and-feasible-options.md` presented an eleven-record storage model as fresh design. Measured against `apps/felicia-providers/sqlite/schema.sql`, nine of the eleven already exist — import runs and source observations have had tables since ADR-0014 and ADR-0010, and mementos and stop candidates are already revision-aware. The delta is two new records, roughly four columns, three `revision` columns and one uniqueness change (observation identity is run-scoped, not source-scoped), and the document now says so in those terms.

Two of its rows were not decisions at all. The blob record is specified by **accepted ADR-0026** down to the directory shape (`originals/<sha256>/<filename>`, "the stable contract is the content hash"), making it a defect against an existing contract rather than a design question — that is #104. And its PostgreSQL paragraph asked for an inventory to decide what this ADR decides, so it records the deferral and drops the dual-provider test burden from every phase. Build/release identity is the one genuinely new decision left, and is marked as wanting its own ADR.

Phases 3 and 4 also gained the exit evidence they were missing for the coordinate-precision (#108) and build-status (#109) findings, and phase 5 says *verify* rather than *port* because option B does not rebuild the readers.

## Validation

`make check` exits 0 — fmt-check including rumdl, vet, lint, `go test -race` with coverage across every module, and 50 Python feature tests. Documentation-only: no Go, frontend, schema or deployment change, and the enforcement work this decision implies is deliberately left to #112.