### PR TITLE
fix: give the Pages preview a workspace it can prove it owns

### DIFF
--- a/docs/publish.md
+++ b/docs/publish.md
@@ -256,7 +256,12 @@ manifest reconciliation removes it from the artifact.
    Add future journeys by adding the same file set and one entry to
    `publication/journeys/catalog.json`; the publisher discovers them without
    source-code edits.
-6. Verify locally with `make pages-preview` (`http://localhost:8082`).
+6. Verify locally with `make pages-preview` (`http://localhost:8082`). The
+   preview builds into a disposable workspace of its own
+   (`.felicia/pages-preview.sqlite` and `.felicia/pages-preview-media/`), which
+   it empties on every run. It never reads or resets your authoring journal or
+   original media. Pointing `PAGES_DB` or `PAGES_MEDIA_ROOT` elsewhere uses that
+   location as given; the preview only empties a directory it can prove it owns.
 7. Push to `main`; the workflow rebuilds and deploys.
 
 The base path is derived from the repository name, so nothing needs editing for

--- a/scripts/felicia.py
+++ b/scripts/felicia.py
@@ -15,9 +15,17 @@ ROOT = Path(__file__).resolve().parent.parent
 WEB = ROOT / "apps" / "felicia-public-site"
 CLI = ROOT / "bin" / "felicia-cli"
 DEFAULT_DB = ROOT / ".felicia" / "pages-preview.sqlite"
-DEFAULT_MEDIA_ROOT = ROOT / ".felicia" / "media"
+# The preview owns a disposable media workspace of its own. It must never
+# default to the authoring media root (`.felicia/media`, per
+# apps/felicia-server/config/config.go and `felicia-cli import`), which holds
+# the only copy of an author's originals: a public artifact is deliberately
+# lossy and providers are not a backup, so nothing there is reconstructible.
+DEFAULT_MEDIA_ROOT = ROOT / ".felicia" / "pages-preview-media"
 DEFAULT_PUBLICATION_PACKAGE = ROOT / ".felicia" / "publication.zip"
 DEFAULT_DIST = WEB / "dist"
+# Written into a directory this script has emptied, so a later run can tell a
+# workspace it owns from one it was merely pointed at.
+WORKSPACE_MARKER = ".felicia-publication-workspace"
 
 
 def run(command: list[str], *, cwd: Path = ROOT, env: dict[str, str] | None = None) -> None:
@@ -25,17 +33,43 @@ def run(command: list[str], *, cwd: Path = ROOT, env: dict[str, str] | None = No
     subprocess.run(command, cwd=cwd, env=env, check=True)
 
 
+def reset_disposable(path: Path) -> None:
+    """Empty a directory this build can prove it owns, then mark it as owned.
+
+    A missing or empty directory is adopted, and one already carrying the marker
+    is reset. Anything else is refused with nothing deleted -- the preview is
+    never worth destroying data whose provenance it cannot establish.
+    """
+    if path.exists() and any(path.iterdir()) and not (path / WORKSPACE_MARKER).exists():
+        raise SystemExit(
+            f"refusing to reset {path}: it is not a publication workspace "
+            f"(no {WORKSPACE_MARKER}) and may hold original media. Point the "
+            f"preview at a disposable directory, or empty this one yourself."
+        )
+    shutil.rmtree(path, ignore_errors=True)
+    path.mkdir(parents=True, exist_ok=True)
+    (path / WORKSPACE_MARKER).touch()
+
+
 def publish(base_path: str) -> None:
     configured_database = os.environ.get("PAGES_DB")
     database = Path(configured_database) if configured_database else DEFAULT_DB
-    media_root = Path(os.environ.get("PAGES_MEDIA_ROOT", DEFAULT_MEDIA_ROOT))
+    configured_media_root = os.environ.get("PAGES_MEDIA_ROOT")
+    media_root = Path(configured_media_root) if configured_media_root else DEFAULT_MEDIA_ROOT
     output = DEFAULT_DIST
-    media_root.mkdir(parents=True, exist_ok=True)
+    # Reset only what this build owns, and decide that per root rather than from
+    # one shared flag: keying the media reset on PAGES_DB is what let an
+    # explicitly configured PAGES_MEDIA_ROOT be deleted.
     if not configured_database:
         for suffix in ("", "-wal", "-shm"):
             database.with_name(database.name + suffix).unlink(missing_ok=True)
-        shutil.rmtree(media_root)
+    if configured_media_root:
+        # Used as given. The caller may have pointed it at real media, and a
+        # stale file here cannot reach the artifact: the compiler resolves media
+        # from photo rows, never by walking this directory.
         media_root.mkdir(parents=True, exist_ok=True)
+    else:
+        reset_disposable(media_root)
     shutil.rmtree(output, ignore_errors=True)
     # The API tree is produced by the Go compiler, not by Vite's public source.
     # Remove an older generated copy before Vite copies its public directory.

--- a/tests/test_pages_preview_workspace.py
+++ b/tests/test_pages_preview_workspace.py
@@ -1,0 +1,145 @@
+"""The Pages preview must never delete an author's original media.
+
+Regression cover for the destructive-reset defect: `publish()` emptied the
+shared authoring media root, and did so whenever `PAGES_DB` was unset, which
+took an explicitly configured `PAGES_MEDIA_ROOT` with it. Every test here
+redirects each root into a temporary directory and stops the build at its first
+external command, so nothing real is touched and no toolchain is needed.
+"""
+
+import re
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from scripts import felicia
+
+
+class PagesPreviewWorkspaceTest(unittest.TestCase):
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.directory.cleanup)
+        root = Path(self.directory.name)
+        self.authoring_media = root / "authoring-media"
+        self.preview_media = root / "preview-media"
+        self.authoring_media.mkdir()
+        self.sentinel = self.authoring_media / "original.jpg"
+        self.sentinel.write_bytes(b"the only copy")
+        # Redirect every path publish() would otherwise resolve under the repo,
+        # and stop at the first external command so no build or import runs.
+        self.patches = [
+            mock.patch.object(felicia, "DEFAULT_MEDIA_ROOT", self.preview_media),
+            mock.patch.object(felicia, "DEFAULT_DB", root / "preview.sqlite"),
+            mock.patch.object(felicia, "DEFAULT_DIST", root / "dist"),
+            mock.patch.object(felicia, "CLI", root / "bin" / "felicia-cli"),
+            mock.patch.object(felicia, "WEB", root / "web"),
+            mock.patch.object(felicia, "run", side_effect=StopBuild),
+        ]
+        for patch in self.patches:
+            patch.start()
+            self.addCleanup(patch.stop)
+
+    def publish(self, **environment):
+        """Run publish() with a clean environment, stopping at the first command."""
+        with mock.patch.dict("os.environ", environment, clear=False):
+            for name in ("PAGES_DB", "PAGES_MEDIA_ROOT"):
+                if name not in environment:
+                    felicia.os.environ.pop(name, None)
+            with self.assertRaises(StopBuild):
+                felicia.publish("/")
+
+    def test_default_run_leaves_the_authoring_media_root_untouched(self):
+        """AC1: the shared authoring root is not the preview's to reset."""
+        self.publish()
+        self.assertEqual(self.sentinel.read_bytes(), b"the only copy")
+
+    def test_configured_media_root_is_never_emptied(self):
+        """AC2: an explicit PAGES_MEDIA_ROOT is used as given, not wiped."""
+        self.publish(PAGES_MEDIA_ROOT=str(self.authoring_media))
+        self.assertEqual(self.sentinel.read_bytes(), b"the only copy")
+
+    def test_configured_media_root_survives_an_unset_pages_db(self):
+        """AC2: the media reset no longer keys off the database variable."""
+        self.publish(PAGES_MEDIA_ROOT=str(self.authoring_media))
+        self.assertTrue(self.sentinel.is_file())
+
+    def test_owned_workspace_is_reset_between_runs(self):
+        """AC3: the disposable workspace really is emptied, or previews go stale."""
+        self.preview_media.mkdir()
+        (self.preview_media / felicia.WORKSPACE_MARKER).touch()
+        stale = self.preview_media / "stale.webp"
+        stale.write_bytes(b"from a previous run")
+        self.publish()
+        self.assertFalse(stale.exists())
+        self.assertTrue((self.preview_media / felicia.WORKSPACE_MARKER).is_file())
+
+    def test_unmarked_workspace_aborts_without_deleting(self):
+        """AC4: no ownership proof means refuse, and remove nothing."""
+        self.preview_media.mkdir()
+        occupied = self.preview_media / "unexplained.jpg"
+        occupied.write_bytes(b"provenance unknown")
+        with self.assertRaises(SystemExit) as raised:
+            felicia.reset_disposable(self.preview_media)
+        self.assertIn(felicia.WORKSPACE_MARKER, str(raised.exception))
+        self.assertEqual(occupied.read_bytes(), b"provenance unknown")
+
+    def test_missing_workspace_is_adopted_and_marked(self):
+        """A fresh checkout has no workspace yet; creating one is not a refusal."""
+        felicia.reset_disposable(self.preview_media)
+        self.assertTrue((self.preview_media / felicia.WORKSPACE_MARKER).is_file())
+
+    def test_failed_build_leaves_originals_intact(self):
+        """AC5: the reset happens before the build, so a failure cannot undo it."""
+        self.publish()
+        self.assertEqual(
+            sorted(path.name for path in self.authoring_media.iterdir()),
+            ["original.jpg"],
+        )
+
+
+class PreviewDefaultsTest(unittest.TestCase):
+    """The shipped defaults, unpatched.
+
+    The tests above redirect `DEFAULT_MEDIA_ROOT` into a temporary directory,
+    which is what makes them safe to run -- and also means they cannot see the
+    original defect, which was the value of the constant itself. These assert on
+    the real one.
+    """
+
+    def test_preview_media_root_is_not_the_authoring_media_root(self):
+        """AC1: the preview's default is a workspace of its own."""
+        self.assertNotEqual(
+            felicia.DEFAULT_MEDIA_ROOT,
+            felicia.ROOT / ".felicia" / "media",
+        )
+
+    def test_preview_media_root_differs_from_the_server_default(self):
+        """Drift guard: the server owns the authoring root, and it may move.
+
+        Reads the authoring default out of the Go config rather than restating
+        it, so repointing either side at the other fails here instead of during
+        a preview.
+        """
+        config = (
+            felicia.ROOT / "apps" / "felicia-server" / "config" / "config.go"
+        ).read_text(encoding="utf-8")
+        declared = re.search(r'defaultMediaRoot\s*=\s*"([^"]+)"', config)
+        self.assertIsNotNone(declared, "defaultMediaRoot not found in config.go")
+        authoring_root = (felicia.ROOT / declared.group(1)).resolve()
+        self.assertNotEqual(felicia.DEFAULT_MEDIA_ROOT.resolve(), authoring_root)
+
+    def test_preview_database_is_not_the_authoring_database(self):
+        """The database already had a dedicated name; keep it that way."""
+        self.assertNotEqual(
+            felicia.DEFAULT_DB,
+            felicia.ROOT / ".felicia" / "felicia.sqlite",
+        )
+
+
+class StopBuild(Exception):
+    """Raised in place of the first external command, ending the run early."""
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #103, the only `prio:P0` in the repository. `make pages-preview` deleted the author's original media.

## The defect

The preview's database already had a disposable name of its own (`.felicia/pages-preview.sqlite`), but its media root defaulted to `.felicia/media` — the **authoring** root shared with the server (`apps/felicia-server/config/config.go:25`) and `felicia-cli import` (`main.go:246`), holding the only copy of the originals. A public artifact is deliberately lossy and providers are not a backup, so nothing deleted there is reconstructible. `docs/publish.md` lists this command as step 6 of the publish flow, so following the documented procedure was the way to lose them.

The reset was also keyed on `PAGES_DB`: leaving that unset wiped the media root **even when `PAGES_MEDIA_ROOT` pointed somewhere explicit**. Two separate defects — a wrong default and a wrong gate.

## The fix

Each root now decides for itself, and an operator-supplied root is used as given and never emptied. A stale file there cannot reach the artifact, because the compiler resolves media from photo rows rather than by walking the directory.

The default workspace is `.felicia/pages-preview-media/` and is still emptied every run, so previews do not go stale — but only when the script can prove it owns it. A missing or empty directory is adopted and marked; a marked one is reset; anything else aborts with nothing deleted.

Ownership proof rather than blacklisting authoring paths, because blacklisting cannot work here: the authoring database default differs between `config.go` (`felicia.db`) and the Makefile (`.felicia/felicia.sqlite`), so there is no single path to exclude. `ADR-0026` already makes originals the private artifact publication derives from, and AGENTS.md development-flow constraint 6 puts them under `.felicia/`; the new path stays inside it.

## Tests

One case per acceptance criterion, each verified to **fail against the unfixed script** — re-run with the fix stashed, 7 of 10 failed.

| Criterion | Covered by |
| --- | --- |
| Default run leaves the authoring root untouched | `PreviewDefaultsTest` |
| Explicit `PAGES_MEDIA_ROOT` is never emptied | 2 cases, incl. the unset-`PAGES_DB` path |
| The disposable workspace *is* still reset | guards against "fixing" this by deleting less |
| Unmarked workspace aborts, deleting nothing | asserts the occupant survives byte-for-byte |

The default-value tests are a separate class on purpose. The workspace tests redirect the constants into a temporary directory, which is what makes them safe to run — and also blinds them to the original defect, which was the value of the constant itself. One of them reads `defaultMediaRoot` out of `config.go` rather than restating it, so repointing either side at the other fails in tests instead of during a preview.

**One criterion holds by construction rather than by a falsifiable test**: originals surviving a failed build. The preview no longer touches the authoring root at any point, so a build failure cannot affect it, but the test asserting that cannot fail. Recorded rather than claimed as coverage.

## Validation

`make check` exits 0 on this branch rebased onto current `main` — fmt-check including rumdl, vet, lint, `go test -race` with coverage across every module, and 50 Python feature tests (up from 40). No real `make pages-preview` run: the reproduction is module-level, with every root redirected to a temporary directory and the build stopped at its first external command, so nothing real was touched.

`docs/publish.md` step 6 now states what the preview owns and what it will not touch.