### PR TITLE
fix: derive media identity from bytes, not the member name

### DIFF
--- a/apps/felicia-cli/cmd/felicia/main.go
+++ b/apps/felicia-cli/cmd/felicia/main.go
@@ -285,7 +285,10 @@ func importCommand(args []string, output io.Writer) error {
 		if !strings.HasPrefix(filename, "media/") {
 			continue
 		}
-		destination, err := publication.SafeJoin(*mediaRoot, filename)
+		// Install by content identity, using the same derivation the importer
+		// recorded, so a member name shared with another package cannot
+		// overwrite that package's bytes (ADR-0026).
+		destination, err := publication.SafeJoin(*mediaRoot, importer.MediaObjectKey(filename, importer.MediaDigest(data)))
 		if err != nil {
 			return err
 		}

--- a/apps/felicia-cli/cmd/felicia/main_test.go
+++ b/apps/felicia-cli/cmd/felicia/main_test.go
@@ -16,6 +16,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	journeypackage "github.com/azusachino/felicia/apps/felicia-core/journeypackage"
+	"github.com/azusachino/felicia/apps/felicia-runtime/importer"
 )
 
 // fixtureJPEG returns a small but real JPEG. The static compiler resizes and
@@ -55,7 +56,9 @@ func TestCLIImportAndStaticCompileEndToEnd(t *testing.T) {
 		"api/v1/journeys.json",
 		"api/v1/journeys/00000000-0000-0000-0000-000000000001.json",
 		"api/v1/journeys/00000000-0000-0000-0000-000000000001/mementos.json",
-		"media/ticket.jpg",
+		// Derived rather than hardcoded, so this asserts the contract the
+		// importer and the installer share instead of one digest literal.
+		importer.MediaObjectKey("media/ticket.jpg", importer.MediaDigest(fixtureJPEG(t))),
 	} {
 		if _, err := os.Stat(filepath.Join(out, relative)); err != nil {
 			t.Fatalf("compiled artifact missing %s: %v report=%s", relative, err, compileReport.String())
@@ -83,11 +86,15 @@ func TestCLIJourneyPlanJSONL(t *testing.T) {
 
 func writeFixturePackage(t *testing.T, filename string) string {
 	t.Helper()
+	// content_hash must be the real digest of the bytes: the importer derives
+	// storage identity from the bytes and rejects a package whose declaration
+	// disagrees, so a placeholder here would not be a valid package.
+	ticket := fixtureJPEG(t)
 	files := map[string][]byte{
 		"journey.yaml":     []byte("id: 00000000-0000-0000-0000-000000000001\njournal_id: 00000000-0000-0000-0000-000000000002\nslug: sample\ntitle: Sample journey\nplace: Kyoto\ndate_start: 2026-04-01\ndate_end: 2026-04-01\n"),
-		"mementos.yaml":    []byte("- id: 00000000-0000-0000-0000-000000000003\n  seq: 1\n  kind: transit\n  occurred_at: 2026-04-01T09:00:00+09:00\n  occurred_tz: Asia/Tokyo\n  state: published\n  title: Train ticket\n  place: Kyoto\n  geom: [[135.7681, 35.0116], [139.7671, 35.6812]]\n  kind_data:\n    operator: JR West\n    from: {name: Kyoto, coords: [135.7681, 35.0116]}\n    to: {name: Tokyo, coords: [139.7671, 35.6812]}\n  photos:\n    - id: 00000000-0000-0000-0000-000000000004\n      path: media/ticket.jpg\n      content_hash: sha256:ticket\n      seq: 1\n"),
+		"mementos.yaml":    []byte("- id: 00000000-0000-0000-0000-000000000003\n  seq: 1\n  kind: transit\n  occurred_at: 2026-04-01T09:00:00+09:00\n  occurred_tz: Asia/Tokyo\n  state: published\n  title: Train ticket\n  place: Kyoto\n  geom: [[135.7681, 35.0116], [139.7671, 35.6812]]\n  kind_data:\n    operator: JR West\n    from: {name: Kyoto, coords: [135.7681, 35.0116]}\n    to: {name: Tokyo, coords: [139.7671, 35.6812]}\n  photos:\n    - id: 00000000-0000-0000-0000-000000000004\n      path: media/ticket.jpg\n      content_hash: sha256:" + importer.MediaDigest(ticket) + "\n      seq: 1\n"),
 		"route.gpx":        []byte(`<?xml version="1.0"?><gpx><trk><trkseg><trkpt lat="35.0116" lon="135.7681"/><trkpt lat="35.6812" lon="139.7671"/></trkseg></trk></gpx>`),
-		"media/ticket.jpg": fixtureJPEG(t),
+		"media/ticket.jpg": ticket,
 	}
 	manifest := journeypackage.Manifest{SchemaVersion: journeypackage.CurrentSchemaVersion, PackageID: "sample-1"}
 	for name, data := range files {

--- a/apps/felicia-runtime/importer/package.go
+++ b/apps/felicia-runtime/importer/package.go
@@ -2,10 +2,13 @@ package importer
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
 	"math"
+	"path"
 	"strings"
 	"time"
 
@@ -335,12 +338,52 @@ func normalizeMemento(pkg *journeypackage.Package, journeyID uuid.UUID, raw meme
 		if rawPhoto.Path == "" || rawPhoto.ContentHash == "" || rawPhoto.Seq < 1 {
 			return nil, nil, fmt.Errorf("photo %d requires path, content_hash, and positive seq", index+1)
 		}
-		if _, ok := pkg.Files[rawPhoto.Path]; !ok {
+		data, ok := pkg.Files[rawPhoto.Path]
+		if !ok {
 			return nil, nil, fmt.Errorf("photo %q is missing from package", rawPhoto.Path)
 		}
-		photos = append(photos, &domain.MementoPhoto{ID: photoID, MementoID: id, ObjectKey: rawPhoto.Path, ContentHash: rawPhoto.ContentHash, Caption: optional(rawPhoto.Caption), Seq: rawPhoto.Seq, SourceRef: optional("package:" + pkg.Manifest.PackageID + ":" + rawPhoto.ID)})
+		// Media identity comes from the bytes, never from the member name
+		// (ADR-0026). Two packages may both carry `media/ticket.jpg` holding
+		// different photos; keying storage on that name let one silently
+		// replace the other's bytes. The digest is computed here rather than
+		// trusted from content_hash, so a package cannot choose where its
+		// bytes land, and the declared value is verified against it.
+		digest := MediaDigest(data)
+		if err := verifyDeclaredHash(rawPhoto.ContentHash, digest); err != nil {
+			return nil, nil, fmt.Errorf("photo %q: %w", rawPhoto.Path, err)
+		}
+		photos = append(photos, &domain.MementoPhoto{ID: photoID, MementoID: id, ObjectKey: MediaObjectKey(rawPhoto.Path, digest), ContentHash: "sha256:" + digest, Caption: optional(rawPhoto.Caption), Seq: rawPhoto.Seq, SourceRef: optional("package:" + pkg.Manifest.PackageID + ":" + rawPhoto.ID)})
 	}
 	return memento, photos, nil
+}
+
+// MediaDigest is the content identity of an original: the lowercase hex SHA-256
+// of its bytes. It is the stable contract ADR-0026 names, and the only thing
+// storage identity may be derived from.
+func MediaDigest(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+// MediaObjectKey is where an original with this digest is stored, shared by the
+// importer that records the reference and by the composition root that installs
+// the bytes, so the two cannot drift. The member's base name is kept for
+// legibility only; uniqueness comes entirely from the digest, so two packages
+// carrying the same member name land in different directories.
+func MediaObjectKey(memberPath string, digest string) string {
+	return path.Join("media", digest, path.Base(memberPath))
+}
+
+// verifyDeclaredHash rejects a package whose declared content_hash disagrees
+// with its own bytes. Without this the declaration would decide where bytes are
+// stored, which is the authority the digest is supposed to take away. Both the
+// bare hex and the `sha256:` prefixed spelling the tooling emits are accepted.
+func verifyDeclaredHash(declared string, digest string) error {
+	normalized := strings.TrimPrefix(strings.ToLower(strings.TrimSpace(declared)), "sha256:")
+	if normalized != digest {
+		return fmt.Errorf("content_hash %q does not match the bytes (sha256:%s)", declared, digest)
+	}
+	return nil
 }
 
 func normalizeGeometry(raw any) (orb.Geometry, error) {

--- a/apps/felicia-runtime/importer/package_test.go
+++ b/apps/felicia-runtime/importer/package_test.go
@@ -1,6 +1,8 @@
 package importer
 
 import (
+	"path"
+	"strings"
 	"testing"
 
 	journeypackage "github.com/azusachino/felicia/apps/felicia-core/journeypackage"
@@ -11,7 +13,7 @@ func TestDecodePackageNormalizesRouteMementoAndMedia(t *testing.T) {
 		Manifest: journeypackage.Manifest{PackageID: "timeline-1"},
 		Files: map[string][]byte{
 			"journey.yaml":     []byte("id: 00000000-0000-0000-0000-000000000001\njournal_id: 00000000-0000-0000-0000-000000000002\nslug: kyoto\ntitle: Kyoto\nplace: Kyoto\ndate_start: 2026-04-01\ndate_end: 2026-04-01\n"),
-			"mementos.yaml":    []byte("- id: 00000000-0000-0000-0000-000000000003\n  seq: 1\n  kind: transit\n  occurred_at: 2026-04-01T09:00:00+09:00\n  occurred_tz: Asia/Tokyo\n  title: Train\n  place: Kyoto\n  vendor: JR East\n  essay: A quiet departure.\n  price_amount: 1800\n  price_currency: JPY\n  authored_fields: [title, vendor, essay, price_amount, price_currency]\n  geom: [[135.7681, 35.0116], [139.7671, 35.6812]]\n  kind_data:\n    operator: JR West\n    from: {name: Kyoto, coords: [135.7681, 35.0116]}\n    to: {name: Tokyo, coords: [139.7671, 35.6812]}\n  photos:\n    - id: 00000000-0000-0000-0000-000000000004\n      path: media/ticket.jpg\n      content_hash: sha256:ticket\n      seq: 1\n"),
+			"mementos.yaml":    []byte("- id: 00000000-0000-0000-0000-000000000003\n  seq: 1\n  kind: transit\n  occurred_at: 2026-04-01T09:00:00+09:00\n  occurred_tz: Asia/Tokyo\n  title: Train\n  place: Kyoto\n  vendor: JR East\n  essay: A quiet departure.\n  price_amount: 1800\n  price_currency: JPY\n  authored_fields: [title, vendor, essay, price_amount, price_currency]\n  geom: [[135.7681, 35.0116], [139.7671, 35.6812]]\n  kind_data:\n    operator: JR West\n    from: {name: Kyoto, coords: [135.7681, 35.0116]}\n    to: {name: Tokyo, coords: [139.7671, 35.6812]}\n  photos:\n    - id: 00000000-0000-0000-0000-000000000004\n      path: media/ticket.jpg\n      content_hash: sha256:6105d6cc76af400325e94d588ce511be5bfdbb73b437dc51eca43917d7a43e3d\n      seq: 1\n"),
 			"route.gpx":        []byte(`<?xml version="1.0"?><gpx><trk><trkseg><trkpt lat="35.0116" lon="135.7681"/><trkpt lat="35.6812" lon="139.7671"/></trkseg></trk></gpx>`),
 			"media/ticket.jpg": []byte("image"),
 		},
@@ -32,5 +34,84 @@ func TestDecodePackageNormalizesRouteMementoAndMedia(t *testing.T) {
 	}
 	if got.Mementos[0].Vendor == nil || *got.Mementos[0].Vendor != "JR East" || got.Mementos[0].Essay == nil || got.Mementos[0].PriceAmount == nil || *got.Mementos[0].PriceAmount != 1800 || len(got.Mementos[0].AuthoredFields) != 5 {
 		t.Fatalf("authored fields were not normalized: %#v", got.Mementos[0])
+	}
+}
+
+// TestPackagesWithTheSameMemberNameDoNotCollide is the invariant that makes the
+// overwrite impossible. Two journeys can each carry `media/ticket.jpg` holding a
+// different photo; while storage identity was the member name, importing the
+// second replaced the first's bytes in the shared media root and the published
+// site showed the wrong image with no error.
+func TestPackagesWithTheSameMemberNameDoNotCollide(t *testing.T) {
+	first := packageWithTicket(t, "first-journey", []byte("the first photo"))
+	second := packageWithTicket(t, "second-journey", []byte("a different photo"))
+
+	firstDocument, err := DecodePackage(first)
+	if err != nil {
+		t.Fatalf("decode first: %v", err)
+	}
+	secondDocument, err := DecodePackage(second)
+	if err != nil {
+		t.Fatalf("decode second: %v", err)
+	}
+
+	firstKey := firstDocument.Photos[0].ObjectKey
+	secondKey := secondDocument.Photos[0].ObjectKey
+	if firstKey == secondKey {
+		t.Fatalf("both packages claim %q, so one overwrites the other", firstKey)
+	}
+	if base := path.Base(firstKey); base != "ticket.jpg" {
+		t.Errorf("member name should survive for legibility, got %q", base)
+	}
+	if firstDocument.Photos[0].ContentHash == secondDocument.Photos[0].ContentHash {
+		t.Error("different bytes must not share a content hash")
+	}
+}
+
+// TestIdenticalBytesShareOneObjectKey is the other half: content addressing must
+// deduplicate rather than merely disambiguate, or the same photo imported twice
+// is stored twice.
+func TestIdenticalBytesShareOneObjectKey(t *testing.T) {
+	same := []byte("identical bytes")
+	first, err := DecodePackage(packageWithTicket(t, "one", same))
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := DecodePackage(packageWithTicket(t, "two", same))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Photos[0].ObjectKey != second.Photos[0].ObjectKey {
+		t.Errorf("identical bytes stored twice: %q vs %q", first.Photos[0].ObjectKey, second.Photos[0].ObjectKey)
+	}
+}
+
+// TestDeclaredContentHashMustMatchTheBytes keeps the declaration from choosing
+// where bytes land, which is the authority the digest is meant to remove.
+func TestDeclaredContentHashMustMatchTheBytes(t *testing.T) {
+	pkg := packageWithTicket(t, "liar", []byte("real bytes"))
+	pkg.Files["mementos.yaml"] = []byte(strings.Replace(
+		string(pkg.Files["mementos.yaml"]),
+		"content_hash: sha256:"+MediaDigest([]byte("real bytes")),
+		"content_hash: sha256:"+MediaDigest([]byte("bytes it wishes it had")),
+		1,
+	))
+	if _, err := DecodePackage(pkg); err == nil {
+		t.Fatal("a package declaring a hash that is not its own bytes must be rejected")
+	}
+}
+
+// packageWithTicket builds a minimal valid package whose single photo is always
+// the member `media/ticket.jpg`, so callers vary only the bytes.
+func packageWithTicket(t *testing.T, id string, image []byte) *journeypackage.Package {
+	t.Helper()
+	mementos := "- id: 00000000-0000-0000-0000-000000000003\n  seq: 1\n  kind: transit\n  occurred_at: 2026-04-01T09:00:00+09:00\n  occurred_tz: Asia/Tokyo\n  title: Train\n  place: Kyoto\n  geom: [[135.7681, 35.0116], [139.7671, 35.6812]]\n  kind_data:\n    operator: JR West\n    from: {name: Kyoto, coords: [135.7681, 35.0116]}\n    to: {name: Tokyo, coords: [139.7671, 35.6812]}\n  photos:\n    - id: 00000000-0000-0000-0000-000000000004\n      path: media/ticket.jpg\n      content_hash: sha256:" + MediaDigest(image) + "\n      seq: 1\n"
+	return &journeypackage.Package{
+		Manifest: journeypackage.Manifest{PackageID: id},
+		Files: map[string][]byte{
+			"journey.yaml":     []byte("id: 00000000-0000-0000-0000-000000000001\njournal_id: 00000000-0000-0000-0000-000000000002\nslug: kyoto\ntitle: Kyoto\nplace: Kyoto\ndate_start: 2026-04-01\ndate_end: 2026-04-01\n"),
+			"mementos.yaml":    []byte(mementos),
+			"media/ticket.jpg": image,
+		},
 	}
 }


### PR DESCRIPTION
Fixes #104.

Two packages may each carry `media/ticket.jpg` holding a different photo. Storage identity was that member name (`importer/package.go` `ObjectKey: rawPhoto.Path`), so importing the second wrote over the first's bytes in the shared media root and the published site showed the wrong image for a memento — silently, in CI, with no error.

Accepted [ADR-0026](docs/adr/0026-local-first-media-and-blob-storage.md) already required the opposite: the content hash is "the stable contract". This is a defect against an existing decision, not a new design.

## What changed

Identity is the SHA-256 of the bytes, **computed at import** rather than taken from the package's declared `content_hash`. Trusting the declaration would leave the package choosing where its bytes land, which is precisely the authority the digest removes; a declaration disagreeing with its own bytes is now rejected.

One derivation is shared by the importer that records the reference and the composition root that installs the file, so they cannot drift. Keys keep the `media/` prefix and the member's base name for legibility with the digest between them, so uniqueness comes entirely from the digest and identical bytes deduplicate rather than merely disambiguating.

## No migration, and why

The Pages route (`.github/workflows/pages.yml:30`) builds its database from scratch every run, so package-path object keys only ever existed inside a throwaway database — there is nothing durable to convert. The catalog holds one journey today (`izu-trip-2026-08-01`, three uniquely named files), so no collision has occurred yet. This lands before a second journey can create one.

## Published URLs change, unavoidably

`ObjectKey` is simultaneously the private storage key, the public artifact path, and the `object_key` in public JSON. A unique private key therefore means a unique public one — a colliding public path would be the same defect relocated, so there is no variant that preserves URLs. Verified nothing depends on the old shape:

- `scripts/verify_static_artifact.py:31-33` derives expected media paths **from** each photo's `object_key`, so it is shape-agnostic;
- the readers build URLs by joining whatever key they receive (`packages/felicia-reader/src/reader/adapt.ts`);
- the site is rebuilt and deployed whole, so no stale references survive.

That `ObjectKey` serves both a private and a public role is itself the conflation the rebuild proposal wants split into Blob and Attachment. Out of scope here, and noted rather than half-done.

## Tests

Three new cases, each verified to fail against the old identity scheme by temporarily restoring member-name keys:

- **same member name, different bytes → different keys.** Fails with `both packages claim "media/ticket.jpg", so one overwrites the other`.
- **identical bytes → one key.** Content addressing must deduplicate, not just disambiguate.
- **a declared hash that is not its own bytes is rejected.**

The end-to-end CLI test now asserts the on-disk path via the shared derivation rather than a hardcoded digest, so it states the contract instead of a literal.

Two fixtures declared `content_hash: sha256:ticket`, a placeholder that never matched its bytes. They now carry real digests — the format should never have accepted them, and the new check caught it immediately.

## Validation

`make check` exits 0: fmt-check including rumdl, vet, lint, `go test -race` with coverage across every module, and 50 Python feature tests.