### PR TITLE
fix: install originals before the references that claim them

### DIFF
--- a/apps/felicia-cli/cmd/felicia/main.go
+++ b/apps/felicia-cli/cmd/felicia/main.go
@@ -277,29 +277,67 @@ func importCommand(args []string, output io.Writer) error {
 		return err
 	}
 	defer func() { _ = repo.Close() }()
+	// Originals are installed before the transaction that references them.
+	// A failed import may leave unreferenced blobs, which are inert and
+	// recoverable; it must never leave committed rows pointing at bytes that
+	// are absent or truncated, which nothing detects and no retry repairs.
+	if err := installPackageMedia(pkg, *mediaRoot); err != nil {
+		return err
+	}
 	report, err := importer.ApplyPackage(context.Background(), document, repo)
 	if err != nil {
 		return err
 	}
+	return writeJSON(output, map[string]any{"mode": "apply", "package_id": pkg.Manifest.PackageID, "journeys": report.Journeys, "candidates": report.Candidates, "mementos": report.Mementos, "photos": report.Photos})
+}
+
+// installPackageMedia writes every media member into the media root under its
+// content identity. Content addressing makes this idempotent: the path encodes
+// the digest, so a member already present is already the right bytes and is
+// left alone. Publishing only ever happens by rename, so a file visible at its
+// final path is a complete one -- an interrupted run leaves a discarded
+// temporary file rather than a truncated original.
+func installPackageMedia(pkg *journeypackage.Package, mediaRoot string) error {
 	for filename, data := range pkg.Files {
 		if !strings.HasPrefix(filename, "media/") {
 			continue
 		}
-		// Install by content identity, using the same derivation the importer
-		// recorded, so a member name shared with another package cannot
-		// overwrite that package's bytes (ADR-0026).
-		destination, err := publication.SafeJoin(*mediaRoot, importer.MediaObjectKey(filename, importer.MediaDigest(data)))
+		// The same derivation the importer recorded, so a member name shared
+		// with another package cannot overwrite that package's bytes (ADR-0026).
+		destination, err := publication.SafeJoin(mediaRoot, importer.MediaObjectKey(filename, importer.MediaDigest(data)))
 		if err != nil {
 			return err
+		}
+		if _, err := os.Stat(destination); err == nil {
+			continue
 		}
 		if err := os.MkdirAll(filepath.Dir(destination), 0o700); err != nil {
 			return err
 		}
-		if err := os.WriteFile(destination, data, 0o600); err != nil {
-			return err
+		if err := writeOriginalAtomically(destination, data); err != nil {
+			return fmt.Errorf("install %s: %w", filename, err)
 		}
 	}
-	return writeJSON(output, map[string]any{"mode": "apply", "package_id": pkg.Manifest.PackageID, "journeys": report.Journeys, "candidates": report.Candidates, "mementos": report.Mementos, "photos": report.Photos})
+	return nil
+}
+
+func writeOriginalAtomically(destination string, data []byte) error {
+	temp, err := os.CreateTemp(filepath.Dir(destination), ".felicia-*")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = os.Remove(temp.Name()) }()
+	if _, err := temp.Write(data); err != nil {
+		_ = temp.Close()
+		return err
+	}
+	if err := temp.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(temp.Name(), 0o600); err != nil {
+		return err
+	}
+	return os.Rename(temp.Name(), destination)
 }
 
 func compileCommand(args []string, output io.Writer) error {

--- a/apps/felicia-cli/cmd/felicia/main_test.go
+++ b/apps/felicia-cli/cmd/felicia/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"archive/zip"
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"image"
@@ -13,9 +14,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
 	"gopkg.in/yaml.v3"
 
 	journeypackage "github.com/azusachino/felicia/apps/felicia-core/journeypackage"
+	"github.com/azusachino/felicia/apps/felicia-providers/sqlite"
 	"github.com/azusachino/felicia/apps/felicia-runtime/importer"
 )
 
@@ -131,5 +134,61 @@ func writeZipFile(t *testing.T, writer *zip.Writer, name string, data []byte) {
 	}
 	if _, err := entry.Write(data); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// TestImportCommitsNoReferencesWhenMediaCannotBeInstalled is the ordering
+// contract. Originals are installed before the transaction that references
+// them, so a failure to write bytes leaves no committed row claiming they
+// exist. Under the previous order the transaction committed first and the
+// journal was left pointing at media that had never landed, which nothing
+// detects and no retry repairs.
+func TestImportCommitsNoReferencesWhenMediaCannotBeInstalled(t *testing.T) {
+	root := t.TempDir()
+	archive := writeFixturePackage(t, filepath.Join(root, "journey.zip"))
+	database := filepath.Join(root, "felicia.sqlite")
+
+	// A regular file where the media root should be: creating any directory
+	// beneath it fails, so installation cannot succeed.
+	blocked := filepath.Join(root, "not-a-directory")
+	if err := os.WriteFile(blocked, []byte("in the way"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var report strings.Builder
+	err := execute([]string{"import", "--db", database, "--media-root", blocked, "--apply", archive}, &report)
+	if err == nil {
+		t.Fatal("import must fail when its originals cannot be installed")
+	}
+
+	repo, err := sqlite.Open(database)
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	defer func() { _ = repo.Close() }()
+	if _, err := repo.GetJourney(context.Background(), uuid.MustParse("00000000-0000-0000-0000-000000000001")); err == nil {
+		t.Fatal("a journey was committed even though its media never landed")
+	}
+}
+
+// TestImportIsIdempotentAcrossRuns covers the other half of installing first:
+// the path encodes the digest, so a second run finds its originals already
+// present and must succeed rather than fail or rewrite them.
+func TestImportIsIdempotentAcrossRuns(t *testing.T) {
+	root := t.TempDir()
+	archive := writeFixturePackage(t, filepath.Join(root, "journey.zip"))
+	database := filepath.Join(root, "felicia.sqlite")
+	mediaRoot := filepath.Join(root, "media")
+
+	for attempt := 1; attempt <= 2; attempt++ {
+		var report strings.Builder
+		if err := execute([]string{"import", "--db", database, "--media-root", mediaRoot, "--apply", archive}, &report); err != nil {
+			t.Fatalf("import attempt %d: %v", attempt, err)
+		}
+	}
+
+	installed := importer.MediaObjectKey("media/ticket.jpg", importer.MediaDigest(fixtureJPEG(t)))
+	if _, err := os.Stat(filepath.Join(mediaRoot, installed)); err != nil {
+		t.Fatalf("original missing after two imports: %v", err)
 	}
 }

--- a/apps/felicia-runtime/importer/package.go
+++ b/apps/felicia-runtime/importer/package.go
@@ -47,6 +47,15 @@ type ImportReport struct {
 // ApplyPackage writes a normalized package into the canonical store. Source
 // fields are applied through the ingest boundary; authored fields are never
 // supplied by this operation.
+//
+// The caller must have installed the package's originals before calling this.
+// This operation commits references to media by object key and has no way to
+// check that the bytes exist, so committing first would leave rows claiming
+// files that never landed -- a state nothing detects and no retry repairs.
+// Unreferenced blobs from a failed import are the acceptable direction of that
+// trade: inert, and recoverable. Object keys come from MediaObjectKey, so a
+// composition root can install bytes before this call without guessing where
+// they belong.
 func ApplyPackage(ctx context.Context, document *PackageDocument, store PackageStore) (ImportReport, error) {
 	// Label every memento write this import performs as importer-sourced in the
 	// lifecycle log (docs/contracts/memento-lifecycle.md §8).


### PR DESCRIPTION
Fixes #105. **Stacked on #117** — based on `fix/content-addressed-media-identity`, because installing before the transaction is only safe once identity is the digest. Retarget to `main` once #117 lands.

## The defect

`importCommand` committed the import transaction and only then copied media to disk (`main.go:280` then `:284-297`). A disk failure, a full volume, or an interrupt in between left the journal holding `tb_memento_photos` rows whose bytes were absent or truncated.

Nothing detects that state: a later compile fails or silently omits the photo while the row still claims a file exists. Against the private authoring journal, those bytes are the only copy.

## The fix

The order is inverted. A failed import may now leave unreferenced blobs — inert, and recoverable — but never committed rows pointing at bytes that never landed. [ADR-0015](docs/adr/0015-transactional-aggregate-revisions.md) makes aggregate writes transactional; a reference to nothing is outside what a transaction can protect, so ordering has to carry it.

Installing first is only safe because #117 made identity the digest: the destination is deterministic, so writing before the database knows anything cannot put bytes in the wrong place. On the old member-name identity this reordering would have been the more dangerous arrangement.

Two supporting properties:

- **Writes publish by rename.** A file visible at its final path is complete; an interrupted run leaves a discarded temporary rather than a truncated original.
- **The digest is in the path**, so a member already present is already the right bytes and is skipped. Re-import is idempotent rather than merely tolerated.

## Why not a port

`ApplyPackage` has exactly one non-test caller. Introducing a `MediaInstaller` port for a single call site is the speculative abstraction this project's conventions warn against, and it would give `felicia-runtime` filesystem knowledge that [ADR-0028](docs/adr/0028-cli-compiler-and-shared-publication-boundary.md) deliberately leaves to the composition root. The ordering now lives in `ApplyPackage`'s doc comment instead, so a second caller inherits the contract rather than rediscovering the defect.

## Scope

As set out on the issue: the Pages route rebuilds its database from scratch every run, so a torn import there is discarded and the build reruns — nothing is lost. The exposure this fixes is the documented authoring path (`felicia-cli import --db .felicia/felicia.sqlite`), and the tests assert it there rather than proving a throwaway build recovers.

## Tests

- **`TestImportCommitsNoReferencesWhenMediaCannotBeInstalled`** — media root blocked by a regular file, so installation cannot succeed; asserts the import fails *and* no journey row was committed. Verified to fail under the old order with `a journey was committed even though its media never landed`.
- **`TestImportIsIdempotentAcrossRuns`** — two consecutive imports both succeed and the original is present, covering the skip path.

`make check` exits 0: fmt-check including rumdl, vet, lint, `go test -race` with coverage across every module, and 50 Python feature tests.