### PR TITLE
fix: round the coordinates in the journey index

### DIFF
--- a/apps/felicia-publication/compiler.go
+++ b/apps/felicia-publication/compiler.go
@@ -222,12 +222,15 @@ func (StaticCompiler) Compile(ctx context.Context, input Input, read ReadModel, 
 // it is reused rather than picked independently.
 //
 // ADR-0025 requires the static artifact to never contain "unrounded private
-// geometry". Rounding here — the sole place both the route (a journey's
-// passive GPS trace) and every memento Geom (frequently derived from that
-// same trace at a stop's timestamp, see apps/felicia-runtime/importer) are projected to
-// GeoJSON — makes the guarantee hold for every importer that could have
-// populated the stored geometry, not just the one path a defect happened to
-// skip.
+// geometry". Rounding where geometry is projected — the route (a journey's
+// passive GPS trace), every memento Geom (frequently derived from that same
+// trace at a stop's timestamp, see apps/felicia-runtime/importer), and the
+// index's representative dots in projection.go — makes the guarantee hold for
+// every importer that could have populated the stored geometry, not just the
+// one path a defect happened to skip. This comment previously called the
+// function below the sole such place; representativeCoord was not routed
+// through it, and the landing index published full-precision coordinates until
+// that was fixed. Any new projection of stored geometry belongs here too.
 const publicCoordDecimals = 4
 
 // roundCoord rounds a single coordinate ordinate (longitude or latitude) to

--- a/apps/felicia-publication/projection.go
+++ b/apps/felicia-publication/projection.go
@@ -59,13 +59,17 @@ func representativeDots(mementos []*domain.Memento) []RepresentativeDot {
 	return dots
 }
 
+// representativeCoord is a public coordinate and is rounded like every other
+// one. This projection is the landing index, reached before any detail page, so
+// leaving it unrounded published full-precision positions on the first page a
+// reader sees while the detail JSON they click into was already rounded.
 func representativeCoord(geom orb.Geometry) []float64 {
 	switch g := geom.(type) {
 	case orb.Point:
-		return []float64{g.X(), g.Y()}
+		return []float64{roundCoord(g.X()), roundCoord(g.Y())}
 	case orb.LineString:
 		if len(g) > 0 {
-			return []float64{g[0].X(), g[0].Y()}
+			return []float64{roundCoord(g[0].X()), roundCoord(g[0].Y())}
 		}
 	}
 	return nil

--- a/apps/felicia-publication/projection_test.go
+++ b/apps/felicia-publication/projection_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
 	"github.com/paulmach/orb"
 
 	"github.com/azusachino/felicia/apps/felicia-core/domain"
@@ -46,5 +47,26 @@ func TestNewJourneyListItemJSONShape(t *testing.T) {
 	want := `{"id":"00000000-0000-0000-0000-000000000000","slug":"japan","title":"日本","memento_count":1,"representative_dots":[{"coord":[139.7,35.6],"label":"東京"}]}`
 	if string(data) != want {
 		t.Errorf("unexpected JSON shape:\n got: %s\nwant: %s", data, want)
+	}
+}
+
+// TestRepresentativeDotsRoundToPublicPrecision closes the index half of the
+// coordinate policy. The detail JSON was already rounded, so a reader clicking
+// into a memento saw ~11m precision while the landing index they arrived on
+// carried whatever the importer had stored — often 7+ digits from a GPS device.
+func TestRepresentativeDotsRoundToPublicPrecision(t *testing.T) {
+	journey := &domain.Journey{ID: uuid.MustParse("00000000-0000-0000-0000-000000000001"), Slug: "kyoto", Title: "Kyoto"}
+	mementos := []*domain.Memento{
+		{ID: uuid.MustParse("00000000-0000-0000-0000-000000000002"), Place: "Shibuya", Geom: orb.Point{fullPrecisionLng, fullPrecisionLat}},
+		{ID: uuid.MustParse("00000000-0000-0000-0000-000000000003"), Place: "Along the route", Geom: orb.LineString{{fullPrecisionLng, fullPrecisionLat}, {139.7, 35.7}}},
+	}
+
+	item := NewJourneyListItem(journey, mementos)
+	if len(item.RepresentativeDots) != 2 {
+		t.Fatalf("expected a dot per place, got %d", len(item.RepresentativeDots))
+	}
+	for _, dot := range item.RepresentativeDots {
+		assertOnPublicPrecisionGrid(t, dot.Label+" lng", dot.Coord[0])
+		assertOnPublicPrecisionGrid(t, dot.Label+" lat", dot.Coord[1])
 	}
 }


### PR DESCRIPTION
Fixes #108.

`representativeCoord` (`projection.go:62-71`) returned stored ordinates untouched, so `representative_dots` published whatever precision an importer had persisted — routinely 7+ digits from a GPS device. Detail geometry was already rounded to four decimals (~11m), so a reader saw the policy honoured on the memento they clicked into and bypassed on the landing page they arrived at.

The projection is shared by the static compiler (`compiler.go:158`) and the live API (`server.go:1443`), so both emitted it.

Two things worth noting beyond the one-line fix:

**#90 was filed on a premise this falsifies.** That issue states as given that `compiler.go` "now rounds **every** published coordinate to 4 decimals", and treats the remaining exposure as route trimming. The index path was never rounded, so the invariant #90 builds on was incomplete. #90's own concern — that rounding reduces precision rather than point count, and cannot hide a residence — is untouched and still open.

**The comment above `roundCoord` was part of the cause.** It described that function as "the sole place" stored geometry is projected to public form, which made the invariant read as total when one path bypassed it. It now names all three projections and says a new one belongs there too. A comment asserting completeness is worth as much as the completeness is real.

## Test

`TestRepresentativeDotsRoundToPublicPrecision` feeds the existing `fullPrecisionLng/Lat` fixtures through both the Point and LineString branches and asserts every emitted ordinate sits on the grid, reusing `assertOnPublicPrecisionGrid` from the detail-side test. Verified to fail against the unrounded code:

```
Shibuya lng = 139.69170612345678 is not rounded to 4 decimals (off-grid by 0.0612...)
```

`make check` exits 0.