### PR TITLE
fix: make journey ingest atomic against a concurrent author

### DIFF
--- a/apps/felicia-providers/sqlite/ingest_race_internal_test.go
+++ b/apps/felicia-providers/sqlite/ingest_race_internal_test.go
@@ -1,0 +1,92 @@
+package sqlite
+
+import (
+	"context"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/azusachino/felicia/apps/felicia-core/domain"
+)
+
+// TestIngestAndAuthoringWriteAreSerialised reproduces the interleaving that
+// made journey ingest unsafe. Ingest read a journey, decided ownership from
+// that copy, then wrote the whole row back; an authoring write landing in
+// between was overwritten by state that was already stale, and it took the
+// authored mask with it. The mask is what ADR-0033 relies on to protect every
+// later import, so losing it silently downgrades all future ingests.
+//
+// The window is too narrow for a stress loop to hit, so the test widens it
+// through afterIngestRead rather than racing and hoping. With the read and the
+// write in one transaction the authoring write cannot land inside the window at
+// all: it waits for the connection this provider pools singly, then applies
+// afterwards.
+func TestIngestAndAuthoringWriteAreSerialised(t *testing.T) {
+	repo, err := Open(":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer func() { _ = repo.Close() }()
+	ctx := context.Background()
+
+	journal := &domain.Journal{ID: uuid.New(), CreatedAt: time.Now().UTC()}
+	if err := repo.CreateJournal(ctx, journal); err != nil {
+		t.Fatalf("create journal: %v", err)
+	}
+	id := uuid.New()
+	seed := &domain.Journey{
+		ID: id, JournalID: journal.ID, Slug: "serialised", Title: "Imported name", Place: "Kyoto",
+		DateStart: time.Date(2026, 3, 20, 0, 0, 0, 0, time.UTC),
+		DateEnd:   time.Date(2026, 3, 22, 0, 0, 0, 0, time.UTC),
+	}
+	if err := repo.UpsertJourney(ctx, seed); err != nil {
+		t.Fatalf("seed journey: %v", err)
+	}
+
+	readHappened := make(chan struct{})
+	original := afterIngestRead
+	afterIngestRead = func() {
+		close(readHappened)
+		// Long enough that an unsynchronised authoring write would certainly
+		// land before the ingest writes its stale copy back.
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Cleanup(func() { afterIngestRead = original })
+
+	ingestDone := make(chan error, 1)
+	go func() {
+		ingestDone <- repo.ApplyIngestJourneyPatch(ctx, &domain.IngestJourneyPatch{
+			Journey: &domain.Journey{
+				ID: id, JournalID: journal.ID, Slug: seed.Slug, Title: "Imported name", Place: "Osaka",
+				DateStart: seed.DateStart, DateEnd: seed.DateEnd,
+			},
+			Fields: []string{"title", "place"},
+		})
+	}()
+
+	<-readHappened
+	authored := &domain.Journey{
+		ID: id, JournalID: journal.ID, Slug: seed.Slug, Title: "The name I chose", Place: "Kyoto",
+		DateStart: seed.DateStart, DateEnd: seed.DateEnd,
+		AuthoredFields: []string{"title"},
+	}
+	if err := repo.UpsertJourney(ctx, authored); err != nil {
+		t.Fatalf("authoring write: %v", err)
+	}
+	if err := <-ingestDone; err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+
+	stored, err := repo.GetJourney(ctx, id)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if stored.Title != authored.Title {
+		t.Errorf("authored title was overwritten by ingest: got %q, want %q", stored.Title, authored.Title)
+	}
+	if !slices.Contains(stored.AuthoredFields, "title") {
+		t.Errorf("authored mask was dropped, leaving future imports unprotected: %v", stored.AuthoredFields)
+	}
+}

--- a/apps/felicia-providers/sqlite/store.go
+++ b/apps/felicia-providers/sqlite/store.go
@@ -386,6 +386,14 @@ func (r *Repository) ListJourneys(ctx context.Context) ([]*domain.Journey, error
 	return result, rows.Err()
 }
 
+// afterIngestRead runs between the ingest read and the write that follows it,
+// and does nothing in production. It exists because that gap is the whole
+// defect: a concurrency bug is only fixed if a test can reproduce the
+// interleaving, and the interleaving here is too narrow for a stress loop to
+// hit reliably. Tests in this package replace it to widen the window; no
+// production path observes it.
+var afterIngestRead = func() {}
+
 // ApplyIngestJourneyPatch applies source-owned journey fields without taking
 // authorship. Every masked field the stored row already claims as authored is
 // skipped, and the stored authored mask is written back unchanged, so a
@@ -395,6 +403,18 @@ func (r *Repository) ApplyIngestJourneyPatch(ctx context.Context, patch *domain.
 	if patch == nil || patch.Journey == nil {
 		return errors.New("ingest journey patch is required")
 	}
+	// The read, the ownership decision and the write are one unit. Separately
+	// they are a race: ingest reads a journey, the author sets a title and
+	// marks it authored, then ingest writes back the copy it read and both the
+	// title and the mask protecting it are gone. Nothing detects that, and the
+	// mask is what ADR-0033 relies on. A transaction holds this provider's
+	// single pooled connection for the whole sequence, so no other statement
+	// can land in the middle of it.
+	if _, inTransaction := r.db.(*sql.Tx); !inTransaction {
+		return r.WithTransaction(ctx, func(repo domain.Repository) error {
+			return repo.ApplyIngestJourneyPatch(ctx, patch)
+		})
+	}
 	current, err := r.GetJourney(ctx, patch.Journey.ID)
 	switch {
 	case errors.Is(err, sql.ErrNoRows), errors.Is(err, domain.ErrNotFound):
@@ -402,6 +422,7 @@ func (r *Repository) ApplyIngestJourneyPatch(ctx context.Context, patch *domain.
 	case err != nil:
 		return fmt.Errorf("load journey ingest target %s: %w", patch.Journey.ID, err)
 	}
+	afterIngestRead()
 	if current.JournalID == uuid.Nil {
 		current.JournalID = patch.Journey.JournalID
 	}


### PR DESCRIPTION
Fixes #107.

`ApplyIngestJourneyPatch` read a journey (`store.go:398`), merged fields in memory, then wrote the whole row back through `UpsertJourney` — which also writes `authored_fields` (`store.go:430`). No revision predicate, no lock. An authoring write landing between the read and the write was overwritten by state that was already stale.

The lost title is the visible half. The **cleared mask** is the dangerous half: it silently unprotects that field for every later import, which is precisely what [ADR-0033](docs/adr/0033-authored-field-protection-and-the-journey-ingest-seam.md) relies on the mask to prevent. Route sync can call this outside any package transaction, so single-user does not mean single-request.

## Fix

The read, the ownership decision and the write are one transaction. This provider pools a single connection (`SetMaxOpenConns(1)`), so holding a transaction holds the only connection and nothing can land in the middle. Callers already inside a transaction reuse it rather than nesting, via the existing `WithTransaction` seam.

## On the test, because the first one was worthless

My first attempt raced an authoring write against an ingest in a 40-round loop. It **passed against the unfixed code** — the window between the two statements is too narrow for the scheduler to land inside reliably. A test that passes when the bug is present is worse than no test, so I deleted it rather than keep a green line.

The fix adds `afterIngestRead`, a no-op in production that tests replace to widen the window deterministically. That is a testing seam in production code, which I would normally avoid; here the gap it names *is* the defect, and a concurrency fix nobody can reproduce is not a fix. It now fails on the old code with both symptoms:

```
authored title was overwritten by ingest: got "Imported name", want "The name I chose"
authored mask was dropped, leaving future imports unprotected: []
```

## Two things deliberately not done

**No `revision` column.** A transaction closes this race; a column nothing reads would be speculative. Optimistic concurrency earns its place when the authoring API needs it — that is #89 — and this change does not preclude it. The review's wider recommendation that curated photos also become revision-aware stands separately.

**PostgreSQL is left alone** (`repository.go:266-277` has the same shape). Under accepted ADR-0032 it is a frozen non-v1 provider, and a gap SQLite does not share is deferred-provider work, consistent with how the stop-candidate transaction gap was reclassified.

`make check` exits 0, including `go test -race`.