### PR TITLE
fix: keep the author's draft when a save conflicts

### DIFF
--- a/apps/felicia-admin/src/mementoForm.test.ts
+++ b/apps/felicia-admin/src/mementoForm.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import type { AdminTemplateField } from "./api"
+import type { AdminMementoDetail, AdminTemplateField, MementoGeom } from "./api"
 import {
   buildKindData,
   buildPhotoPayload,
@@ -21,6 +21,7 @@ import {
   toRFC3339,
   unpublishActionLabel,
   FORM_LEVEL_ISSUE_KEY,
+  serverChangedFields,
 } from "./mementoForm"
 
 const transitFields: AdminTemplateField[] = [
@@ -346,5 +347,50 @@ describe("photo payload mapping", () => {
     })
     expect(payload.taken_at).toBe("2026-03-21T09:00:00Z")
     expect(payload.source_ref).toBeUndefined()
+  })
+})
+
+describe("serverChangedFields (conflict reporting)", () => {
+  const base: AdminMementoDetail = {
+    id: "memento-1",
+    journey_id: "journey-1",
+    kind: "transit",
+    seq: 1,
+    occurred_at: "2026-04-01T09:00:00+09:00",
+    occurred_tz: "Asia/Tokyo",
+    geom: [139.7671, 35.6812] as MementoGeom,
+    title: "Train ticket",
+    place: "Kyoto",
+    essay: "A quiet departure.",
+    kind_data: { operator: "JR West" },
+    authored_fields: ["title"],
+    state: "draft",
+    revision: 3,
+    created_at: "2026-04-01T00:00:00Z",
+    updated_at: "2026-04-01T00:00:00Z",
+  }
+
+  test("reports nothing when the server copy is unchanged", () => {
+    expect(serverChangedFields(base, { ...base, revision: 4 })).toEqual([])
+  })
+
+  test("names the fields the other writer touched", () => {
+    const current = { ...base, title: "Shinkansen ticket", essay: "Rewritten by someone else." }
+    expect(serverChangedFields(base, current)).toEqual(["title", "essay"])
+  })
+
+  test("treats a missing optional and an empty string as the same value", () => {
+    const loaded = { ...base, essay: undefined, vendor: undefined }
+    const current = { ...base, essay: "", vendor: "" }
+    expect(serverChangedFields(loaded, current)).toEqual([])
+  })
+
+  test("notices location and kind detail changes without diffing their contents", () => {
+    const current: AdminMementoDetail = { ...base, geom: [139.9, 35.9] as MementoGeom, kind_data: { operator: "JR East" } }
+    expect(serverChangedFields(base, current)).toEqual(["location", "kind details"])
+  })
+
+  test("notices a lifecycle state change, which decides whether a retry publishes", () => {
+    expect(serverChangedFields(base, { ...base, state: "published" })).toEqual(["state"])
   })
 })

--- a/apps/felicia-admin/src/mementoForm.ts
+++ b/apps/felicia-admin/src/mementoForm.ts
@@ -16,7 +16,7 @@
 //   - Validation issues come back as domain.Issue{Field, Code} — capitalized,
 //     no json tags, same as AdminTemplateField in api.ts.
 
-import type { AdminIssue, AdminTemplateField, MementoGeom, UpsertMementoGeom, UpsertMementoRequest, UpsertPhotoRequest } from "./api"
+import type { AdminIssue, AdminMementoDetail, AdminTemplateField, MementoGeom, UpsertMementoGeom, UpsertMementoRequest, UpsertPhotoRequest } from "./api"
 
 // --- Date/time -------------------------------------------------------------
 
@@ -378,4 +378,25 @@ export function buildPhotoPayload(id: string, mementoId: string, fields: PhotoFo
     taken_at: fields.takenAt ? toRFC3339(fields.takenAt) : undefined,
     source_ref: fields.sourceRef.trim() || undefined,
   }
+}
+
+// Fields the other writer changed between the copy this editor loaded and the
+// copy now on the server. Shown on a save conflict so the author can decide
+// whether their draft still makes sense, without building a merge UI: the
+// question "what moved under me" is answerable from two records, while "how do
+// I combine them" is a design this surface deliberately does not have.
+export function serverChangedFields(loaded: AdminMementoDetail, current: AdminMementoDetail): string[] {
+  const comparable: [string, unknown, unknown][] = [
+    ["title", loaded.title, current.title],
+    ["place", loaded.place, current.place],
+    ["essay", loaded.essay ?? "", current.essay ?? ""],
+    ["vendor", loaded.vendor ?? "", current.vendor ?? ""],
+    ["date and time", loaded.occurred_at, current.occurred_at],
+    ["timezone", loaded.occurred_tz, current.occurred_tz],
+    ["price", `${loaded.price_amount ?? ""} ${loaded.price_currency ?? ""}`, `${current.price_amount ?? ""} ${current.price_currency ?? ""}`],
+    ["state", loaded.state, current.state],
+    ["location", JSON.stringify(loaded.geom ?? null), JSON.stringify(current.geom ?? null)],
+    ["kind details", JSON.stringify(loaded.kind_data ?? {}), JSON.stringify(current.kind_data ?? {})],
+  ]
+  return comparable.filter(([, before, after]) => before !== after).map(([label]) => label)
 }

--- a/apps/felicia-admin/src/views/MementoEditor.svelte
+++ b/apps/felicia-admin/src/views/MementoEditor.svelte
@@ -31,6 +31,7 @@
     photoFormFieldsFromRequest,
     previousLifecycleState,
     priceFormFieldsFromMemento,
+    serverChangedFields,
     unpublishActionLabel,
     FORM_LEVEL_ISSUE_KEY,
     type CommonFormFields,
@@ -143,8 +144,10 @@
   }
 
   // Rehydrates every piece of local form state from a freshly-fetched
-  // memento. Used both on initial load and after a conflict reload (which
-  // must discard whatever the user had typed, per ADMIN-01.5 — no merge UI).
+  // memento. Used on initial load, after a successful save, and when the
+  // author explicitly chooses to discard their draft. A conflict does NOT
+  // call this: ADMIN-01.5 rules out a merge UI, which is a reason not to build
+  // a diff editor, not a reason to delete the only copy of an essay.
   function hydrateForm(fetched: AdminMementoDetail, registry: AdminTemplateRegistry | null) {
     common = {
       title: fetched.title ?? "",
@@ -228,9 +231,24 @@
       saveState = { status: "success", message: "Saved.", fieldErrors: {} }
     } catch (cause) {
       if (isConflict(cause)) {
+        // The draft stays exactly as typed. Fetch the server copy only to
+        // report what moved, so the author can judge whether their text still
+        // applies before retrying.
+        let changed: string[]
+        try {
+          const current = await getMemento(memento.id)
+          changed = serverChangedFields(memento, current)
+        } catch {
+          // Reporting what moved is a courtesy; failing to fetch it must not
+          // turn a recoverable conflict into a lost draft.
+          changed = []
+        }
         saveState = {
           status: "conflict",
-          message: "Someone else changed this memento since it was loaded.",
+          message:
+            changed.length > 0
+              ? `Someone else changed this memento since it was loaded (${changed.join(", ")}). Your edits are still here.`
+              : "Someone else changed this memento since it was loaded. Your edits are still here.",
           fieldErrors: {},
         }
         return
@@ -243,7 +261,24 @@
     }
   }
 
-  async function reloadAfterConflict() {
+  // Keeps the typed draft and refreshes only the revision the next save must
+  // carry, so retrying submits the author's work against current state. This
+  // is not a merge: the draft wins wholesale, which is the author's own most
+  // recent intent.
+  async function retryKeepingDraft() {
+    if (!memento) return
+    saveState = { status: "pending", message: "Rechecking…", fieldErrors: {} }
+    try {
+      memento = await getMemento(memento.id)
+      saveState = { status: "idle", message: "", fieldErrors: {} }
+      await save()
+    } catch (cause) {
+      saveState = { status: "error", message: actionErrorMessage(cause), fieldErrors: {} }
+    }
+  }
+
+  // The old behaviour, now only when asked for by name.
+  async function discardDraftAndReload() {
     await loadAll()
   }
 
@@ -393,7 +428,8 @@
     {#if saveState.status === "conflict"}
       <div class="conflict-banner" role="alert">
         <p>{saveState.message}</p>
-        <button type="button" onclick={reloadAfterConflict}>Reload and reapply</button>
+        <button type="button" onclick={retryKeepingDraft}>Save my version anyway</button>
+        <button type="button" class="secondary" onclick={discardDraftAndReload}>Discard my edits and load theirs</button>
       </div>
     {/if}
 


### PR DESCRIPTION
Fixes #110.

The conflict banner read "Reload and reapply" (`MementoEditor.svelte:396`) and called `loadAll()` (`:246-247`), which refetches and rehydrates the form (`:175-178`). Clicking the button that promised to reapply the work was what destroyed it.

## The comment was part of the defect

`hydrateForm`'s comment said the conflict path "must discard whatever the user had typed, per ADMIN-01.5 — no merge UI". Those are two different claims. Not building a diff editor is a scope decision; deleting the only copy of an unsaved essay is data loss wearing that decision's authority. The comment now says which is which.

## What changed

The draft stays exactly as typed, and the banner offers both outcomes by name:

- **"Save my version anyway"** — refetches only the revision the next save must carry (`expectedRevision`, `:220`) and resubmits the author's work against current state. Not a merge: the draft wins wholesale, which is that author's own most recent intent.
- **"Discard my edits and load theirs"** — the old behaviour, kept but no longer disguised as recovery.

The message also names the fields the other writer touched, so the author can judge whether their text still applies without a diff view. If fetching that report fails, it degrades to a plain conflict message rather than turning a recoverable state into a lost draft.

`serverChangedFields` is a pure helper in `mementoForm.ts` so it is testable without a browser, and treats a missing optional as equal to an empty string — the API omits empty fields, and reporting phantom changes would train the author to ignore the list.

## A gap found on the way, filed separately

`make admin-check` runs `svelte-check && eslint && prettier`. It does **not** run `bun test`, and neither does CI's `make web-check` — so `apps/felicia-admin` has a test script no gate invokes. Three of its tests are currently failing, on a real defect: `parseLatLng` returns `[0, 0]` instead of `null` for invalid input, so an empty or malformed coordinate becomes 0°,0° rather than being rejected. Filed rather than fixed here, to keep this change to one concern.

I did have to fix two type errors my new test introduced (it was the first thing to typecheck that file in a while).

## Validation

`make check` exits 0. `make admin-check` passes: 229 files, 0 errors, 0 warnings, Prettier clean. `bun test src/mementoForm.test.ts` — 36 pass, 3 fail, all three pre-existing and unrelated (31 pass / 3 fail on `main`).