### PR TITLE
fix: report what a build would change, not what it would add

### DIFF
--- a/apps/felicia-admin/src/api.ts
+++ b/apps/felicia-admin/src/api.ts
@@ -598,6 +598,9 @@ export async function browseDirectories(path?: string): Promise<AdminBrowseResul
 export interface AdminJourneyBuildStatus {
   pending_memento_ids: string[]
   pending_count: number
+  // never_built | changed | built. Absent from an older server, and an
+  // unreadable status is reported as unknown by the caller rather than clean.
+  build_state?: string
 }
 
 export async function getJourneyBuildStatus(journeyId: string): Promise<AdminJourneyBuildStatus> {

--- a/apps/felicia-admin/src/views/JourneyDetail.svelte
+++ b/apps/felicia-admin/src/views/JourneyDetail.svelte
@@ -212,15 +212,24 @@
   // highlighted rather than failing the whole page.
   let pendingMementoIds = $state<Set<string>>(new Set())
   let pendingCount = $state(0)
+  // Whether the artifact is current, stale, absent, or unreadable. Distinct
+  // from buildState below, which tracks an in-flight build action.
+  let artifactState = $state("")
 
   async function loadBuildStatus(journeyId: string) {
     try {
       const status = await getJourneyBuildStatus(journeyId)
       pendingMementoIds = new Set(status.pending_memento_ids)
       pendingCount = status.pending_count
+      artifactState = status.build_state ?? ""
     } catch {
+      // A status we could not read is unknown, not current. Reporting zero
+      // pending here made a failed request indistinguishable from a site with
+      // nothing to publish, which is the more reassuring of the two and the
+      // wrong one.
       pendingMementoIds = new Set()
       pendingCount = 0
+      artifactState = "unknown"
     }
   }
 
@@ -283,6 +292,24 @@
   function buildButtonLabel(pending: number, status: BuildStatus): string {
     if (status === "pending") return "Building…"
     return pending > 0 ? `Build & preview (${pending})` : "Build & preview"
+  }
+
+  // Says which of the four situations the author is in. "Built" is the only
+  // one that means the artifact matches what a build would now produce, and
+  // none of them claims anything about a remote deployment.
+  function artifactStateLabel(state: string, pending: number): string {
+    switch (state) {
+      case "never_built":
+        return pending > 0 ? `Never built — ${pending} to publish` : "Never built"
+      case "changed":
+        return `Changes since last build (${pending})`
+      case "built":
+        return "Built — matches your published content"
+      case "unknown":
+        return "Build state unknown — could not read it"
+      default:
+        return ""
+    }
   }
 
   function previewUrl(port: string): string {
@@ -476,6 +503,9 @@
       <div class="build-row">
         <span class="build-label">Build &amp; preview</span>
         <button type="button" onclick={triggerJourneyBuild} disabled={buildState.status === "pending"}>{buildButtonLabel(pendingCount, buildState.status)}</button>
+        {#if artifactStateLabel(artifactState, pendingCount)}
+          <p class="hint" class:api-error={artifactState === "unknown"}>{artifactStateLabel(artifactState, pendingCount)}</p>
+        {/if}
         {#if buildState.status === "success"}
           {#if buildState.report}
             <span class="trigger-status trigger-status--success build-report">

--- a/apps/felicia-server/api/buildstatus.go
+++ b/apps/felicia-server/api/buildstatus.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net/http"
@@ -15,78 +16,180 @@ import (
 )
 
 // Pending-build tracking (docs/contracts/memento-lifecycle.md §6). A memento is
-// pending-build when its current published visibility differs from the deployed
-// artifact: the DB's set of published memento IDs for a journey is compared
-// against the IDs present in that journey's compiled mementos.json. This is
-// stateless and self-correcting — the artifact is the source of truth for what
-// is deployed, so there is no dirty flag to drift. When no artifact exists yet
-// nothing is pending; the first build establishes the baseline.
+// pending-build when what a build would now publish for it differs from what
+// the artifact already holds. Comparison is by projected content, not by ID
+// membership: the artifact's mementos.json carries the whole public projection
+// — title, place, essay, price, kind_data and photos — so projecting current
+// state through the same NewStaticMemento the compiler uses and comparing the
+// result answers "would a build change anything" rather than only "did
+// something appear or disappear". Editing an already-published essay is a
+// change to the site, and membership cannot see it.
+//
+// This stays stateless and self-correcting: the artifact remains the record of
+// what was built, so there is no dirty flag to drift.
+//
+// "No artifact" is reported as its own state rather than as nothing pending.
+// Those are different situations — one site is current, the other has never
+// been built — and collapsing them told the author their site was up to date
+// when it did not exist.
+//
+// What this cannot know is what a remote host actually serves. A local output
+// directory is evidence of a local build, so the states below describe the
+// build, and deployment acknowledgement is deliberately absent rather than
+// implied.
 
 // artifactReady reports whether a compiled artifact exists to compare against.
 func (s *Server) artifactReady() bool {
 	return fileExists(filepath.Join(s.SiteOutDir(), filepath.FromSlash(publication.ManifestPath)))
 }
 
-// artifactMementoIDs returns the memento IDs present in a journey's compiled
-// mementos.json (the deployed/published set). A missing file yields an empty
-// set — the journey has no deployed mementos.
-func (s *Server) artifactMementoIDs(journeyID uuid.UUID) (map[string]bool, error) {
+// artifactMementos returns what the compiled artifact already publishes for a
+// journey, keyed by memento ID, as canonical JSON per entry. A missing file
+// yields an empty map — that journey has nothing built.
+//
+// Re-marshalling each entry rather than keeping the raw bytes normalises key
+// order and whitespace, so the comparison answers "is the content different"
+// and not "did the encoder space it differently".
+func (s *Server) artifactMementos(journeyID uuid.UUID) (map[string][]byte, error) {
 	path := filepath.Join(s.SiteOutDir(), "api", "v1", "journeys", journeyID.String(), "mementos.json")
 	raw, err := os.ReadFile(path)
 	if os.IsNotExist(err) {
-		return map[string]bool{}, nil
+		return map[string][]byte{}, nil
 	}
 	if err != nil {
 		return nil, err
 	}
-	var mementos []struct {
-		ID string `json:"id"`
-	}
+	var mementos []json.RawMessage
 	if err := json.Unmarshal(raw, &mementos); err != nil {
 		return nil, err
 	}
-	ids := make(map[string]bool, len(mementos))
-	for _, m := range mementos {
-		ids[m.ID] = true
+	built := make(map[string][]byte, len(mementos))
+	for _, entry := range mementos {
+		var identified struct {
+			ID string `json:"id"`
+		}
+		if err := json.Unmarshal(entry, &identified); err != nil {
+			return nil, err
+		}
+		canonical, err := canonicalJSON(entry)
+		if err != nil {
+			return nil, err
+		}
+		built[identified.ID] = canonical
 	}
-	return ids, nil
+	return built, nil
 }
 
-// journeyPendingBuild computes, for one journey, the set of existing mementos
-// whose published visibility differs from the artifact (for highlighting) and
-// the total pending count (which also includes artifact entries with no live
-// row — e.g. an unpublished-then-deleted memento still listed in the artifact).
-func (s *Server) journeyPendingBuild(ctx context.Context, journeyID uuid.UUID) (pendingIDs []string, count int, err error) {
-	if !s.artifactReady() {
-		return nil, 0, nil
+// canonicalJSON re-encodes a value so two semantically equal documents compare
+// equal as bytes. encoding/json sorts map keys, which is what makes this work.
+func canonicalJSON(value any) ([]byte, error) {
+	var intermediate any
+	switch typed := value.(type) {
+	case json.RawMessage:
+		if err := json.Unmarshal(typed, &intermediate); err != nil {
+			return nil, err
+		}
+	default:
+		encoded, err := json.Marshal(typed)
+		if err != nil {
+			return nil, err
+		}
+		if err := json.Unmarshal(encoded, &intermediate); err != nil {
+			return nil, err
+		}
 	}
-	artifactIDs, err := s.artifactMementoIDs(journeyID)
+	return json.Marshal(intermediate)
+}
+
+// Build states reported to the author. They are deliberately about the local
+// build, never about a remote deployment, which this server has no evidence of.
+const (
+	buildStateNeverBuilt = "never_built"
+	buildStateChanged    = "changed"
+	buildStateBuilt      = "built"
+)
+
+// journeyPendingBuild computes, for one journey, which mementos a build would
+// change (for highlighting), the total pending count, and the build state.
+//
+// The count includes artifact entries with no live row — an unpublished or
+// deleted memento still present in the artifact is pending removal, and has no
+// live memento to highlight.
+func (s *Server) journeyPendingBuild(ctx context.Context, journeyID uuid.UUID) (pendingIDs []string, count int, state string, err error) {
+	pendingIDs = []string{}
+	if !s.artifactReady() {
+		// Nothing has been built, so everything currently publishable is
+		// pending. Reporting zero here is what told an author with no artifact
+		// at all that their site was up to date.
+		mementos, listErr := s.repo.ListMementosByJourney(ctx, journeyID)
+		if listErr != nil {
+			return nil, 0, "", listErr
+		}
+		for _, m := range mementos {
+			if m.State == domain.MementoPublished {
+				pendingIDs = append(pendingIDs, m.ID.String())
+			}
+		}
+		return pendingIDs, len(pendingIDs), buildStateNeverBuilt, nil
+	}
+	built, err := s.artifactMementos(journeyID)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, "", err
 	}
 	mementos, err := s.repo.ListMementosByJourney(ctx, journeyID)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, "", err
 	}
 	liveIDs := make(map[string]bool, len(mementos))
-	pendingIDs = []string{}
-	for _, m := range mementos {
-		id := m.ID.String()
+	for _, memento := range mementos {
+		id := memento.ID.String()
 		liveIDs[id] = true
-		publishedNow := m.State == domain.MementoPublished
-		inArtifact := artifactIDs[id]
-		if publishedNow != inArtifact {
+		existing, inArtifact := built[id]
+		if memento.State != domain.MementoPublished {
+			// Only pending if the artifact still carries it, i.e. a build would
+			// withdraw it.
+			if inArtifact {
+				pendingIDs = append(pendingIDs, id)
+			}
+			continue
+		}
+		if !inArtifact {
+			pendingIDs = append(pendingIDs, id)
+			continue
+		}
+		projected, projectErr := s.projectedMemento(ctx, memento)
+		if projectErr != nil {
+			return nil, 0, "", projectErr
+		}
+		if !bytes.Equal(projected, existing) {
 			pendingIDs = append(pendingIDs, id)
 		}
 	}
 	count = len(pendingIDs)
-	// Artifact entries with no live row are stale deployments pending removal.
-	for id := range artifactIDs {
+	for id := range built {
 		if !liveIDs[id] {
 			count++
 		}
 	}
-	return pendingIDs, count, nil
+	if count == 0 {
+		return pendingIDs, 0, buildStateBuilt, nil
+	}
+	return pendingIDs, count, buildStateChanged, nil
+}
+
+// projectedMemento renders one memento exactly as a build would publish it,
+// through the same projection the compiler uses, so a difference here is a
+// difference the reader would see.
+func (s *Server) projectedMemento(ctx context.Context, memento *domain.Memento) ([]byte, error) {
+	photos, err := s.repo.ListPhotosByMemento(ctx, memento.ID)
+	if err != nil {
+		return nil, err
+	}
+	projection := make([]publication.StaticPhoto, 0, len(photos))
+	for _, photo := range photos {
+		projection = append(projection, publication.NewStaticPhoto(photo))
+	}
+	return canonicalJSON(publication.NewStaticMemento(memento, projection))
 }
 
 // handleJourneyBuildStatus returns the pending-build state for one journey:
@@ -98,7 +201,7 @@ func (s *Server) handleJourneyBuildStatus(w http.ResponseWriter, r *http.Request
 		respondError(w, http.StatusBadRequest, "invalid journey UUID")
 		return
 	}
-	pendingIDs, count, err := s.journeyPendingBuild(r.Context(), journeyID)
+	pendingIDs, count, state, err := s.journeyPendingBuild(r.Context(), journeyID)
 	if err != nil {
 		respondError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -106,6 +209,7 @@ func (s *Server) handleJourneyBuildStatus(w http.ResponseWriter, r *http.Request
 	respondJSON(w, http.StatusOK, map[string]any{
 		"pending_memento_ids": pendingIDs,
 		"pending_count":       count,
+		"build_state":         state,
 	})
 }
 
@@ -119,7 +223,7 @@ func (s *Server) handleBuildStatus(w http.ResponseWriter, r *http.Request) {
 	}
 	counts := map[string]int{}
 	for _, j := range journeys {
-		_, count, err := s.journeyPendingBuild(r.Context(), j.ID)
+		_, count, _, err := s.journeyPendingBuild(r.Context(), j.ID)
 		if err != nil {
 			respondError(w, http.StatusInternalServerError, err.Error())
 			return

--- a/apps/felicia-server/api/buildstatus_test.go
+++ b/apps/felicia-server/api/buildstatus_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/azusachino/felicia/apps/felicia-core/domain"
+	publication "github.com/azusachino/felicia/apps/felicia-publication"
 	"github.com/azusachino/felicia/apps/felicia-server/api"
 )
 
@@ -18,22 +19,23 @@ func TestJourneyBuildStatus(t *testing.T) {
 	outDir := t.TempDir()
 	journeyID := uuid.New()
 
-	// Deployed artifact: one published memento (id "in-artifact").
 	inArtifact := uuid.New()
 	unpublishedSince := uuid.New() // in artifact but now authored → pending removal
-	writeArtifactMementos(t, outDir, journeyID, inArtifact, unpublishedSince)
+	newlyPublished := uuid.New()   // published but absent from the artifact → pending add
+
+	unchanged := &domain.Memento{ID: inArtifact, JourneyID: journeyID, Kind: "transit", Seq: 1, Title: "As built", State: domain.MementoPublished}
+	withdrawn := &domain.Memento{ID: unpublishedSince, JourneyID: journeyID, Kind: "transit", Seq: 2, Title: "Was built", State: domain.MementoAuthored}
+
+	// The artifact holds both, projected exactly as a build would write them.
+	writeArtifactMementos(t, outDir, journeyID, unchanged, &domain.Memento{ID: unpublishedSince, JourneyID: journeyID, Kind: "transit", Seq: 2, Title: "Was built", State: domain.MementoPublished})
 	// Manifest marks the artifact as ready.
 	mustWrite(t, filepath.Join(outDir, "api", "v1", "manifest.json"), `{"files":[]}`)
 
 	repo := newMockRepository()
 	repo.journeys[journeyID] = &domain.Journey{ID: journeyID}
-	// DB state: inArtifact still published (not pending); unpublishedSince now
-	// authored (pending removal); newlyPublished published but absent from the
-	// artifact (pending add).
-	newlyPublished := uuid.New()
-	repo.mementos[inArtifact] = &domain.Memento{ID: inArtifact, JourneyID: journeyID, State: domain.MementoPublished}
-	repo.mementos[unpublishedSince] = &domain.Memento{ID: unpublishedSince, JourneyID: journeyID, State: domain.MementoAuthored}
-	repo.mementos[newlyPublished] = &domain.Memento{ID: newlyPublished, JourneyID: journeyID, State: domain.MementoPublished}
+	repo.mementos[inArtifact] = unchanged
+	repo.mementos[unpublishedSince] = withdrawn
+	repo.mementos[newlyPublished] = &domain.Memento{ID: newlyPublished, JourneyID: journeyID, Kind: "transit", Seq: 3, Title: "New", State: domain.MementoPublished}
 
 	handler := api.NewServer(repo, nil, api.NewCacheManager("", testLogger), testLogger, nil,
 		api.RouteConfig{SiteOutDir: outDir}).Handler()
@@ -65,35 +67,81 @@ func TestJourneyBuildStatus(t *testing.T) {
 	}
 }
 
-func TestJourneyBuildStatusNoArtifactIsZero(t *testing.T) {
+func TestJourneyBuildStatusWithNoArtifactReportsNeverBuilt(t *testing.T) {
 	journeyID := uuid.New()
+	published := uuid.New()
 	repo := newMockRepository()
 	repo.journeys[journeyID] = &domain.Journey{ID: journeyID}
-	repo.mementos[uuid.New()] = &domain.Memento{ID: uuid.New(), JourneyID: journeyID, State: domain.MementoPublished}
+	repo.mementos[published] = &domain.Memento{ID: published, JourneyID: journeyID, Kind: "transit", Seq: 1, State: domain.MementoPublished}
 
-	// No SiteOutDir artifact → nothing is pending (first build sets the baseline).
+	// No artifact at all. This previously reported zero pending, which told an
+	// author whose site had never been built that it was up to date.
 	handler := api.NewServer(repo, nil, api.NewCacheManager("", testLogger), testLogger, nil,
 		api.RouteConfig{SiteOutDir: t.TempDir()}).Handler()
 
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/admin/journeys/"+journeyID.String()+"/build-status", nil))
 	var res struct {
-		PendingCount int `json:"pending_count"`
+		PendingCount int    `json:"pending_count"`
+		BuildState   string `json:"build_state"`
 	}
 	_ = json.NewDecoder(w.Body).Decode(&res)
-	if res.PendingCount != 0 {
-		t.Fatalf("pending count without artifact = %d, want 0", res.PendingCount)
+	if res.BuildState != "never_built" {
+		t.Errorf("build state = %q, want never_built", res.BuildState)
+	}
+	if res.PendingCount != 1 {
+		t.Errorf("pending count = %d, want 1: everything publishable is pending when nothing is built", res.PendingCount)
 	}
 }
 
-func writeArtifactMementos(t *testing.T, outDir string, journeyID uuid.UUID, ids ...uuid.UUID) {
-	t.Helper()
-	type entry struct {
-		ID string `json:"id"`
+// TestJourneyBuildStatusSeesAnEssayOnlyEdit is the defect this tracking was
+// blind to: membership comparison could not tell that a published memento's
+// content had changed, so editing an essay left the site reported as current.
+func TestJourneyBuildStatusSeesAnEssayOnlyEdit(t *testing.T) {
+	outDir := t.TempDir()
+	journeyID := uuid.New()
+	mementoID := uuid.New()
+
+	asBuilt := &domain.Memento{ID: mementoID, JourneyID: journeyID, Kind: "transit", Seq: 1, Title: "Kyoto", State: domain.MementoPublished}
+	writeArtifactMementos(t, outDir, journeyID, asBuilt)
+	mustWrite(t, filepath.Join(outDir, "api", "v1", "manifest.json"), `{"files":[]}`)
+
+	edited := *asBuilt
+	essay := "Rewritten after the trip."
+	edited.Essay = &essay
+
+	repo := newMockRepository()
+	repo.journeys[journeyID] = &domain.Journey{ID: journeyID}
+	repo.mementos[mementoID] = &edited
+
+	handler := api.NewServer(repo, nil, api.NewCacheManager("", testLogger), testLogger, nil,
+		api.RouteConfig{SiteOutDir: outDir}).Handler()
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/admin/journeys/"+journeyID.String()+"/build-status", nil))
+	var res struct {
+		PendingMementoIDs []string `json:"pending_memento_ids"`
+		PendingCount      int      `json:"pending_count"`
+		BuildState        string   `json:"build_state"`
 	}
-	entries := make([]entry, 0, len(ids))
-	for _, id := range ids {
-		entries = append(entries, entry{ID: id.String()})
+	_ = json.NewDecoder(w.Body).Decode(&res)
+	if res.PendingCount != 1 || len(res.PendingMementoIDs) != 1 || res.PendingMementoIDs[0] != mementoID.String() {
+		t.Fatalf("an essay-only edit must mark the memento pending: count=%d ids=%v", res.PendingCount, res.PendingMementoIDs)
+	}
+	if res.BuildState != "changed" {
+		t.Errorf("build state = %q, want changed", res.BuildState)
+	}
+}
+
+// writeArtifactMementos writes what a real build would have written: the full
+// public projection per memento, not just its ID. Build status compares
+// projected content now, so a stub entry would read as "changed" and the
+// fixture would be testing the comparison against itself.
+func writeArtifactMementos(t *testing.T, outDir string, journeyID uuid.UUID, mementos ...*domain.Memento) {
+	t.Helper()
+	entries := make([]publication.StaticMemento, 0, len(mementos))
+	for _, memento := range mementos {
+		entries = append(entries, publication.NewStaticMemento(memento, nil))
 	}
 	raw, _ := json.Marshal(entries)
 	path := filepath.Join(outDir, "api", "v1", "journeys", journeyID.String(), "mementos.json")


### PR DESCRIPTION
Fixes #109.

`journeyPendingBuild` compared the *set of published memento IDs* in the database against the IDs in the artifact (`buildstatus.go:59-89`). Membership answers "did something appear or disappear", which is not what the author is asking. Three ways it lied:

| Situation | Reported | Actually |
| --- | --- | --- |
| Edited an already-published essay, caption, title or price | 0 pending | the deployed site still shows the old words |
| Never built at all | 0 pending | nothing exists |
| Status request failed | 0 pending | unknown |

## Comparison is now by content

The artifact's `mementos.json` already carries the entire public projection — title, place, essay, price, `kind_data`, photos. So current state is projected through the same `NewStaticMemento` the compiler uses and compared entry by entry. Both sides are re-marshalled first, so the answer is "is the content different" rather than "did the encoder space it differently".

No digest column and no dirty flag: the artifact remains the record of what was built, which keeps this stateless and self-correcting as before.

## Four states, none of them about deployment

The response carries `never_built`, `changed` or `built`, and the client adds `unknown` when it cannot read the status. The journey view names which one it is, and an unreadable status renders as an error rather than silence.

Deployment acknowledgement is deliberately **absent** rather than implied. A local output directory is evidence of a local build and nothing else, so nothing here claims to know what a remote host serves — the old comment called the artifact "the source of truth for what is deployed", which it never was.

## Two existing tests changed, and why that is not me bending them

- The artifact fixture wrote stub entries carrying only an ID. Under content comparison a stub reads as changed, so it now writes real projections — otherwise the fixture would be testing the comparison against itself.
- `TestJourneyBuildStatusNoArtifactIsZero` **asserted the defect in its name**. It is replaced by `TestJourneyBuildStatusWithNoArtifactReportsNeverBuilt`.

A new test covers the case membership was blind to, and fails on the old logic:

```
an essay-only edit must mark the memento pending: count=0 ids=[]
```

## Not covered

Journey-level fields and site settings live in other artifact files; changing a site title still will not mark a journey dirty. That is a smaller version of the same gap and worth a follow-up, but the per-journey content path is where the author's writing lives.

`make check` exits 0; `make admin-check` passes 229 files clean.