### PR TITLE
fix: stop re-import from overwriting the author's own work

### DIFF
--- a/apps/felicia-cli/cmd/felicia/main.go
+++ b/apps/felicia-cli/cmd/felicia/main.go
@@ -288,7 +288,10 @@ func importCommand(args []string, output io.Writer) error {
 	if err != nil {
 		return err
 	}
-	return writeJSON(output, map[string]any{"mode": "apply", "package_id": pkg.Manifest.PackageID, "journeys": report.Journeys, "candidates": report.Candidates, "mementos": report.Mementos, "photos": report.Photos})
+	// Conflicts are the author's to resolve, so they are named in the report
+	// rather than counted. An import that silently "succeeded" while declining
+	// to apply half a package is not a success the author can act on.
+	return writeJSON(output, map[string]any{"mode": "apply", "package_id": pkg.Manifest.PackageID, "journeys": report.Journeys, "candidates": report.Candidates, "mementos": report.Mementos, "photos": report.Photos, "authorship_conflicts": report.Conflicts})
 }
 
 // installPackageMedia writes every media member into the media root under its

--- a/apps/felicia-providers/sqlite/runtime_test.go
+++ b/apps/felicia-providers/sqlite/runtime_test.go
@@ -183,3 +183,93 @@ func mustRuntimeUUID(t *testing.T) uuid.UUID {
 	}
 	return id
 }
+
+// TestReimportDoesNotOverwriteAuthoredValues is the defect. A package can carry
+// authored values — an export, or a workspace edited by hand — and applying
+// them wholesale meant re-importing an older one replaced an essay the author
+// had written since. The journal's own authorship wins and the collision is
+// reported rather than resolved, because deciding which essay is better is not
+// an import's call to make.
+func TestReimportDoesNotOverwriteAuthoredValues(t *testing.T) {
+	repo, err := Open(":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer repo.Close()
+	ctx := context.Background()
+
+	journeyID := mustRuntimeUUID(t)
+	journalID := mustRuntimeUUID(t)
+	mementoID := mustRuntimeUUID(t)
+	document := authoredPackage(t, journeyID, journalID, mementoID, "The package's older essay.")
+
+	// First import: nothing is owned locally, so the package's essay lands.
+	first, err := importer.ApplyPackage(ctx, document, repo)
+	if err != nil {
+		t.Fatalf("first import: %v", err)
+	}
+	if len(first.Conflicts) != 0 {
+		t.Fatalf("first import should not conflict: %v", first.Conflicts)
+	}
+	stored, err := repo.GetMemento(ctx, mementoID)
+	if err != nil {
+		t.Fatalf("read after first import: %v", err)
+	}
+	if stored.Essay == nil || *stored.Essay != "The package's older essay." {
+		t.Fatalf("first import did not apply the only copy of the essay: %v", stored.Essay)
+	}
+
+	// The author rewrites it, and withdraws the memento from publication.
+	authored := *stored
+	authored.Essay = runtimeStringPtr("What I actually remember.")
+	authored.Title = "My title"
+	if err := repo.ApplyManualMementoPatch(ctx, &domain.ManualMementoPatch{
+		Memento: &authored, Fields: []string{"essay", "title"}, State: domain.MementoAuthored,
+	}); err != nil {
+		t.Fatalf("authoring write: %v", err)
+	}
+
+	// Re-importing the same, now stale, package must change none of that.
+	second, err := importer.ApplyPackage(ctx, document, repo)
+	if err != nil {
+		t.Fatalf("re-import: %v", err)
+	}
+	after, err := repo.GetMemento(ctx, mementoID)
+	if err != nil {
+		t.Fatalf("read after re-import: %v", err)
+	}
+	if after.Essay == nil || *after.Essay != "What I actually remember." {
+		t.Errorf("re-import overwrote the author's essay: %v", after.Essay)
+	}
+	if after.Title != "My title" {
+		t.Errorf("re-import overwrote the author's title: %q", after.Title)
+	}
+	if after.State != domain.MementoAuthored {
+		t.Errorf("re-import republished a withdrawn memento: state = %q", after.State)
+	}
+	if len(second.Conflicts) == 0 {
+		t.Error("the declined authored values must be reported, not silently dropped")
+	}
+}
+
+// authoredPackage is a one-memento package that carries authored values and a
+// published state, i.e. the shape an export or a hand-edited workspace has.
+func authoredPackage(t *testing.T, journeyID, journalID, mementoID uuid.UUID, essay string) *importer.PackageDocument {
+	t.Helper()
+	source := domain.SourceIdentity{System: "package:authored", ExternalID: mementoID.String()}
+	day := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	return &importer.PackageDocument{
+		Journey: &domain.Journey{ID: journeyID, JournalID: journalID, Slug: "authored", Title: "Authored", Place: "Kyoto", DateStart: day, DateEnd: day},
+		Mementos: []*domain.Memento{{
+			ID: mementoID, JourneyID: journeyID, Kind: "transit", Seq: 1,
+			OccurredAt: day.Add(9 * time.Hour), OccurredTZ: "Asia/Tokyo",
+			Geom:  orb.LineString{{135.7, 35.0}, {135.8, 35.1}},
+			Title: "Package title", Place: "Kyoto",
+			Essay:          runtimeStringPtr(essay),
+			AuthoredFields: []string{"title", "essay"},
+			KindData:       []byte(`{"operator":"JR","from":{"name":"Kyoto","coords":[135.7,35.0]},"to":{"name":"Tokyo","coords":[135.8,35.1]}}`),
+			SourceIdentity: &source,
+			State:          domain.MementoPublished,
+		}},
+	}
+}

--- a/apps/felicia-runtime/importer/package.go
+++ b/apps/felicia-runtime/importer/package.go
@@ -6,9 +6,11 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"math"
 	"path"
+	"slices"
 	"strings"
 	"time"
 
@@ -42,6 +44,11 @@ type ImportReport struct {
 	Candidates int
 	Mementos   int
 	Photos     int
+	// Conflicts names authored values the package carried that the journal
+	// already owns, in "<memento id>.<field>" form. They are reported and left
+	// alone: an import is not entitled to decide that a package's copy of an
+	// essay is better than the one the author has since written.
+	Conflicts []string
 }
 
 // ApplyPackage writes a normalized package into the canonical store. Source
@@ -94,6 +101,7 @@ func ApplyPackage(ctx context.Context, document *PackageDocument, store PackageS
 }
 
 func applyPackage(ctx context.Context, document *PackageDocument, store PackageStore) (ImportReport, error) {
+	var conflicts []string
 	if err := store.EnsureJournal(ctx, &domain.Journal{ID: document.Journey.JournalID}); err != nil {
 		return ImportReport{}, fmt.Errorf("ensure journal: %w", err)
 	}
@@ -114,9 +122,49 @@ func applyPackage(ctx context.Context, document *PackageDocument, store PackageS
 		if err := store.ApplyIngestMementoPatch(ctx, &domain.IngestMementoPatch{Memento: memento, Fields: fields}); err != nil {
 			return ImportReport{}, fmt.Errorf("import memento %s: %w", memento.ID, err)
 		}
+		// A package can carry authored values -- an export, or a workspace the
+		// author edited by hand. Applying them wholesale is what let an old
+		// package overwrite a newer essay, so the journal's own authorship
+		// wins and the collision is reported instead of resolved.
 		if len(memento.AuthoredFields) > 0 || (memento.State != "" && memento.State != domain.MementoCandidateState) {
-			if err := store.ApplyManualMementoPatch(ctx, &domain.ManualMementoPatch{Memento: memento, Fields: memento.AuthoredFields, State: memento.State}); err != nil {
-				return ImportReport{}, fmt.Errorf("apply authored memento %s: %w", memento.ID, err)
+			existing, err := store.GetMemento(ctx, memento.ID)
+			switch {
+			case errors.Is(err, domain.ErrNotFound):
+				existing = nil
+			case err != nil:
+				return ImportReport{}, fmt.Errorf("load memento %s: %w", memento.ID, err)
+			}
+			fields := memento.AuthoredFields
+			state := memento.State
+			if existing != nil {
+				fields = nil
+				for _, field := range memento.AuthoredFields {
+					if slices.Contains(existing.AuthoredFields, field) {
+						conflicts = append(conflicts, memento.ID.String()+"."+field)
+						continue
+					}
+					fields = append(fields, field)
+				}
+				// Lifecycle is a local decision, so an import does not advance
+				// it: re-importing a package that still says "published" must
+				// not republish what the author has since withdrawn. A move the
+				// lifecycle forbids outright is still passed through, because
+				// the store raising InvalidTransitionError is how a package
+				// trying to unpublish content fails loudly instead of quietly
+				// (docs/contracts/memento-lifecycle.md §6, §7) -- declining that
+				// case here would turn a reported error into silence.
+				switch {
+				case state == "" || state == existing.State:
+					state = ""
+				case domain.CanTransitionMementoState(existing.State, state):
+					conflicts = append(conflicts, memento.ID.String()+".state")
+					state = ""
+				}
+			}
+			if len(fields) > 0 || state != "" {
+				if err := store.ApplyManualMementoPatch(ctx, &domain.ManualMementoPatch{Memento: memento, Fields: fields, State: state}); err != nil {
+					return ImportReport{}, fmt.Errorf("apply authored memento %s: %w", memento.ID, err)
+				}
 			}
 		}
 	}
@@ -136,7 +184,7 @@ func applyPackage(ctx context.Context, document *PackageDocument, store PackageS
 			}
 		}
 	}
-	return ImportReport{Journeys: 1, Candidates: len(document.Stops), Mementos: len(document.Mementos), Photos: len(document.Photos)}, nil
+	return ImportReport{Journeys: 1, Candidates: len(document.Stops), Mementos: len(document.Mementos), Photos: len(document.Photos), Conflicts: conflicts}, nil
 }
 
 type journeyFile struct {

--- a/apps/felicia-runtime/importer/reimport_test.go
+++ b/apps/felicia-runtime/importer/reimport_test.go
@@ -29,6 +29,18 @@ func newLifecycleStore() *lifecycleStore {
 	return &lifecycleStore{states: map[uuid.UUID]domain.MementoState{}}
 }
 
+// GetMemento answers whether the journal already holds this memento, which is
+// how the importer decides between applying a package's authored values and
+// declining to overwrite the author's. A miss must be ErrNotFound rather than a
+// nil memento, or the caller cannot tell "absent" from "empty".
+func (s *lifecycleStore) GetMemento(_ context.Context, id uuid.UUID) (*domain.Memento, error) {
+	state, ok := s.states[id]
+	if !ok {
+		return nil, domain.ErrNotFound
+	}
+	return &domain.Memento{ID: id, State: state}, nil
+}
+
 func (s *lifecycleStore) EnsureJournal(context.Context, *domain.Journal) error    { return nil }
 func (s *lifecycleStore) UpsertPhoto(context.Context, *domain.MementoPhoto) error { return nil }
 func (s *lifecycleStore) WithTransaction(_ context.Context, fn func(domain.Repository) error) error {


### PR DESCRIPTION
Fixes #106.

`ApplyPackage` states in its own comment that "authored fields are never supplied by this operation" (`package.go:44-46`), then handed the package's `AuthoredFields` and `State` straight to `ApplyManualMementoPatch` with no expected revision (`:105-107`). Re-importing an older export replaced an essay the author had written since.

## Authorship

A package's authored value is applied only for a field the stored memento does not already claim. Collisions are reported as `<memento id>.<field>` in `ImportReport.Conflicts` and named in the CLI output — deciding that a package's copy of an essay is better than the author's is not an import's call, and quietly declining half a package would be a success the author could not act on.

First import is unchanged: with nothing owned locally, a package carrying an essay holds the only copy of it.

## Lifecycle, and a correction I had to make mid-change

My first version suppressed the package's `State` for any existing memento. That broke `TestReimportSameStateSucceedsAndDowngradeFails`, which deliberately asserts that a package trying to move `published → draft` **fails loudly** rather than silently unpublishing, citing memento-lifecycle §6 and §7.

It was right and I was wrong: suppressing state replaced that error with silence, which is exactly what the test exists to prevent. The narrowed rule:

| Package state vs stored | Behaviour |
| --- | --- |
| same, or empty | nothing to do |
| a legal forward move (e.g. `authored → published`) | **declined and reported** — an import must not republish what the author withdrew |
| a move the lifecycle forbids | **passed through**, so the store raises `InvalidTransitionError` and the attempt is loud |

## Two things found on the way

`lifecycleStore` embeds a nil `domain.Repository`, so every method the fake does not implement is a runtime panic rather than a compile error. My new `GetMemento` call crashed it. It now implements `GetMemento` and reports a miss as `ErrNotFound`, since a nil memento cannot be distinguished from an empty one.

I also committed once against a red gate — `make check` exited 2 on gofmt import ordering and that panic — and amended after fixing both. The commit that stood was never the broken one, but I should have read the exit code before committing.

## Tests

The end-to-end case lives with the sqlite provider, where `ApplyPackage` is already exercised against a real store rather than a fake with more surface than the behaviour under test. It imports, has the author rewrite the essay and title and withdraw the memento, then re-imports the same stale package. Against the old code all four assertions fail:

```
re-import overwrote the author's essay
re-import overwrote the author's title: "Package title"
re-import republished a withdrawn memento: state = "published"
the declined authored values must be reported, not silently dropped
```

## Not included

An explicit restore/replace command. Overwriting authored state on purpose is a real workflow, but it needs a preview and a backup to be safe, and it is not needed to stop the accidental case.

`make check` exits 0.