### PR TITLE
feat: record when supplied visits overrode the route

### DIFF
--- a/apps/felicia-runtime/intake/planner.go
+++ b/apps/felicia-runtime/intake/planner.go
@@ -123,6 +123,21 @@ func BuildPlan(input PlanInput, config PlanConfig) (DraftPlan, error) {
 		var derivedIssues []Issue
 		visits, derivedIssues = deriveVisits(input.Routes, config)
 		plan.Issues = append(plan.Issues, derivedIssues...)
+	} else if derivable, _ := deriveVisits(input.Routes, config); len(derivable) > 0 {
+		// Two sources both describe where this trip stopped, and the precedence
+		// rule silently picks one. ADR-0030 requires the conflict to be
+		// recorded as well as decided: without this the author cannot tell that
+		// the route disagreed, so a supplied source missing a stay they
+		// remember looks like the trip simply had none. Recording it is not a
+		// merge and changes no outcome -- the supplied visits still win.
+		plan.Issues = append(plan.Issues, Issue{
+			Severity: IssueInfo,
+			Code:     "visit_source_conflict",
+			Message: fmt.Sprintf(
+				"%d supplied visits took precedence over %d the route would have derived; route-derived stays were not considered",
+				len(visits), len(derivable),
+			),
+		})
 	}
 	plan.Visits = visits
 	for index, visit := range visits {

--- a/apps/felicia-runtime/intake/planner_test.go
+++ b/apps/felicia-runtime/intake/planner_test.go
@@ -168,3 +168,72 @@ func hasIssue(issues []Issue, code string) bool {
 	}
 	return false
 }
+
+// TestBuildPlanRecordsWhenSuppliedVisitsOverrodeTheRoute is the clause ADR-0030
+// required and the planner did not meet: when a connected source and the route
+// both describe where the trip stopped, precedence decides the outcome and the
+// conflict is recorded rather than left invisible. Without the record, a
+// supplied source that missed a stay the author remembers looks like the trip
+// simply had none.
+func TestBuildPlanRecordsWhenSuppliedVisitsOverrodeTheRoute(t *testing.T) {
+	// A route that would derive a stay of its own: two hours inside the radius.
+	dwellStart := time.Date(2026, 4, 2, 9, 0, 0, 0, time.UTC)
+	dwell := []domain.Route{{Points: []domain.TrackPoint{
+		{Coord: orb.Point{139.7000, 35.6000}, At: dwellStart},
+		{Coord: orb.Point{139.7001, 35.6001}, At: dwellStart.Add(30 * time.Minute)},
+		{Coord: orb.Point{139.7000, 35.6001}, At: dwellStart.Add(90 * time.Minute)},
+	}}}
+	supplied := domain.Visit{
+		Coord: orb.Point{135.5, 34.7}, Label: "Kobe",
+		Arrive:     time.Date(2026, 4, 2, 1, 0, 0, 0, time.UTC),
+		Depart:     time.Date(2026, 4, 2, 3, 0, 0, 0, time.UTC),
+		Confidence: 0.9, SourceRef: "dawarich:visit-1",
+	}
+
+	plan, err := BuildPlan(PlanInput{JourneyID: uuid.New(), Routes: dwell, Visits: []domain.Visit{supplied}}, DefaultConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Precedence is unchanged: the supplied visit still wins.
+	if len(plan.Stops) != 1 || plan.Stops[0].Label != "Kobe" {
+		t.Fatalf("supplied visits must still take precedence, got %#v", plan.Stops)
+	}
+	var recorded *Issue
+	for index, issue := range plan.Issues {
+		if issue.Code == "visit_source_conflict" {
+			recorded = &plan.Issues[index]
+		}
+	}
+	if recorded == nil {
+		t.Fatalf("the disagreement between sources was not recorded: %#v", plan.Issues)
+	}
+	if recorded.Severity != IssueInfo {
+		t.Errorf("severity = %q, want info: precedence resolved it, so nothing needs review", recorded.Severity)
+	}
+}
+
+// TestBuildPlanRecordsNoConflictWhenTheRouteAgreesOnNothing keeps the record
+// meaningful: a route with no derivable stay is not a disagreement, and
+// reporting one would train the author to ignore the list.
+func TestBuildPlanRecordsNoConflictWhenTheRouteAgreesOnNothing(t *testing.T) {
+	passing := []domain.Route{{Points: []domain.TrackPoint{
+		{Coord: orb.Point{139.7, 35.6}, At: time.Date(2026, 4, 2, 9, 0, 0, 0, time.UTC)},
+		{Coord: orb.Point{140.9, 36.9}, At: time.Date(2026, 4, 2, 9, 5, 0, 0, time.UTC)},
+	}}}
+	supplied := domain.Visit{
+		Coord: orb.Point{135.5, 34.7}, Label: "Kobe",
+		Arrive:     time.Date(2026, 4, 2, 1, 0, 0, 0, time.UTC),
+		Depart:     time.Date(2026, 4, 2, 3, 0, 0, 0, time.UTC),
+		Confidence: 0.9, SourceRef: "dawarich:visit-1",
+	}
+	plan, err := BuildPlan(PlanInput{JourneyID: uuid.New(), Routes: passing, Visits: []domain.Visit{supplied}}, DefaultConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, issue := range plan.Issues {
+		if issue.Code == "visit_source_conflict" {
+			t.Errorf("a route with no derivable stay is not a conflict: %q", issue.Message)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #111 — the clause left outstanding when ADR-0030 was accepted in #114.

[ADR-0030](docs/adr/0030-intake-planning-contract.md) requires that when connected and local sources both describe a trip, the runtime "record the conflict and apply an explicit source precedence policy; it must not silently merge contradictory semantics".

Only the precedence half existed. `planner.go:121-125`: supplied visits win, route-derived stays are used purely as a fallback, and nothing says the route disagreed. So a connected source that missed a stay the author remembers looks identical to a trip that simply had none.

## What changed

The planner emits a `visit_source_conflict` issue when supplied visits displaced stays the route would have derived. `DraftPlan.Issues` already existed as the carrier, so nothing new holds it.

**Severity is `info`, not `warning`.** Precedence already resolved the disagreement, so there is nothing for the author to decide — this is context for reading a plan that came back thinner than expected, not a review item. Filing it as a warning would misreport a working policy as a problem.

**Nothing about the outcome changes.** Supplied visits still win. This is explicitly not the merge ADR-0030 forbids.

**Recording is conditional on the route actually deriving something.** A route that never dwells is not a disagreement, and reporting one would train the author to ignore the list. The second test pins that.

## Tests

Both use `deriveVisits`'s real thresholds rather than asserting against a mock: a two-hour dwell inside the stop radius for the conflict case, a five-minute transit for the non-conflict case. Verified to fail without the change:

```
the disagreement between sources was not recorded: []intake.Issue{}
```

`make check` exits 0.