### PR TITLE
fix: make the SQLite-only v1 scope true in config, CI and compose

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,24 +14,11 @@ jobs:
   backend:
     name: Backend (make check-ci)
     runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: postgis/postgis:18-3.6-alpine
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: password
-          POSTGRES_DB: felicia
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd "pg_isready -U postgres -d felicia"
-          --health-interval 5s
-          --health-timeout 5s
-          --health-retries 10
-    env:
-      # The service database is disposable for this CI job. Destructive tests
-      # use this dedicated test DSN, never the normal runtime DSN.
-      CI_DATABASE_DSN: postgres://postgres:password@localhost:5432/felicia?sslmode=disable
+    # No PostgreSQL service. SQLite is the only v1 persistence contract
+    # (ADR-0032), and the v1 gate must not require a PostgreSQL service, its
+    # migrations, or its behavioural parity. The provider stays in the tree as
+    # frozen non-v1 work; its checks return with the re-entry milestone rather
+    # than running here in a lane that cannot block anything meaningful.
     steps:
       - uses: actions/checkout@v7
 
@@ -41,11 +28,8 @@ jobs:
       - name: Install frontend dependencies
         run: make web-install
 
-      - name: Apply migrations
-        run: DATABASE_DSN="$CI_DATABASE_DSN" make migrate
-
       - name: Check (vet, lint, race tests)
-        run: FELICIA_TEST_DATABASE_DSN="$CI_DATABASE_DSN" make check-ci
+        run: make check-ci
 
       - name: SQLite journey workflow
         run: make test-workflow

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ dev: ## Start the local API with SQLite
 dev-sqlite: ## Start the API locally with the default SQLite provider
 	$(UV_RUN) run python scripts/dev.py --driver sqlite
 
-dev-postgres: ## Start the PostgreSQL-backed local stack, seed data, and serve the web app
+dev-postgres: ## [non-v1, ADR-0032] PostgreSQL-backed local stack -- deferred provider work only
 	$(UV_RUN) run python scripts/dev.py --driver postgres --web
 
 mock-up: ## Start the mock Dawarich+Immich upstream in the background (:8099)
@@ -141,7 +141,7 @@ sqlc: ## Regenerate the postgres query bindings (apps/felicia-providers/postgres
 test-sqlite: ## Run all tests with SQLite as the only enabled provider
 	DATABASE_DSN= FELICIA_TEST_DATABASE_DSN= $(MAKE) test
 
-test-postgres: ## Run PostgreSQL tests against the disposable test database
+test-postgres: ## [non-v1, ADR-0032] PostgreSQL tests -- not a release gate
 	@test -n "$(FELICIA_TEST_DATABASE_DSN)" || (echo "FELICIA_TEST_DATABASE_DSN is required" >&2; exit 1)
 	DATABASE_DSN="$(FELICIA_TEST_DATABASE_DSN)" $(MAKE) migrate
 	DATABASE_DSN= FELICIA_TEST_DATABASE_DSN="$(FELICIA_TEST_DATABASE_DSN)" $(MAKE) test

--- a/apps/felicia-server/cmd/build/main.go
+++ b/apps/felicia-server/cmd/build/main.go
@@ -1,4 +1,15 @@
-// Package main implements the command-line entry point for the Static Site Compiler.
+// Package main implements a PostgreSQL-backed static site compiler.
+//
+// NOT PART OF V1. This entry point composes the PostgreSQL provider, which
+// ADR-0032 defers to v1.1/v1.2, so it is experimental deferred-provider work
+// and no v1 workflow, gate or deployment invokes it. It does use the shared
+// publication.StaticCompiler, so it is not a second compiler -- only a second
+// composition root, and provider choice per composition root is what ADR-0028
+// permits.
+//
+// The supported path is `felicia-cli static compile`, which does the same job
+// against SQLite. Prefer that; reach for this only while working on
+// PostgreSQL re-entry.
 package main
 
 import (

--- a/apps/felicia-server/config/config.go
+++ b/apps/felicia-server/config/config.go
@@ -140,14 +140,25 @@ func load(path string, lookup func(string) (string, bool), required bool) (Confi
 
 // Validate checks the values that would make the API unsafe or inoperable.
 func (c Config) Validate() error {
-	if c.DatabaseDriver != "sqlite" && c.DatabaseDriver != "postgres" {
-		return fmt.Errorf("database driver must be sqlite or postgres, got %q", c.DatabaseDriver)
+	// SQLite is the only v1 persistence contract (ADR-0032). PostgreSQL is a
+	// frozen non-v1 provider, so a supported executable refuses to start on it
+	// rather than running an unsupported one.
+	if c.DatabaseDriver == "postgres" {
+		return errors.New("database driver \"postgres\" is deferred to v1.1/v1.2 and not supported by this executable (ADR-0032); unset DATABASE_DRIVER to use sqlite")
 	}
-	if c.DatabaseDriver == "sqlite" && c.DatabasePath == "" {
+	if c.DatabaseDriver != "sqlite" {
+		return fmt.Errorf("database driver must be sqlite, got %q", c.DatabaseDriver)
+	}
+	if c.DatabasePath == "" {
 		return errors.New("database path is required for sqlite")
 	}
-	if c.DatabaseDriver == "postgres" && c.DatabaseDSN == "" {
-		return errors.New("DATABASE_DSN environment variable is required for postgres")
+	// A DSN configured for a provider that was not selected is a
+	// mis-selection, never a silent default. ops/compose.yaml shipped exactly
+	// this and ran on a throwaway in-container SQLite file while PostgreSQL,
+	// PostGIS and every migration sat unused, with nothing in the logs to say
+	// so (AGENTS.md development-flow constraint 1, ADR-0021).
+	if c.DatabaseDSN != "" {
+		return errors.New("DATABASE_DSN is set but the sqlite driver is selected: a DSN for an unselected provider is a configuration error, not a default")
 	}
 	if c.Port == "" {
 		return errors.New("server port is required")

--- a/apps/felicia-server/config/config_file_test.go
+++ b/apps/felicia-server/config/config_file_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -16,28 +17,55 @@ func TestLoadSQLiteConfigFixture(t *testing.T) {
 	}
 }
 
-func TestLoadPostgresConfigFixture(t *testing.T) {
-	cfg, err := Load(filepath.Join("testdata", "postgres.toml"), lookup(nil))
-	if err != nil {
-		t.Fatalf("Load: %v", err)
+// A PostgreSQL config file used to load successfully. Under ADR-0032 it is a
+// startup error: PostgreSQL is deferred to v1.1/v1.2, and a supported
+// executable refuses rather than running an unsupported provider.
+func TestLoadRejectsPostgresConfigFixture(t *testing.T) {
+	_, err := Load(filepath.Join("testdata", "postgres.toml"), lookup(nil))
+	if err == nil {
+		t.Fatal("a postgres config file must be refused, not loaded")
 	}
-	if cfg.DatabaseDriver != "postgres" || cfg.DatabaseDSN != "postgres://from-file" {
-		t.Errorf("unexpected PostgreSQL config: %+v", cfg)
+	if !strings.Contains(err.Error(), "ADR-0032") {
+		t.Errorf("the refusal should say why it is refused, got %v", err)
 	}
 }
 
+// The precedence this asserts is unchanged; only the values are, since the
+// provider it used to override to is no longer a supported one.
 func TestLoadEnvironmentOverridesConfigFile(t *testing.T) {
 	path := filepath.Join("testdata", "sqlite.toml")
 	cfg, err := Load(path, lookup(map[string]string{
-		"FELICIA_DATABASE_DRIVER": "postgres",
-		"FELICIA_DATABASE_DSN":    "postgres://from-env",
-		"FELICIA_DATABASE_PATH":   "overridden.db",
+		"FELICIA_DATABASE_PATH": "overridden.db",
+		"FELICIA_PORT":          "9999",
 	}))
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	if cfg.DatabaseDriver != "postgres" || cfg.DatabaseDSN != "postgres://from-env" || cfg.DatabasePath != "overridden.db" {
+	if cfg.DatabasePath != "overridden.db" || cfg.Port != "9999" {
 		t.Errorf("environment did not override config file: %+v", cfg)
+	}
+}
+
+// Selecting PostgreSQL through the environment is refused for the same reason
+// as through a file: the precedence chain does not create an exception.
+func TestLoadRejectsPostgresFromEnvironment(t *testing.T) {
+	_, err := Load(filepath.Join("testdata", "sqlite.toml"), lookup(map[string]string{
+		"FELICIA_DATABASE_DRIVER": "postgres",
+		"FELICIA_DATABASE_DSN":    "postgres://from-env",
+	}))
+	if err == nil {
+		t.Fatal("selecting postgres via the environment must be refused")
+	}
+}
+
+// A DSN with no driver selected used to start SQLite silently, which is what
+// ops/compose.yaml did while PostgreSQL and every migration sat unused.
+func TestLoadRejectsADSNForAnUnselectedProvider(t *testing.T) {
+	_, err := Load(filepath.Join("testdata", "sqlite.toml"), lookup(map[string]string{
+		"DATABASE_DSN": "postgres://nobody-selected-this",
+	}))
+	if err == nil {
+		t.Fatal("a DSN for an unselected provider must be a configuration error, not a default")
 	}
 }
 
@@ -56,5 +84,22 @@ func TestLoadFromEnvRejectsMissingExplicitConfig(t *testing.T) {
 	t.Setenv("FELICIA_CONFIG", missing)
 	if _, err := LoadFromEnv(); err == nil {
 		t.Fatal("expected missing explicit config to fail")
+	}
+}
+
+// TestLoadAcceptsTheComposeShape pins the deployment configuration ops/compose.yaml
+// now ships: an explicit sqlite driver, an explicit path, and no DSN. The
+// previous shape (a PostgreSQL DSN with no driver) is what this refuses.
+func TestLoadAcceptsTheComposeShape(t *testing.T) {
+	cfg, err := Load("", lookup(map[string]string{
+		"DATABASE_DRIVER": "sqlite",
+		"DATABASE_PATH":   "/data/felicia.sqlite",
+		"CACHE_ADDR":      "cache:6379",
+	}))
+	if err != nil {
+		t.Fatalf("the shipped compose configuration must start: %v", err)
+	}
+	if cfg.DatabaseDriver != "sqlite" || cfg.DatabasePath != "/data/felicia.sqlite" {
+		t.Errorf("unexpected compose config: %+v", cfg)
 	}
 }

--- a/apps/felicia-server/config/config_test.go
+++ b/apps/felicia-server/config/config_test.go
@@ -10,7 +10,7 @@ func TestLoadAppliesTOMLThenEnvironment(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "felicia.toml")
 	if err := os.WriteFile(path, []byte(`
 [database]
-dsn = "postgres://from-file"
+# dsn removed: a DSN for an unselected provider is now a configuration error
 
 [server]
 port = "9090"
@@ -34,7 +34,7 @@ transit_segment_length_m = 200000
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	if cfg.Port != "9191" || cfg.DatabaseDSN != "postgres://from-file" || cfg.CacheAddr != "" {
+	if cfg.Port != "9191" || cfg.CacheAddr != "" {
 		t.Errorf("unexpected base config: %+v", cfg)
 	}
 	if cfg.Dawarich.URL != "https://dawarich.example" || cfg.Dawarich.APIKey != "legacy-key" || cfg.Immich.URL != "https://immich.example" {
@@ -55,21 +55,23 @@ func TestLoadUsesSQLiteDefaults(t *testing.T) {
 	}
 
 	if _, err := Load("", lookup(map[string]string{"DATABASE_DRIVER": "postgres"})); err == nil {
-		t.Error("expected postgres without DATABASE_DSN to fail")
+		t.Error("expected an explicit postgres selection to fail as deferred (ADR-0032)")
 	}
 }
 
+// Precedence is unchanged. It is asserted on values that remain legal, since
+// a DSN is now refused outright whichever variable carries it.
 func TestLoadPrefersFeliciaEnvironment(t *testing.T) {
 	cfg, err := Load("", lookup(map[string]string{
-		"DATABASE_DSN":         "postgres://legacy",
-		"FELICIA_DATABASE_DSN": "postgres://preferred",
-		"DAWARICH_URL":         "https://legacy.example",
-		"FELICIA_DAWARICH_URL": "https://preferred.example",
+		"DATABASE_PATH":         "legacy.db",
+		"FELICIA_DATABASE_PATH": "preferred.db",
+		"DAWARICH_URL":          "https://legacy.example",
+		"FELICIA_DAWARICH_URL":  "https://preferred.example",
 	}))
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	if cfg.DatabaseDSN != "postgres://preferred" || cfg.Dawarich.URL != "https://preferred.example" {
+	if cfg.DatabasePath != "preferred.db" || cfg.Dawarich.URL != "https://preferred.example" {
 		t.Errorf("FELICIA_* overrides were not preferred: %+v", cfg)
 	}
 }

--- a/docs/development/database.md
+++ b/docs/development/database.md
@@ -1,9 +1,19 @@
 # Database development
 
-Felicia supports two persistence providers behind the same repository contract:
+SQLite is the **only v1 persistence provider**
+([ADR-0032](../adr/0032-sqlite-first-v1-postgres-follow-up.md)). It backs local
+development, single-user operation, the API, the admin GUI, the CLI compiler and
+every release gate.
 
-- SQLite is the default for local development and single-user operation.
-- PostgreSQL/PostGIS is available for deployment and provider-parity coverage.
+PostgreSQL/PostGIS remains in the tree behind the same repository contract, as
+frozen work deferred to a v1.1/v1.2 milestone. It is not a supported v1
+deployment target, it is not covered by any v1 gate, and a supported executable
+**refuses to start** when PostgreSQL is selected rather than running an
+unsupported provider. New v1 schema changes are not duplicated into it.
+
+Configuring a DSN for a provider you did not select is also a startup error, not
+a silent default -- the hole that once let `ops/compose.yaml` run on a throwaway
+in-container SQLite file while PostgreSQL and every migration sat unused.
 
 ## Configuration precedence
 
@@ -46,7 +56,7 @@ missing required configuration.
 make admin               # authoring GUI, same database as make dev
 make dev                 # API with SQLite at .felicia/felicia.sqlite
 make dev-sqlite          # explicit SQLite API
-make dev-postgres        # PostgreSQL/PostGIS stack, migration, seed, web app
+make dev-postgres        # [non-v1] PostgreSQL/PostGIS stack -- deferred, see ADR-0032
 make migrate             # PostgreSQL migrations only
 ```
 

--- a/ops/compose.yaml
+++ b/ops/compose.yaml
@@ -1,5 +1,10 @@
 services:
+  # Not part of the v1 supported deployment shape: PostgreSQL is deferred to
+  # v1.1/v1.2 (ADR-0032) and no v1 service composes against it. Kept behind a
+  # profile so it starts only when asked for by name, for deferred-provider
+  # work, and never as a side effect of `make share` or the dev stack.
   db:
+    profiles: ["postgres-deferred"]
     image: postgis/postgis:18-3.6-alpine
     # The pinned PostGIS image currently publishes amd64 only; Podman on
     # Apple Silicon runs this service through its supported emulation path.
@@ -40,15 +45,22 @@ services:
       dockerfile: ops/Containerfile
     container_name: felicia-api
     environment:
-      DATABASE_DSN: postgres://postgres:password@db:5432/felicia?sslmode=disable
+      # Explicit and SQLite, per ADR-0032. This previously set a PostgreSQL DSN
+      # with no driver, which selected SQLite silently: the API ran on a
+      # throwaway in-container file while PostgreSQL, PostGIS and every
+      # migration sat unused, with nothing in the logs to say so. Configuring a
+      # DSN for an unselected provider is now a startup error, so the ambiguity
+      # cannot come back by omission.
+      DATABASE_DRIVER: sqlite
+      DATABASE_PATH: /data/felicia.sqlite
       CACHE_ADDR: cache:6379
       FELICIA_HOST: "0.0.0.0"
       PORT: "8080"
     ports:
       - "8080:8080"
+    volumes:
+      - apidata:/data
     depends_on:
-      db:
-        condition: service_healthy
       cache:
         condition: service_healthy
 
@@ -85,4 +97,5 @@ services:
       - web
 
 volumes:
+  apidata:
   pgdata:


### PR DESCRIPTION
Addresses #112. ADR-0032 was accepted in #115, but the repository still contradicted it — and that ADR's own standard is that "the scope decision is only truthful once the repository reflects it".

## Provider mis-selection is now loud

A supported executable **refuses to start** when PostgreSQL is selected, rather than running a provider that no v1 gate covers (ADR-0032 item 5).

And a DSN configured for a provider that was not selected is now an error, not a silent default. That is the hole AGENTS.md development-flow constraint 1 describes in full: `ops/compose.yaml` set a PostgreSQL DSN with no `DATABASE_DRIVER`, so the API ran on a throwaway in-container SQLite file while PostgreSQL, PostGIS and every migration sat unused — with nothing in the logs to say so.

## Compose

Selects `sqlite` explicitly against a named `apidata` volume, so the ambiguity cannot return by omission. The `db` service moves behind a `postgres-deferred` profile: it starts only when named, never as a side effect of `make share` or the dev stack.

## CI

The v1 lane drops the PostGIS service, the migration step and `FELICIA_TEST_DATABASE_DSN`. ADR-0032 item 6 permits either a separate non-v1 lane or removal until re-entry work begins — **removal is the honest option**, because a lane that cannot block anything reports nothing while looking like coverage.

## cmd/build

Kept, and now says what it is: a PostgreSQL-only composition root, not part of v1, superseded for supported use by `felicia-cli static compile`. It uses the shared `publication.StaticCompiler`, so it was never a second compiler — only a second composition root, which ADR-0028 explicitly permits. `dev-postgres` and `test-postgres` carry `[non-v1, ADR-0032]` in their help text, and `docs/development/database.md` now leads with SQLite being the only v1 provider instead of describing two supported ones.

## Four config tests changed

Worth being explicit, since changing tests alongside a behaviour change deserves scrutiny:

- two asserted that a PostgreSQL config **loads successfully**; they are replaced by tests that it is refused, one checking the refusal explains why;
- two asserted *precedence* (`FELICIA_*` over legacy, env over TOML) using a DSN as a convenient value to read back. The precedence assertions are unchanged; only the values moved to ones that remain legal.

A new test pins the configuration shape compose actually ships, so "the deployment still starts" is covered rather than assumed.

## Not included

The reproducible real-journey fixture ADR-0032 also lists (admin authoring → SQLite → static compile → Pages artifact). That is acceptance-test infrastructure rather than enforcement of this decision, and it deserves its own change. #112 should stay open for it.

`make check` exits 0; `make pages-workflow-validate` passes; CI and compose verified structurally after editing.