### PR TITLE
fix: un-break the public page — basemap watermarks and a stuck photo lightbox

### DIFF
--- a/packages/felicia-components/src/PhotoLightbox.svelte
+++ b/packages/felicia-components/src/PhotoLightbox.svelte
@@ -1,13 +1,27 @@
 <script lang="ts">
-  export let src: string
-  export let alt: string
-  export let caption = ""
-  export let openLabel = "Open photo"
-  export let closeLabel = "Close"
-  export let imageClass = ""
+  // Runes, not `export let`. Svelte 5 picks a component's mode from its own
+  // syntax: one `export let` puts the whole file in legacy mode, where
+  // `onclick={...}` and `onclose={...}` below are inert DOM attributes rather
+  // than event handlers. This component had exactly that mix -- the only one
+  // in the repo -- so nothing could open it and nothing could close it.
+  let {
+    src,
+    alt,
+    caption = "",
+    openLabel = "Open photo",
+    closeLabel = "Close",
+    imageClass = "",
+  }: {
+    src: string
+    alt: string
+    caption?: string
+    openLabel?: string
+    closeLabel?: string
+    imageClass?: string
+  } = $props()
 
-  let triggerButton: HTMLButtonElement
-  let dialogEl: HTMLDialogElement
+  let triggerButton: HTMLButtonElement | undefined
+  let dialogEl: HTMLDialogElement | undefined
 
   function show() {
     dialogEl?.showModal()
@@ -56,11 +70,18 @@
     cursor: zoom-in;
   }
 
+  /* Only the open state gets a display, because the browser hides a closed
+     <dialog> with `display: none` and any unconditional `display` here
+     overrides it -- which is what painted this lightbox over every theme
+     before anyone clicked a photo. */
+  .photo-lightbox[open] {
+    display: grid;
+  }
+
   .photo-lightbox {
     position: fixed;
     z-index: 100;
     inset: 0;
-    display: grid;
     overflow: auto;
     width: 100%;
     max-width: 100%;
@@ -87,6 +108,15 @@
 
   .lightbox-image {
     display: block;
+    /* The reader's global `.gallery img` rule (felicia-reader/src/public.css)
+       crops every thumbnail to a 4:3 tile. This dialog is markup *inside* that
+       gallery figure, so the rule reached the full-size photo too: the box was
+       forced to 4:3 and `object-fit: contain` then letterboxed a 16:9 photo
+       inside it, with dead bands above and below. The modal shows a photo
+       whole and at its own shape, so it restates both properties rather than
+       relying on every theme to scope its gallery selector. */
+    aspect-ratio: auto;
+    outline: none;
     max-width: 92vw;
     max-height: 84vh;
     width: auto;

--- a/packages/felicia-reader/src/theme-ui/atlas/AtlasMap.svelte
+++ b/packages/felicia-reader/src/theme-ui/atlas/AtlasMap.svelte
@@ -32,17 +32,30 @@
   const mapStyle: StyleSpecification = {
     version: 8,
     sources: {
+      // CARTO's free basemaps began requiring an API key and now answer 200
+      // with "API KEY REQUIRED" stamped into the PNG itself, so the map broke
+      // without a single failed request, console error or red test. Esri's
+      // Canvas basemaps are keyless. Note the template order: Esri serves
+      // {z}/{y}/{x} -- row before column -- the reverse of the XYZ scheme
+      // CARTO and OSM use, so swapping the host alone silently transposes the
+      // world.
       dark: {
         type: "raster",
-        tiles: ["https://a.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png"],
+        tiles: [
+          "https://server.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Dark_Gray_Base/MapServer/tile/{z}/{y}/{x}",
+        ],
         tileSize: 256,
-        attribution: "&copy; OpenStreetMap contributors &copy; CARTO",
+        maxzoom: 16,
+        attribution: "&copy; OpenStreetMap contributors, Esri, HERE, Garmin",
       },
       light: {
         type: "raster",
-        tiles: ["https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"],
+        tiles: [
+          "https://server.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Light_Gray_Base/MapServer/tile/{z}/{y}/{x}",
+        ],
         tileSize: 256,
-        attribution: "&copy; OpenStreetMap contributors &copy; CARTO",
+        maxzoom: 16,
+        attribution: "&copy; OpenStreetMap contributors, Esri, HERE, Garmin",
       },
     },
     layers: [

--- a/packages/felicia-reader/src/theme-ui/cartography/Cartography.svelte
+++ b/packages/felicia-reader/src/theme-ui/cartography/Cartography.svelte
@@ -120,17 +120,30 @@
   const mapStyle: StyleSpecification = {
     version: 8,
     sources: {
+      // CARTO's free basemaps began requiring an API key and now answer 200
+      // with "API KEY REQUIRED" stamped into the PNG itself, so the map broke
+      // without a single failed request, console error or red test. Esri's
+      // Canvas basemaps are keyless. Note the template order: Esri serves
+      // {z}/{y}/{x} -- row before column -- the reverse of the XYZ scheme
+      // CARTO and OSM use, so swapping the host alone silently transposes the
+      // world.
       dark: {
         type: "raster",
-        tiles: ["https://a.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png"],
+        tiles: [
+          "https://server.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Dark_Gray_Base/MapServer/tile/{z}/{y}/{x}",
+        ],
         tileSize: 256,
-        attribution: "&copy; OpenStreetMap contributors &copy; CARTO",
+        maxzoom: 16,
+        attribution: "&copy; OpenStreetMap contributors, Esri, HERE, Garmin",
       },
       light: {
         type: "raster",
-        tiles: ["https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"],
+        tiles: [
+          "https://server.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Light_Gray_Base/MapServer/tile/{z}/{y}/{x}",
+        ],
         tileSize: 256,
-        attribution: "&copy; OpenStreetMap contributors &copy; CARTO",
+        maxzoom: 16,
+        attribution: "&copy; OpenStreetMap contributors, Esri, HERE, Garmin",
       },
     },
     layers: [


### PR DESCRIPTION
Two independent defects, both visible to anyone who opened the public site, neither detectable by any check the repo runs.

## 1. Basemap watermarks

CARTO began requiring an API key for its free basemaps. It does not refuse the request — it answers **200 with a valid PNG that has "API KEY REQUIRED" stamped across it**:

```
GET https://a.basemaps.cartocdn.com/dark_all/5/28/12.png
→ HTTP 200  size=5216  type=image/png
```

So every map was covered in watermarks while no request failed, no console error appeared, and no test went red. Only looking at the page could catch it.

Swapped to Esri's keyless Canvas basemaps in `Cartography.svelte` and `AtlasMap.svelte` (dark + light, 4 URLs). The raster architecture and the two-layer visibility toggle are untouched.

⚠️ Esri serves `{z}/{y}/{x}` — row before column — the reverse of the XYZ order CARTO and OSM share. Swapping only the hostname would have transposed the world silently. `maxzoom: 16` is declared because the Esri service stops there and MapLibre should overzoom rather than request 404s.

## 2. Photo lightbox covering every theme

Three faults stacked into one symptom — an undismissable overlay over cabinet, techo, atlas and cartography alike:

- **`export let` put the component in Svelte 5 legacy mode**, where the `onclick`/`onclose` attributes it *also* used are inert DOM attributes, not handlers. Nothing could open it; nothing could close it. It was the only file in the repo mixing legacy props with runes-style handlers (12 components use `$props()`, 3 use `export let`, 1 mixes).
- **`.photo-lightbox { display: grid }` overrode `dialog:not([open]) { display: none }`**, so it painted anyway — inline, permanently, with no backdrop and no Escape, because a dialog never shown via `showModal()` isn't modal.
- **The global `.gallery img` rule leaked in.** `felicia-reader/src/public.css:871` crops thumbnails to `aspect-[4/3]`, and this dialog is markup *inside* the gallery figure — so the full-size photo got a 4:3 box that `object-fit: contain` then letterboxed a 16:9 photo inside, with dead bands above and below.

## Verification

Built locally and driven in a real browser against the **published journal data**, since `make site-build` needs the private `.felicia/` journal:

| Check | Result |
|---|---|
| Map tiles | no watermark, dark + light |
| Route geometry | renders correctly over the Izu Peninsula — confirms `{y}/{x}` order |
| Lightbox on load | absent from the a11y tree |
| Open on click | dialog present, backdrop dims |
| Close via Escape | closes |
| Close via × | closes |
| Image box aspect | `1.778` vs natural `1.778` — exact match, no letterboxing |
| `make validate` | passes (Go check + build + public/admin/private frontend checks) |

## Notes

- No status-doc update: this restores intended behavior rather than changing capability or milestone progress.
- Neither defect has an issue filed. Both qualify as `type:defect` under the issue convention and I can file them retroactively for the ledger if you want the trace.
- The `.gallery img` leak is fixed by making the modal defend its own presentation. Scoping the four themes' gallery selectors instead would be the other direction, and a larger change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)