### PR TITLE
fix: clear the floating chrome on mobile reader headers

### DIFF
--- a/apps/felicia-public-site/src/App.svelte
+++ b/apps/felicia-public-site/src/App.svelte
@@ -65,7 +65,13 @@
   }
 </script>
 
-<div class="public-reader-shell" class:theme-light={theme === "light"} class:design-cabinet={active.id === "cabinet"} class:design-cartography={active.id === "cartography"}>
+<div
+  class="public-reader-shell"
+  class:theme-light={theme === "light"}
+  class:design-cabinet={active.id === "cabinet"}
+  class:design-cartography={active.id === "cartography"}
+  class:design-techo={active.id === "techo"}
+>
   <a class="public-brand" href="/" aria-label="Felicia home">
     <img src={markUrl} alt="" aria-hidden="true" />
     <span>felicia</span>
@@ -215,11 +221,33 @@
 
   @media (max-width: 700px) {
     .public-reader-shell.design-cabinet :global(.cabinet-top) {
+      /* Two fixed overlays stack at the top of this breakpoint -- the brand
+         (ends ~3.5rem) and, below it, the near-full-width design switcher
+         (ends ~7.25rem). Dropping the desktop 10rem of *left* clearance
+         without replacing it put the theme's own header under both. There is
+         no room to clear them horizontally at this width, so clear them
+         vertically instead -- the same trade cartography makes just below.
+         Clearing only the brand is not enough; the switcher is the lower of
+         the two and is what the title actually lands on. */
+      padding-top: 8rem;
       padding-left: 1.25rem;
     }
 
     .public-reader-shell.design-cartography :global(.index-rail) {
       padding-top: 7.5rem;
+    }
+
+    /* Techo never had a clearance rule at all, so the switcher landed on its
+       index header -- the eyebrow and journal title sat behind the pill.
+
+       The shell centres the spread vertically, and at this width the spread is
+       taller than the viewport, so centring pushes it *above* the padding box
+       and padding-top moves it by only part of what you ask for. Anchoring to
+       the top first makes the clearance exact; the spread scrolls here anyway,
+       so there is no centring left to lose. */
+    .public-reader-shell.design-techo :global(.techo-shell) {
+      align-items: flex-start;
+      padding-top: 8rem;
     }
 
     .public-brand {


### PR DESCRIPTION
Closes #129. Blocks closing #9, which sets "on desktop **and mobile**" as its exit criterion.

## The defect

Two fixed overlays stack at the top of the public reader: `.public-brand` (ends ~3.5rem) and, below it, the near-full-width `.public-design-switcher` (ends ~7.25rem). Desktop clears them by reserving *horizontal* room — `.cabinet-top { padding-left: 10rem }`. The `max-width: 700px` block dropped that to `1.25rem` **without replacing it**, so the theme's own header rendered underneath both and the journal title was unreadable.

Measured on the live site at 390×844 before the fix:

```
logo: x 10–114, y 10–55
h1:   x 20–141, y 40–76     overlapping: true
```

## Two things #129 got wrong, found while fixing it

**1. It's the switcher, not the brand.** My first attempt cleared only the brand (`padding-top: 4rem`) and reported success against a logo-only check. Re-measuring against *every* fixed overlay showed I'd just moved the collision:

```
A.public-brand             y 10–56    overlapsH1: false  ✓
NAV.public-design-switcher y 64–116   overlapsH1: true   ✗   (h1 at y 84–120)
```

The switcher is the lower of the two and is what the title actually lands on. 8rem clears both.

**2. Techo is affected too.** #129 says cabinet only — that came from a check that tested header elements against the brand alone. A proper sweep against all fixed overlays found techo's index header behind the switcher as well. Techo had no clearance rule at all; the shell was never even given a `design-techo` class.

Techo also needed a different fix. Padding its shell barely moved it — 96px of padding shifted the frame 28px — because `.techo-shell` centres a spread **taller than the viewport**, so centring pushes it *above* the padding box. `align-items: flex-start` at this breakpoint makes the clearance exact, and nothing is lost because the spread scrolls here regardless.

## Verification

Every `h1`/`h2`/`.eyebrow`/`p` tested against every `position: fixed` overlay, all four designs, 390×844:

| design | before | after |
| --- | --- | --- |
| cabinet | brand + switcher over title | `[]` |
| techo | switcher over eyebrow + title | `[]` |
| ngraphy | — | `[]` |
| atlas | — | `[]` |

`.map-surface` is excluded from the sweep: atlas and ngraphy lay their hero text over the map deliberately.

Desktop unchanged — cabinet keeps `padding-left: 160px`, techo keeps `align-items: center`, both keep their original `padding-top`. All changes are inside the `max-width: 700px` query.

`make validate` passes. The only formatter change was wrapping the `<div>` attributes onto separate lines; I read the diff before accepting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)