### PR TITLE
docs: accept ADR-0039

### DIFF
--- a/docs/adr/0039-journey-authoring-writes-and-mask-ownership.md
+++ b/docs/adr/0039-journey-authoring-writes-and-mask-ownership.md
@@ -1,7 +1,7 @@
 ---
 id: "0039"
 title: "Journey Authoring Writes and Mask Ownership"
-status: "proposed"
+status: "accepted"
 date: "2026-09-11"
 related:
   - "0022"

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -36,4 +36,4 @@ This directory stores the immutable records of design and architecture choices m
 | [0037](0037-private-local-development-layout.md)                      | Private Local Development Layout                         | 2026-08-20 | Accepted |
 | [0038](0038-named-frontend-package-boundaries.md)                     | Named Frontend Package Boundaries                        | 2026-08-20 | Accepted |
 | [0036](0036-theme-runtime-and-scene-actions.md)                       | Reader Runtime and Scene Actions                         | 2026-08-20 | Accepted |
-| [0039](0039-journey-authoring-writes-and-mask-ownership.md)           | Journey Authoring Writes and Mask Ownership              | 2026-09-11 | Proposed |
+| [0039](0039-journey-authoring-writes-and-mask-ownership.md)           | Journey Authoring Writes and Mask Ownership              | 2026-09-11 | Accepted |


### PR DESCRIPTION
Settles the governance step before the code that implements it, per the repo's own pattern (`docs: accept ADR-0028 and ADR-0030`).

ADR-0039 landed as `proposed` in #128 because one question was genuinely open: whether `gps_route` can be claimed by an authoring write. It's answered — **it can't**. Ingest owns the trace for the life of the journey, which is what keeps the model free of un-authoring: every claimable field is one an author sets deliberately, so the mask only grows and nothing needs a way out.

Nothing else in the record was left unresolved, so it moves to `accepted` and the index row follows.

`make fmt-docs-check` clean, 129 files.

Next: #89 implements this — derived seven-field mask, `authored_fields` removed from the request and the admin client, stored route preserved, `expected_revision` + 409.

🤖 Generated with [Claude Code](https://claude.com/claude-code)