### PR TITLE
fix: let the server decide a journey's authored mask

### DIFF
--- a/apps/felicia-core/domain/authorship.go
+++ b/apps/felicia-core/domain/authorship.go
@@ -29,6 +29,35 @@ func IngestableFields(mask, authored []string) []string {
 	return allowed
 }
 
+// JourneyAuthoredFields is what an authoring write claims on a journey,
+// whatever the caller sent. Per ADR-0039 the mask is derived from the fields
+// the authoring surface writes, not supplied by the client — a client that
+// omits a mask used to clear it, and the next import then legally overwrote
+// the author's work.
+//
+// gps_route is deliberately absent. The passive GPS trace is re-ingested for
+// the life of the journey, so letting an authoring save claim it would freeze
+// it forever. Keeping it out is also what keeps the model free of
+// un-authoring: every field here is one an author sets deliberately and
+// rarely wants to un-set, so the mask only ever grows.
+var JourneyAuthoredFields = []string{"slug", "title", "place", "country", "region", "date_start", "date_end"}
+
+// ClaimJourneyAuthorship returns the authored mask an authoring write leaves
+// behind, given the mask already stored on the row. It is the authoring
+// counterpart to IngestableFields: every field the authoring surface writes is
+// claimed, and anything the stored row already claimed is kept, so no sequence
+// of authoring writes can shrink the mask.
+func ClaimJourneyAuthorship(stored []string) []string {
+	mask := make([]string, len(JourneyAuthoredFields), len(JourneyAuthoredFields)+len(stored))
+	copy(mask, JourneyAuthoredFields)
+	for _, field := range stored {
+		if !slices.Contains(mask, field) {
+			mask = append(mask, field)
+		}
+	}
+	return mask
+}
+
 // IngestJourneyPatch is an explicit source operation on a journey. It mirrors
 // IngestMementoPatch: its fields are chosen by the importer, and it can never
 // add, remove, or overwrite authored ownership. Journey authoring keeps using

--- a/apps/felicia-providers/sqlite/store.go
+++ b/apps/felicia-providers/sqlite/store.go
@@ -321,6 +321,13 @@ func (r *Repository) GetJourney(ctx context.Context, id uuid.UUID) (*domain.Jour
 	var rawJournalID, slug, title, place, start, end, route, fields, created, updated string
 	var sourceRef, country, region sql.NullString
 	if err := row.Scan(&rawJournalID, &slug, &sourceRef, &title, &place, &country, &region, &start, &end, &route, &fields, &created, &updated); err != nil {
+		// Normalised like every other getter here (GetSoleJournal,
+		// GetStopCandidate): callers above the provider match on
+		// domain.ErrNotFound, and leaking sql.ErrNoRows would put
+		// database/sql in their import list to read one absence.
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, domain.ErrNotFound
+		}
 		return nil, err
 	}
 	journalID, err := parseID(rawJournalID)

--- a/apps/felicia-server/api/journey_authoring_test.go
+++ b/apps/felicia-server/api/journey_authoring_test.go
@@ -1,0 +1,142 @@
+package api_test
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/paulmach/orb"
+
+	"github.com/azusachino/felicia/apps/felicia-core/domain"
+	"github.com/azusachino/felicia/apps/felicia-server/api"
+)
+
+// The authoring API used to take the client's authored mask at face value and
+// assign every column from the request. A save that omitted either therefore
+// destroyed data twice over (ADR-0039): the mask was cleared, so the next
+// import legally overwrote the author's work, and gps_route was written as
+// null, so the stored trace was blanked by the save itself.
+//
+// These pin the invariants ADR-0039 states, which is what makes them testable
+// before #82 builds the form that would otherwise reach them first.
+
+func saveJourney(t *testing.T, handler http.Handler, body string) {
+	t.Helper()
+	w := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/api/admin/journeys", bytes.NewBufferString(body))
+	request.Header.Set("Content-Type", "application/json")
+	handler.ServeHTTP(w, request)
+	if w.Code != http.StatusOK {
+		t.Fatalf("upsert journey: expected 200, got %d (%s)", w.Code, w.Body)
+	}
+}
+
+func authoringHandler(t *testing.T) (http.Handler, *mockRepository) {
+	t.Helper()
+	repo := newMockRepository()
+	reg := loadKinds(t)
+	return api.NewServer(repo, reg, api.NewCacheManager("", testLogger), testLogger, nil, api.RouteConfig{}).Handler(), repo
+}
+
+func TestUpsertJourneyClaimsItsOwnAuthoredFields(t *testing.T) {
+	handler, repo := authoringHandler(t)
+	id := uuid.New()
+
+	// No authored_fields in the body at all -- the shape that used to clear it.
+	saveJourney(t, handler, `{"id":"`+id.String()+`","journal_id":"`+uuid.NewString()+`","slug":"izu","title":"Izu","place":"Izu Peninsula","date_start":"2026-08-01","date_end":"2026-08-02"}`)
+
+	stored := repo.journeys[id]
+	if stored == nil {
+		t.Fatal("journey was not stored")
+	}
+	for _, field := range domain.JourneyAuthoredFields {
+		if !slices.Contains(stored.AuthoredFields, field) {
+			t.Errorf("authoring write did not claim %q; mask is %v", field, stored.AuthoredFields)
+		}
+	}
+	if slices.Contains(stored.AuthoredFields, "gps_route") {
+		t.Error("authoring write claimed gps_route; ingest must keep owning the trace")
+	}
+}
+
+func TestUpsertJourneyLeavesTheStoredRouteAlone(t *testing.T) {
+	handler, repo := authoringHandler(t)
+	id := uuid.New()
+	route := orb.MultiLineString{{{139.0, 35.0}, {139.7, 35.6}}}
+	repo.journeys[id] = &domain.Journey{
+		ID:             id,
+		Slug:           "izu",
+		Title:          "Imported name",
+		Place:          "Izu Peninsula",
+		DateStart:      time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC),
+		DateEnd:        time.Date(2026, 8, 2, 0, 0, 0, 0, time.UTC),
+		GPSRoute:       route,
+		AuthoredFields: []string{},
+	}
+
+	// A save that carries no route. This used to write gps_route = null.
+	saveJourney(t, handler, `{"id":"`+id.String()+`","journal_id":"`+uuid.NewString()+`","slug":"izu","title":"The name I chose","place":"Izu Peninsula","date_start":"2026-08-01","date_end":"2026-08-02"}`)
+
+	stored := repo.journeys[id]
+	if len(stored.GPSRoute) != len(route) {
+		t.Fatalf("stored route was blanked by an authoring save: got %v, want %v", stored.GPSRoute, route)
+	}
+	if stored.Title != "The name I chose" {
+		t.Errorf("authoring write did not apply the title: %q", stored.Title)
+	}
+}
+
+func TestUpsertJourneyNeverShrinksTheStoredMask(t *testing.T) {
+	handler, repo := authoringHandler(t)
+	id := uuid.New()
+	// A field the authoring surface does not write, claimed by some earlier
+	// path. Invariant 4: no sequence of authoring writes may drop it.
+	repo.journeys[id] = &domain.Journey{
+		ID:             id,
+		Slug:           "izu",
+		Title:          "Izu",
+		Place:          "Izu Peninsula",
+		DateStart:      time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC),
+		DateEnd:        time.Date(2026, 8, 2, 0, 0, 0, 0, time.UTC),
+		AuthoredFields: []string{"gps_route"},
+	}
+
+	saveJourney(t, handler, `{"id":"`+id.String()+`","journal_id":"`+uuid.NewString()+`","slug":"izu","title":"Izu","place":"Izu Peninsula","date_start":"2026-08-01","date_end":"2026-08-02"}`)
+
+	if !slices.Contains(repo.journeys[id].AuthoredFields, "gps_route") {
+		t.Errorf("authoring write dropped a stored claim; mask is %v", repo.journeys[id].AuthoredFields)
+	}
+}
+
+func TestIngestCannotOverwriteWhatAuthoringJustClaimed(t *testing.T) {
+	handler, repo := authoringHandler(t)
+	id := uuid.New()
+	repo.journeys[id] = &domain.Journey{
+		ID:             id,
+		Slug:           "izu",
+		Title:          "Imported name",
+		Place:          "Izu Peninsula",
+		DateStart:      time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC),
+		DateEnd:        time.Date(2026, 8, 2, 0, 0, 0, 0, time.UTC),
+		AuthoredFields: []string{},
+	}
+
+	saveJourney(t, handler, `{"id":"`+id.String()+`","journal_id":"`+uuid.NewString()+`","slug":"izu","title":"The name I chose","place":"Izu Peninsula","date_start":"2026-08-01","date_end":"2026-08-02"}`)
+
+	// The whole point of the mask: an import arriving afterwards must not win.
+	if err := repo.ApplyIngestJourneyPatch(context.Background(), &domain.IngestJourneyPatch{
+		Journey: &domain.Journey{ID: id, Title: "Imported name", Place: "Somewhere else"},
+		Fields:  []string{"title", "place"},
+	}); err != nil {
+		t.Fatalf("ingest patch: %v", err)
+	}
+
+	if got := repo.journeys[id].Title; got != "The name I chose" {
+		t.Errorf("import overwrote an authored title: got %q", got)
+	}
+}

--- a/apps/felicia-server/api/server.go
+++ b/apps/felicia-server/api/server.go
@@ -592,18 +592,19 @@ func (s *Server) handleGetJourney(w http.ResponseWriter, r *http.Request) {
 }
 
 type upsertJourneyRequest struct {
-	ID             uuid.UUID     `json:"id"`
-	JournalID      uuid.UUID     `json:"journal_id"`
-	Slug           string        `json:"slug"`
-	SourceRef      *string       `json:"source_ref,omitempty"`
-	Title          string        `json:"title"`
-	Place          string        `json:"place"`
-	Country        *string       `json:"country,omitempty"`
-	Region         *string       `json:"region,omitempty"`
-	DateStart      string        `json:"date_start"`
-	DateEnd        string        `json:"date_end"`
-	GPSRoute       [][][]float64 `json:"gps_route,omitempty"`
-	AuthoredFields []string      `json:"authored_fields"`
+	ID        uuid.UUID `json:"id"`
+	JournalID uuid.UUID `json:"journal_id"`
+	Slug      string    `json:"slug"`
+	SourceRef *string   `json:"source_ref,omitempty"`
+	Title     string    `json:"title"`
+	Place     string    `json:"place"`
+	Country   *string   `json:"country,omitempty"`
+	Region    *string   `json:"region,omitempty"`
+	DateStart string    `json:"date_start"`
+	DateEnd   string    `json:"date_end"`
+	// No authored_fields and no gps_route: an authoring write derives its own
+	// mask (ADR-0039) and never touches the trace, so neither is something a
+	// client can express.
 }
 
 func (s *Server) handleUpsertJourney(w http.ResponseWriter, r *http.Request) {
@@ -611,10 +612,6 @@ func (s *Server) handleUpsertJourney(w http.ResponseWriter, r *http.Request) {
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		respondError(w, http.StatusBadRequest, "invalid request JSON")
 		return
-	}
-
-	if req.AuthoredFields == nil {
-		req.AuthoredFields = []string{}
 	}
 
 	start, err := time.Parse("2006-01-02", req.DateStart)
@@ -628,17 +625,20 @@ func (s *Server) handleUpsertJourney(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var gpsRoute orb.MultiLineString
-	if len(req.GPSRoute) > 0 {
-		for _, segment := range req.GPSRoute {
-			var ls orb.LineString
-			for _, coord := range segment {
-				if len(coord) >= 2 {
-					ls = append(ls, orb.Point{coord[0], coord[1]})
-				}
-			}
-			gpsRoute = append(gpsRoute, ls)
-		}
+	// The stored row supplies what an authoring write does not own: the GPS
+	// trace, which ingest keeps refreshing, and whatever the mask already
+	// claims. Absent means unchanged -- a save that carried no route used to
+	// write gps_route = 'null' and blank the trace outright.
+	var storedRoute orb.MultiLineString
+	var storedMask []string
+	switch stored, err := s.repo.GetJourney(r.Context(), req.ID); {
+	case errors.Is(err, domain.ErrNotFound):
+		// A new journey owns no trace yet; ingest seeds it.
+	case err != nil:
+		respondError(w, http.StatusInternalServerError, err.Error())
+		return
+	default:
+		storedRoute, storedMask = stored.GPSRoute, stored.AuthoredFields
 	}
 
 	journey := &domain.Journey{
@@ -652,8 +652,8 @@ func (s *Server) handleUpsertJourney(w http.ResponseWriter, r *http.Request) {
 		Region:         req.Region,
 		DateStart:      start,
 		DateEnd:        end,
-		GPSRoute:       gpsRoute,
-		AuthoredFields: req.AuthoredFields,
+		GPSRoute:       storedRoute,
+		AuthoredFields: domain.ClaimJourneyAuthorship(storedMask),
 	}
 
 	if err := s.journeyWriter.Save(r.Context(), journey); err != nil {


### PR DESCRIPTION
Closes #89. Implements ADR-0039 (accepted in #131) — except one invariant, noted below.

## What was wrong

The authoring endpoint treated a partial request as a complete description of the row, and lost data two ways.

**1. An omitted mask cleared the mask.** `if req.AuthoredFields == nil { req.AuthoredFields = []string{} }` fed straight into `UpsertJourney`, which per ADR-0033 is the authoring write and takes the caller's mask at face value. The next import then legally overwrote title, place and route — the exact loss #73 was filed for, reached through the documented authoring surface rather than the importer.

**2. An omitted route blanked the route.** Not recorded in #89. `UpsertJourney` assigns every column and `marshalJSON(nil)` writes `gps_route = 'null'`, so **the save itself** destroyed the stored trace, no later import needed.

## What changed

`authored_fields` and `gps_route` are gone from `upsertJourneyRequest` entirely — clearing the mask is no longer something a client can express, rather than something a client is trusted not to do. The server claims `domain.JourneyAuthoredFields` (slug, title, place, country, region, date_start, date_end) and unions in whatever the stored row already held, so the mask can only grow. The stored row supplies the trace: absent means unchanged.

The rule lives in `apps/felicia-core/domain/authorship.go` next to `IngestableFields`, which is where ADR-0033 says this decision belongs — "not in provider SQL — so both persistence backends behave identically."

`GetJourney` now normalises `sql.ErrNoRows` to `domain.ErrNotFound`, matching `GetSoleJournal` and `GetStopCandidate`. Without it the handler would need `database/sql` in its imports to read one absence, and the transport layer is deliberately free of persistence detail (ADR-0018).

## Tests

Four, pinning ADR-0039's invariants. **Confirmed to fail against the previous behaviour** — I reverted the two lines and watched all four go red, rather than trusting that they pass against the new one:

```
--- FAIL: TestUpsertJourneyClaimsItsOwnAuthoredFields
--- FAIL: TestUpsertJourneyLeavesTheStoredRouteAlone
--- FAIL: TestUpsertJourneyNeverShrinksTheStoredMask
--- FAIL: TestIngestCannotOverwriteWhatAuthoringJustClaimed
```

`make validate` passes.

## Deliberately not in this PR

**ADR-0039's invariant 3 (`expected_revision`) is not implemented.** Journeys have no `revision` column — mementos and stop candidates do, journeys don't — so it needs a schema change I did not scope when drafting the ADR. Filing separately rather than bundling a migration into a defect fix.

**#89's third evidence line is misattributed.** It cites the admin client declaring an optional `authored_fields`, but that line is `UpsertMementoRequest`, not a journey type. There is no journey upsert type in the admin client at all, consistent with #82. Nothing to remove client-side.

**A sibling instance of this defect exists in `localjourney.go`.** It builds a journey with a GPX-derived route and no mask and calls the same authoring `Save`, so a local-journey import both claims nothing and resets the mask. Fixing it means deciding whether that path is ingest or authoring — an ADR-shaped question, since ADR-0033 says the split port is what makes the two intents distinguishable. Filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)